### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -186,17 +186,27 @@ jobs:
             cat bench/benchmark_results.txt
             echo "EOF"
           } >> $GITHUB_OUTPUT
+          
       - name: Find Comment
         uses: peter-evans/find-comment@v3
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
+          body-includes: "perf-results"
+
       - id: post-report-as-pr-comment
         name: Post Report as Pull Request Comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body: "Performance Ratio:\nRatio of time to compute gradient and time to compute function.\nWarning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.\n```\n${{ steps.read-file.outputs.table }}\n```"
+          body: |
+            <!-- perf-results -->
+            Performance Ratio:
+            Ratio of time to compute gradient and time to compute function.
+            Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
+            ```
+            ${{ steps.read-file.outputs.table }}
+            ```
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
By default, the CI workflow was finding a comment posted by the GitHub Actions bot, which had the same comment ID as one generated by the Documentation workflow. This caused a permissions error because the CI workflow couldn’t update a comment created by another workflow, despite both using the same bot. We fixed this by ensuring each workflow creates and manages its own distinct comment using unique identifiers, like `<!-- perf-results -->` for CI and `<!-- docs-preview-url-Mooncake.jl -->` for Documentation, preventing overlap and resolving the issue.

Fixes https://github.com/TuringLang/actions/issues/22