### PR TITLE
Add arrayify for ReinterpretArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.118"
+version = "0.4.119"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -48,6 +48,11 @@ function arrayify(x::A, dx::FData) where {A<:Base.ReshapedArray{<:BlasRealFloat}
     _, _dx = arrayify(x.parent, dx.data.parent)
     return x, A(_dx, x.dims, x.mi)
 end
+function arrayify(x::Base.ReinterpretArray{T}, dx::FData) where {T<:BlasFloat}
+    _, _dx = arrayify(x.parent, dx.data.parent)
+    return x, reinterpret(T, _dx)
+end
+
 function arrayify(x::A, dx::DA) where {A,DA}
     msg =
         "Encountered unexpected array type in `Mooncake.arrayify`. This error is likely " *

--- a/test/rrules/blas.jl
+++ b/test/rrules/blas.jl
@@ -3,6 +3,8 @@
     TestUtils.run_rrule!!_test_cases(StableRNG, Val(:blas))
 
     @testset "mixed complex-real" begin
-        TestUtils.test_rule(StableRNG(123456), x->sum(complex(x)*x), rand(5,5), is_primitive=false)
+        TestUtils.test_rule(
+            StableRNG(123456), x->sum(complex(x)*x), rand(5, 5), is_primitive=false
+        )
     end
 end

--- a/test/rrules/blas.jl
+++ b/test/rrules/blas.jl
@@ -1,4 +1,8 @@
 @testset "blas" begin
     @test_throws ErrorException Mooncake.arrayify(5, 4)
     TestUtils.run_rrule!!_test_cases(StableRNG, Val(:blas))
+
+    @testset "mixed complex-real" begin
+        TestUtils.test_rule(StableRNG(123456), x->sum(complex(x)*x), rand(5,5), is_primitive=false)
+    end
 end


### PR DESCRIPTION
Should fix #577.

I tried to implement  a test using the `hand_written_rrule!!_test_cases`, but that fails because Base.ReinterpretArray does not have a default constructor. The error messages suggested to try `unsafe_perturb` but it this does not seem to be accessible from the test case tuple.
