### PR TITLE
Clarify public symbols

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.97"
+version = "0.4.98"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.95"
+version = "0.4.96"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.84"
+version = "0.4.85"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.96"
+version = "0.4.97"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -23,7 +23,10 @@ using Mooncake:
     generate_hand_written_rrule!!_test_cases,
     generate_derived_rrule!!_test_cases,
     TestUtils,
-    _typeof
+    _typeof,
+    primal,
+    tangent,
+    zero_codual
 
 using Mooncake.TestUtils: _deepcopy
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -34,6 +34,7 @@ makedocs(;
     pages=[
         "Mooncake.jl" => "index.md",
         "Tutorial" => "tutorial.md",
+        "Interface" => "interface.md",
         "Understanding Mooncake.jl" => [
             joinpath("understanding_mooncake", "introduction.md"),
             joinpath("understanding_mooncake", "algorithmic_differentiation.md"),

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,10 @@ DocMeta.setdocmeta!(
     :DocTestSetup,
     quote
         using Random, Mooncake
+        using Mooncake: tangent_type, fdata_type, rdata_type
+        using Mooncake: zero_tangent
+        using Mooncake: NoTangent, NoFData, NoRData, MutableTangent, Tangent
+        using Mooncake: build_rrule, Config
     end;
     recursive=true,
 )

--- a/docs/src/developer_documentation/developer_tools.md
+++ b/docs/src/developer_documentation/developer_tools.md
@@ -6,7 +6,7 @@ which save you from having to dig in to the objects created by `build_rrule`.
 
 Since these provide access to internals, they do not follow the usual rules of semver, and
 may change without notice!
-```@docs
+```@docs; canonical=false
 Mooncake.primal_ir
 Mooncake.fwd_ir
 Mooncake.rvs_ir

--- a/docs/src/developer_documentation/internal_docstrings.md
+++ b/docs/src/developer_documentation/internal_docstrings.md
@@ -5,11 +5,12 @@ Consequently, they can change between non-breaking changes to Mooncake.jl withou
 
 The purpose of this is to make it easy for developers to find docstrings straightforwardly via the docs, as opposed to having to ctrl+f through Mooncake.jl's source code, or looking at the docstrings via the Julia REPL.
 
-```@autodocs; canonical=false
+```@autodocs; canonical=true
 Modules = [Mooncake]
 Public = false
+Filter = t -> !(t in [Mooncake.value_and_pullback!!, Mooncake.prepare_pullback_cache, Mooncake.Config])
 ```
 
-```@docs; canonical=false
+```@docs; canonical=true
 Mooncake.IntrinsicsWrappers
 ```

--- a/docs/src/developer_documentation/internal_docstrings.md
+++ b/docs/src/developer_documentation/internal_docstrings.md
@@ -13,3 +13,8 @@ Public = false
 ```@docs
 Mooncake.IntrinsicsWrappers
 ```
+
+```@autodocs; canonical=false
+Modules = [Mooncake]
+Public = true
+```

--- a/docs/src/developer_documentation/internal_docstrings.md
+++ b/docs/src/developer_documentation/internal_docstrings.md
@@ -10,11 +10,6 @@ Modules = [Mooncake]
 Public = false
 ```
 
-```@docs
+```@docs; canonical=false
 Mooncake.IntrinsicsWrappers
-```
-
-```@autodocs; canonical=false
-Modules = [Mooncake]
-Public = true
 ```

--- a/docs/src/developer_documentation/misc_internals_notes.md
+++ b/docs/src/developer_documentation/misc_internals_notes.md
@@ -132,7 +132,7 @@ Last checked: 09/02/2025, Julia v1.10.8 / v1.11.3, Mooncake 0.4.82.
 Mooncake handles recursive function calls by delaying code generation for generic function calls until the first time that they are actually run.
 The docstring below contains a thorough explanation:
 
-```@docs
+```@docs; canonical=false
 Mooncake.LazyDerivedRule
 ```
 

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -1,0 +1,14 @@
+# Interface
+
+This is the public interface that day-to-day users of AD are expected to interact with if
+for some reason DifferentiationInterface.jl does not suffice.
+If you have not tried using Mooncake.jl via DifferentiationInterface.jl, please do so.
+See [Tutorial](@ref) for more info.
+
+```@docs; canonical=false
+Mooncake.Config
+Mooncake.value_and_gradient!!(::Mooncake.Cache, f::F, x::Vararg{Any, N}) where {F, N}
+Mooncake.value_and_pullback!!(::Mooncake.Cache, ȳ, f::F, x::Vararg{Any, N}) where {F, N}
+Mooncake.prepare_gradient_cache
+Mooncake.prepare_pullback_cache
+```

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -5,7 +5,7 @@ for some reason DifferentiationInterface.jl does not suffice.
 If you have not tried using Mooncake.jl via DifferentiationInterface.jl, please do so.
 See [Tutorial](@ref) for more info.
 
-```@docs; canonical=false
+```@docs; canonical=true
 Mooncake.Config
 Mooncake.value_and_gradient!!(::Mooncake.Cache, f::F, x::Vararg{Any, N}) where {F, N}
 Mooncake.value_and_pullback!!(::Mooncake.Cache, ȳ, f::F, x::Vararg{Any, N}) where {F, N}

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -7,6 +7,7 @@ Mooncake.jl has a number of known qualitative limitations, which we document her
 ```@meta
 DocTestSetup = quote
     using Mooncake
+    using Mooncake: NoTangent, build_rrule
 end
 ```
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -15,7 +15,7 @@ import Mooncake
 ## DifferentiationInterface.jl API
 
 DifferentiationInterface.jl (or DI for short) provides a common entry point for every automatic differentiation package in Julia.
-To specify that you want to use Mooncake.jl, just create the right "backend" object (with an optional [`Mooncake.Config`](@ref)):
+To specify that you want to use Mooncake.jl, just create the right "backend" object (with an optional [`Config`](@ref)):
 
 ```@example tuto
 backend = DI.AutoMooncake(; config=nothing)

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -15,7 +15,7 @@ import Mooncake
 ## DifferentiationInterface.jl API
 
 DifferentiationInterface.jl (or DI for short) provides a common entry point for every automatic differentiation package in Julia.
-To specify that you want to use Mooncake.jl, just create the right "backend" object (with an optional [`Config`](@ref)):
+To specify that you want to use Mooncake.jl, just create the right "backend" object (with an optional [`Mooncake.Config`](@ref)):
 
 ```@example tuto
 backend = DI.AutoMooncake(; config=nothing)

--- a/docs/src/understanding_mooncake/rule_system.md
+++ b/docs/src/understanding_mooncake/rule_system.md
@@ -279,7 +279,7 @@ _**Representing Gradients**_
 This package assigns to each type in Julia a unique `tangent_type`, the purpose of which is to contain the gradients computed during reverse mode AD.
 The extended docstring for [`tangent_type`](@ref) provides the best introduction to the types which are used to represent tangents / gradients.
 
-```@docs
+```@docs; canonical=false
 Mooncake.tangent_type(P)
 ```
 
@@ -295,7 +295,7 @@ Conversely, the gradient w.r.t. a value type resides in another value type.
 
 The following docstring provides the best in-depth explanation.
 
-```@docs
+```@docs; canonical=false
 Mooncake.fdata_type(T)
 ```
 

--- a/docs/src/understanding_mooncake/rule_system.md
+++ b/docs/src/understanding_mooncake/rule_system.md
@@ -327,7 +327,7 @@ Now that you've seen what data structures are used to represent gradients, we ca
 ```@meta
 DocTestSetup = quote
     using Mooncake
-    using Mooncake: CoDual
+    using Mooncake: CoDual, NoFData, NoRData
     import Mooncake: rrule!!
 end
 ```

--- a/docs/src/understanding_mooncake/rule_system.md
+++ b/docs/src/understanding_mooncake/rule_system.md
@@ -280,7 +280,7 @@ This package assigns to each type in Julia a unique `tangent_type`, the purpose 
 The extended docstring for [`tangent_type`](@ref) provides the best introduction to the types which are used to represent tangents / gradients.
 
 ```@docs
-tangent_type(P)
+Mooncake.tangent_type(P)
 ```
 
 

--- a/docs/src/utilities/debug_mode.md
+++ b/docs/src/utilities/debug_mode.md
@@ -33,12 +33,12 @@ _**The Solution**_
 Check that the types of the fdata / rdata associated to arguments are exactly what `tangent_type` / `fdata_type` / `rdata_type` require upon entry to / exit from rules and pullbacks.
 
 This is implemented via `DebugRRule`:
-```@docs
+```@docs; canonical=false
 Mooncake.DebugRRule
 ```
 
 You can straightforwardly enable it when building a rule via the `debug_mode` kwarg in the following:
-```@docs
+```@docs; canonical=false
 Mooncake.build_rrule
 ```
 

--- a/docs/src/utilities/debug_mode.md
+++ b/docs/src/utilities/debug_mode.md
@@ -44,8 +44,8 @@ Mooncake.build_rrule
 
 When using ADTypes.jl, you can choose whether or not to use it via the `debug_mode` kwarg:
 ```jldoctest
-julia> AutoMooncake(; config=Config(; debug_mode=true))
-AutoMooncake{Config}(Config(true, false))
+julia> AutoMooncake(; config=Mooncake.Config(; debug_mode=true))
+AutoMooncake{Mooncake.Config}(Mooncake.Config(true, false))
 ```
 
 ### When Should You Use Debug Mode?

--- a/docs/src/utilities/debug_mode.md
+++ b/docs/src/utilities/debug_mode.md
@@ -44,8 +44,8 @@ Mooncake.build_rrule
 
 When using ADTypes.jl, you can choose whether or not to use it via the `debug_mode` kwarg:
 ```jldoctest
-julia> AutoMooncake(; config=Mooncake.Config(; debug_mode=true))
-AutoMooncake{Mooncake.Config}(Mooncake.Config(true, false))
+julia> AutoMooncake(; config=Config(; debug_mode=true))
+AutoMooncake{Config}(Config(true, false))
 ```
 
 ### When Should You Use Debug Mode?

--- a/docs/src/utilities/debugging_and_mwes.md
+++ b/docs/src/utilities/debugging_and_mwes.md
@@ -5,7 +5,7 @@ In order to debug what is going on when this happens, or to produce an MWE, it i
 
 We recommend making use of Mooncake.jl's testing functionality to generate your test cases:
 
-```@docs
+```@docs; canonical=false
 Mooncake.TestUtils.test_rule
 ```
 

--- a/docs/src/utilities/defining_rules.md
+++ b/docs/src/utilities/defining_rules.md
@@ -6,7 +6,7 @@ In this section, we detail some useful strategies which can help you avoid havin
 
 ## Simplfiying Code via Overlays
 
-```@docs
+```@docs; canonical=false
 Mooncake.@mooncake_overlay
 ```
 
@@ -15,7 +15,7 @@ Mooncake.@mooncake_overlay
 If the above strategy does not work, but you find yourself in the surprisingly common
 situation that the adjoint of the derivative of your function is always zero, you can very
 straightforwardly write a rule by making use of the following:
-```@docs
+```@docs; canonical=false
 Mooncake.@zero_adjoint
 Mooncake.zero_adjoint
 ```
@@ -28,18 +28,18 @@ There are some instances where it is most convenient to implement a `Mooncake.rr
 
 There is enough similarity between these two systems that most of the boilerplate code can be avoided.
 
-```@docs
+```@docs; canonical=false
 Mooncake.@from_rrule
 ```
 
 ## Adding Methods To `rrule!!` And `build_primitive_rrule`
 
 If the above strategies do not work for you, you should first implement a method of [`Mooncake.is_primitive`](@ref) for the signature of interest:
-```@docs
+```@docs; canonical=false
 Mooncake.is_primitive
 ```
 Then implement a method of one of the following:
-```@docs
+```@docs; canonical=false
 Mooncake.rrule!!
 Mooncake.build_primitive_rrule
 ```

--- a/ext/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt.jl
@@ -10,6 +10,7 @@ import Mooncake:
     rrule!!,
     @is_primitive,
     tangent_type,
+    primal,
     tangent,
     zero_tangent_internal,
     randn_tangent_internal,
@@ -25,7 +26,8 @@ import Mooncake:
     to_cr_tangent,
     increment_and_get_rdata!,
     MaybeCache,
-    IncCache
+    IncCache,
+    NoRData
 
 import Mooncake.TestUtils:
     populate_address_map_internal, AddressMap, __increment_should_allocate

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -142,14 +142,10 @@ include("config.jl")
 include("developer_tools.jl")
 
 # Public, not exported
-
 include("public.jl")
-@public CoDual
+@public value_and_pullback!!, prepare_pullback_cache
 
 # Public, exported
-
-export Config
-export value_and_pullback!!, prepare_pullback_cache
-export value_and_gradient!!, prepare_gradient_cache
+export Config, value_and_gradient!!, prepare_gradient_cache
 
 end

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -158,7 +158,7 @@ export primal
 export Tangent, MutableTangent, PossiblyUninitTangent, NoTangent
 export tangent_type, tangent, zero_tangent
 export NoFData, fdata_type, fdata
-export NoRData,rdata_type, rdata
+export NoRData, rdata_type, rdata
 export rrule!!, build_rrule
 export value_and_pullback!!
 export value_and_gradient!!

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -144,9 +144,9 @@ include("developer_tools.jl")
 
 # Public, not exported
 include("public.jl")
-@public value_and_pullback!!, prepare_pullback_cache
+@public Config, value_and_pullback!!, prepare_pullback_cache
 
 # Public, exported
-export Config, value_and_gradient!!, prepare_gradient_cache
+export value_and_gradient!!, prepare_gradient_cache
 
 end

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -147,9 +147,9 @@ include("public.jl")
 
 @public set_to_zero!!, increment!!
 @public get_interpreter
-@public zero_adjoint
+@public zero_adjoint, var"@zero_adjoint"
 @public is_primitive, build_primitive_rrule
-export @mooncake_overlay, @zero_adjoint, @from_rrule  # how to make macros public with the @public workaround??
+@public var"@mooncake_overlay", var"@from_rrule"
 @public Config
 
 # Public, exported

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -144,23 +144,11 @@ include("developer_tools.jl")
 # Public, not exported
 
 include("public.jl")
-
-@public set_to_zero!!, increment!!
-@public get_interpreter
-@public zero_adjoint, var"@zero_adjoint"
-@public is_primitive, build_primitive_rrule
-@public var"@mooncake_overlay", var"@from_rrule"
-@public Config
+@public CoDual
 
 # Public, exported
 
-export CoDual, codual_type, zero_codual
-export primal
-export Tangent, MutableTangent, PossiblyUninitTangent, NoTangent
-export tangent_type, tangent, zero_tangent
-export NoFData, fdata_type, fdata
-export NoRData, rdata_type, rdata
-export rrule!!, build_rrule
+export Config
 export value_and_pullback!!, prepare_pullback_cache
 export value_and_gradient!!, prepare_gradient_cache
 

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -150,6 +150,7 @@ include("public.jl")
 @public zero_adjoint
 @public is_primitive, build_primitive_rrule
 export @mooncake_overlay, @zero_adjoint, @from_rrule  # how to make macros public with the @public workaround??
+@public Config
 
 # Public, exported
 
@@ -160,7 +161,7 @@ export tangent_type, tangent, zero_tangent
 export NoFData, fdata_type, fdata
 export NoRData, rdata_type, rdata
 export rrule!!, build_rrule
-export value_and_pullback!!
-export value_and_gradient!!
+export value_and_pullback!!, prepare_pullback_cache
+export value_and_gradient!!, prepare_gradient_cache
 
 end

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -141,33 +141,27 @@ include("interface.jl")
 include("config.jl")
 include("developer_tools.jl")
 
-export primal,
-    tangent,
-    randn_tangent,
-    increment!!,
-    NoTangent,
-    Tangent,
-    MutableTangent,
-    PossiblyUninitTangent,
-    set_to_zero!!,
-    tangent_type,
-    zero_tangent,
-    _scale,
-    _add_to_primal,
-    _diff,
-    _dot,
-    zero_codual,
-    codual_type,
-    rrule!!,
-    build_rrule,
-    value_and_gradient!!,
-    value_and_pullback!!,
-    NoFData,
-    NoRData,
-    fdata_type,
-    rdata_type,
-    fdata,
-    rdata,
-    get_interpreter
+# Public, not exported
+
+include("public.jl")
+
+@public set_to_zero!!, increment!!
+@public get_interpreter
+@public mooncake_overlay
+@public zero_adjoint
+@public from_rrule
+@public is_primitive, build_primitive_rrule
+
+# Public, exported
+
+export CoDual, codual_type, zero_codual
+export primal
+export Tangent, MutableTangent, PossiblyUninitTangent, NoTangent
+export tangent_type, tangent, zero_tangent
+export NoFData, fdata_type, fdata
+export NoRData,rdata_type, rdata
+export rrule!!, build_rrule
+export value_and_pullback!!
+export value_and_gradient!!
 
 end

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -147,10 +147,9 @@ include("public.jl")
 
 @public set_to_zero!!, increment!!
 @public get_interpreter
-@public mooncake_overlay
 @public zero_adjoint
-@public from_rrule
 @public is_primitive, build_primitive_rrule
+export @mooncake_overlay, @zero_adjoint, @from_rrule  # how to make macros public with the @public workaround??
 
 # Public, exported
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,7 +1,7 @@
 """
     Config(; debug_mode=false, silence_debug_messages=false)
 
-Configuration struct for use with ADTypes.AutoMooncake.
+Configuration struct for use with `ADTypes.AutoMooncake`.
 """
 @kwdef struct Config
     debug_mode::Bool = false

--- a/src/public.jl
+++ b/src/public.jl
@@ -1,5 +1,5 @@
 macro public(ex)
-    if VERSION >= v"1.11.0-DEV.469"
+    @static if isdefined(Base, :ispublic)
         args = if ex isa Symbol
             (ex,)
         elseif Base.isexpr(ex, :tuple)

--- a/src/public.jl
+++ b/src/public.jl
@@ -1,0 +1,14 @@
+macro public(ex)
+    if VERSION >= v"1.11.0-DEV.469"
+        args = if ex isa Symbol
+            (ex,)
+        elseif Base.isexpr(ex, :tuple)
+            ex.args
+        else
+            error("Misuse of `@public` macro on $ex")
+        end
+        esc(Expr(:public, args...))
+    else
+        nothing
+    end
+end

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -18,7 +18,9 @@ using ..Mooncake:
     ircode,
     @is_primitive,
     MinimalCtx,
-    val
+    val,
+    primal,
+    tangent
 
 using DiffTests, LinearAlgebra, Random, Setfield
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -13,6 +13,10 @@ using Core: svec
 using ExprTools: combinedef
 using ..Mooncake: NoTangent, tangent_type, _typeof
 
+include("public.jl")
+
+@public test_rule
+
 const PRIMALS = Tuple{Bool,Any,Tuple}[]
 
 # Generate all of the composite types against which we might wish to test.

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -161,7 +161,6 @@ using Mooncake:
     rdata_type,
     rdata
 
-
 struct Shim end
 
 function test_opt(::Any, args...)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -11,8 +11,10 @@ module TestTypes
 using Base.Iterators: product
 using Core: svec
 using ExprTools: combinedef
-using ..Mooncake: NoTangent, tangent_type, _typeof
 using ..Mooncake:
+    NoTangent,
+    tangent_type,
+    _typeof,
     set_to_zero!!,
     increment!!,
     is_primitive,
@@ -21,10 +23,6 @@ using ..Mooncake:
     _add_to_primal,
     _diff,
     _dot
-
-include("public.jl")
-
-@public test_rule
 
 const PRIMALS = Tuple{Bool,Any,Tuple}[]
 
@@ -139,7 +137,15 @@ using Mooncake:
     lsetfield!,
     increment_internal!!,
     set_to_zero_internal!!,
-    CC
+    CC,
+    set_to_zero!!,
+    increment!!,
+    is_primitive,
+    randn_tangent,
+    _scale,
+    _add_to_primal,
+    _diff,
+    _dot
 
 struct Shim end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -102,7 +102,15 @@ using Random, Mooncake, Test, InteractiveUtils
 using Mooncake:
     CoDual,
     NoTangent,
+    PossiblyUninitTangent,
+    Tangent,
+    MutableTangent,
     rrule!!,
+    build_rrule,
+    tangent_type,
+    zero_tangent,
+    primal,
+    tangent,
     is_init,
     zero_codual,
     DefaultCtx,
@@ -145,7 +153,14 @@ using Mooncake:
     _scale,
     _add_to_primal,
     _diff,
-    _dot
+    _dot,
+    NoFData,
+    fdata_type,
+    fdata,
+    NoRData,
+    rdata_type,
+    rdata
+
 
 struct Shim end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -12,6 +12,15 @@ using Base.Iterators: product
 using Core: svec
 using ExprTools: combinedef
 using ..Mooncake: NoTangent, tangent_type, _typeof
+using ..Mooncake:
+    set_to_zero!!,
+    increment!!,
+    is_primitive,
+    randn_tangent,
+    _scale,
+    _add_to_primal,
+    _diff,
+    _dot
 
 include("public.jl")
 

--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -358,7 +358,7 @@ Convenience functionality to assist in using `ChainRulesCore.rrule`s to write `r
 ```jldoctest
 julia> using Mooncake: @from_rrule, DefaultCtx, rrule!!, zero_fcodual, TestUtils
 
-julia> using ChainRulesCore
+julia> import ChainRulesCore
 
 julia> foo(x::Real) = 5x;
 
@@ -382,7 +382,7 @@ Test Passed
 ```jldoctest
 julia> using Mooncake: @from_rrule, DefaultCtx, rrule!!, zero_fcodual, TestUtils
 
-julia> using ChainRulesCore
+julia> import ChainRulesCore
 
 julia> foo(x::Real; cond::Bool) = cond ? 5x : 4x;
 

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -19,6 +19,38 @@ using Core:
 using Core.Intrinsics: pointerref, pointerset
 using FunctionWrappers: FunctionWrapper
 
+using Mooncake
+
+using Mooncake:
+    primal,
+    tangent,
+    randn_tangent,
+    increment!!,
+    NoTangent,
+    Tangent,
+    MutableTangent,
+    PossiblyUninitTangent,
+    set_to_zero!!,
+    tangent_type,
+    zero_tangent,
+    _scale,
+    _add_to_primal,
+    _diff,
+    _dot,
+    zero_codual,
+    codual_type,
+    rrule!!,
+    build_rrule,
+    value_and_gradient!!,
+    value_and_pullback!!,
+    NoFData,
+    NoRData,
+    fdata_type,
+    rdata_type,
+    fdata,
+    rdata,
+    get_interpreter
+
 using Mooncake:
     CC,
     IntrinsicsWrappers,


### PR DESCRIPTION
First attempt to fix #475 

My rationale was:

- stuff starting with an underscore should be private
- stuff with generic names like `set_to_zero!!` should be unexported
- whatever isn't in the "Developer Documentation" should be public

But note that this is not easy to walk back because public symbols are part of the official API, so we can't remove them without a breaking release. Therefore, we need to get this right on the first try, and it would be safer to start with a reduced list of public symbols.
