### PR TITLE
Demo of compile-time rule generation

### DIFF
--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -75,7 +75,7 @@ function _show_interp(io::IO, ::MIME"text/plain", ::MooncakeInterpreter)
     return print(io, "MooncakeInterpreter()")
 end
 
-MooncakeInterpreter() = MooncakeInterpreter(DefaultCtx)
+MooncakeInterpreter(; world=Base.get_world_counter()) = MooncakeInterpreter(DefaultCtx; world)
 
 context_type(::MooncakeInterpreter{C}) where {C} = C
 
@@ -203,16 +203,16 @@ Globally cached interpreter. Should only be accessed via `get_interpreter`.
 const GLOBAL_INTERPRETER = Ref(MooncakeInterpreter())
 
 """
-    get_interpreter()
+    get_interpreter(; world=Base.get_world_counter)
 
 Returns a `MooncakeInterpreter` appropriate for the current world age. Will use a cached
 interpreter if one already exists for the current world age, otherwise creates a new one.
 
 This should be prefered over constructing a `MooncakeInterpreter` directly.
 """
-function get_interpreter()
-    if GLOBAL_INTERPRETER[].world != Base.get_world_counter()
-        GLOBAL_INTERPRETER[] = MooncakeInterpreter()
+function get_interpreter(; world=Base.get_world_counter())
+    if GLOBAL_INTERPRETER[].world != world
+        GLOBAL_INTERPRETER[] = MooncakeInterpreter(; world)
     end
     return GLOBAL_INTERPRETER[]
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -166,8 +166,7 @@ is_vararg_and_sparam_names(m::Method) = m.isva, sparam_names(m)
 
 Finds the method associated to `sig`, and calls `is_vararg_and_sparam_names` on it.
 """
-function is_vararg_and_sparam_names(sig)::Tuple{Bool,Vector{Symbol}}
-    world = Base.get_world_counter()
+function is_vararg_and_sparam_names(sig; world=Base.get_world_counter())::Tuple{Bool,Vector{Symbol}}
     min = Base.RefValue{UInt}(typemin(UInt))
     max = Base.RefValue{UInt}(typemax(UInt))
     ms = Base._methods_by_ftype(


### PR DESCRIPTION
This is a little demo followup to https://github.com/chalk-lab/Mooncake.jl/issues/498

I made a generated function `Mooncake.generated_build_rrule` that is able to create an `rrule` at compile time and return it as a compiletime const.  Here's a little demo of it in action:
```julia
julia> using Mooncake

julia> @generated function foo(f, args...)
           # I'm just wrapping this in a generated function to more easily show when it gets recompiled
           Core.println("(re-)compiling!")
           quote
               rule = Mooncake.generated_build_rrule(Tuple{typeof(f), typeof.(args)...})
           end
       end;
```
```julia
julia> f(x) = sin(g(x - 1.0));

julia> g(x) = x^2;

julia> foo(f, 1.0)
(re-)compiling!
Mooncake.DerivedRule{Tuple{typeof(f), Float64}, Tuple{Mooncake.CoDual{typeof(f), Mooncake.NoFData}, Mooncake.CoDual{Float64, Mooncake.NoFData}}, Mooncake.CoDual{Float64, Mooncake.NoFData}, Tuple{Float64}, Tuple{Mooncake.NoRData, Float64}, false, Val{2}}(MistyClosure (::Mooncake.CoDual{typeof(f), Mooncake.NoFData}, ::Mooncake.CoDual{Float64, Mooncake.NoFData})::Mooncake.CoDual{Float64, Mooncake.NoFData}->◌, Base.RefValue{MistyClosures.MistyClosure{Core.OpaqueClosure{Tuple{Float64}, Tuple{Mooncake.NoRData, Float64}}}}(MistyClosure (::Float64)::Tuple{Mooncake.NoRData, Float64}->◌), Val{2}())
```
This thing only has the overhead of passing around a struct:
```julia
julia> @btime foo(f, 1.0);
  2.224 ns (0 allocations: 0 bytes)
```
And it carries backedges to `f` so that if a relevant methodistance is invalidated, then the `rrule` is re-compiled:
```julia
julia> foo(f, 1.0); # no message becuase it's already recompiled

julia> g(x) = x + 1; # invalidate f by changing g

julia> foo(f, 1.0);
(re-)compiling!
```