### PR TITLE
Some minor doc updates

### DIFF
--- a/docs/src/understanding_mooncake/rule_system.md
+++ b/docs/src/understanding_mooncake/rule_system.md
@@ -205,7 +205,7 @@ must have signature
 Tuple{Trule, CoDual{typeof(foo), NoFData}, CoDual{Float64, NoFData}} ->
     Tuple{CoDual{Float64, NoFData}, Trvs_pass}
 ```
-For example, if we call `foo(5.0)`, it rules would be called as `rule(CoDual(foo, NoFData()), CoDual(5.0, NoFData()))`.
+For example, if we call `foo(5.0)`, its rules would be called as `rule(CoDual(foo, NoFData()), CoDual(5.0, NoFData()))`.
 The precise definition and role of `NoFData` will be explained shortly, but the general scheme is that to a rule for `foo` you must pass `foo` itself, its arguments, and some additional data for book-keeping.
 `foo` and each of its arguments are paired with this additional book-keeping data via the `CoDual` type.
 

--- a/src/developer_tools.jl
+++ b/src/developer_tools.jl
@@ -1,8 +1,9 @@
 """
     primal_ir(sig::Type{<:Tuple}; interp=get_interpreter())::IRCode
 
-!!! warning: this is not part of the public interface of Mooncake. As such, it may change as
-part of a non-breaking release of the package.
+!!! warning
+    This is not part of the public interface of Mooncake. As such, it may change as 
+    part of a non-breaking release of the package.
 
 Get the `Core.Compiler.IRCode` associated to `sig` from which the a rule can be derived.
 Roughly equivalent to `Base.code_ircode_by_type(sig; interp)`.
@@ -26,8 +27,9 @@ end
         interp=get_interpreter(), debug_mode::Bool=false, do_inline::Bool=true
     )::IRCode
 
-!!! warning: this is not part of the public interface of Mooncake. As such, it may change as
-part of a non-breaking release of the package.
+!!! warning
+    This is not part of the public interface of Mooncake. As such, it may change as
+    part of a non-breaking release of the package.
 
 Generate the `Core.Compiler.IRCode` used to construct the forwards-pass of AD. Take a look
 at how `build_rrule` makes use of `generate_ir` to see exactly how this is used in practice.
@@ -67,8 +69,9 @@ end
         interp=get_interpreter(), debug_mode::Bool=false, do_inline::Bool=true
     )::IRCode
 
-!!! warning: this is not part of the public interface of Mooncake. As such, it may change as
-part of a non-breaking release of the package.
+!!! warning
+    This is not part of the public interface of Mooncake. As such, it may change as
+    part of a non-breaking release of the package.
 
 Generate the `Core.Compiler.IRCode` used to construct the reverse-pass of AD. Take a look
 at how `build_rrule` makes use of `generate_ir` to see exactly how this is used in practice.


### PR DESCRIPTION
fix a grammatical error and try to get the warning blocks to render nicely
