### PR TITLE
Tweak a few tests for tangents

### DIFF
--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -860,7 +860,10 @@ tangent type. This method must be equivalent to `tangent_type(_typeof(primal))`.
 @foldable tangent_type(::Type{NoFData}, ::Type{R}) where {R<:IEEEFloat} = R
 @foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
 
-# Union type: `Union{Nothing, T}` where T could be, eg, Array or Float
+# Handling union types: `Union{Nothing, T}`
+# NOTE: Only the union of `Nothing`, `Array{<:IEEEFloat}` and `Base.IEEEFloat` are 
+# supported; these union types are also only supported for struct field annotation. 
+# Other use cases may fail.
 @foldable tangent_type(::Type{NoFData}, ::Type{T}) where {T<:Union{NoRData,Base.IEEEFloat,RData}} = Union{
     NoTangent,tangent_type(T)
 }

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -1146,9 +1146,6 @@ function tangent_test_cases()
         (Union, NoTangent),
         (UnionAll, NoTangent),
         (typeof(<:), NoTangent),
-        # Tests for Base.TTY
-        (Base.stdout, NoTangent),
-        (Base.stdin, NoTangent),
         (IOStream(""), NoTangent),
         # Test for unions involving `Nothing`
         (P_union_nothing(1.0), T_union_nothing),

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -1137,7 +1137,9 @@ function tangent_test_cases()
         (Union, NoTangent),
         (UnionAll, NoTangent),
         (typeof(<:), NoTangent),
-        (Base.TTY, NoTangent),
+        # Tests for Base.TTY
+        (Base.stdout, NoTangent),
+        (Base.stdin, NoTangent),
     ]
     # Construct test cases containing circular references. These typically require multiple
     # lines of code to construct, so we build them before adding them to `rel_test_cases`.

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -1109,9 +1109,7 @@ function tangent_test_cases()
 
     # Test for unions involving `Nothing`. See, 
     # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
-    struct P_union_nothing
-        x::Union{Base.IEEEFloat,Nothing}
-    end
+    P_union_nothing = NamedTuple{(:x,),Tuple{Union{Base.IEEEFloat,Nothing}}}
     T_union_nothing = Mooncake.Tangent{
         @NamedTuple{x::Union{Mooncake.NoTangent,Float16,Float32,Float64}}
     }

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -1109,13 +1109,6 @@ function tangent_test_cases()
     N_large = 33
     _names = Tuple(map(n -> Symbol("x$n"), 1:N_large))
 
-    # Test for unions involving `Nothing`. See, 
-    # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
-    P_union_nothing = NamedTuple{(:x,),Tuple{Union{Base.IEEEFloat,Nothing}}}
-    T_union_nothing = Mooncake.Tangent{
-        @NamedTuple{x::Union{Mooncake.NoTangent,Float16,Float32,Float64}}
-    }
-
     abs_test_cases = [
         (sin, NoTangent),
         (Float16(5.0), Float16),
@@ -1147,8 +1140,6 @@ function tangent_test_cases()
         (UnionAll, NoTangent),
         (typeof(<:), NoTangent),
         (IOStream(""), NoTangent),
-        # Test for unions involving `Nothing`
-        (P_union_nothing(1.0), T_union_nothing),
     ]
     # Construct test cases containing circular references. These typically require multiple
     # lines of code to construct, so we build them before adding them to `rel_test_cases`.

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -1107,6 +1107,15 @@ function tangent_test_cases()
     N_large = 33
     _names = Tuple(map(n -> Symbol("x$n"), 1:N_large))
 
+    # Test for unions involving `Nothing`. See, 
+    # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
+    struct P_union_nothing
+        x::Union{Base.IEEEFloat,Nothing}
+    end
+    T_union_nothing = Mooncake.Tangent{
+        @NamedTuple{x::Union{Mooncake.NoTangent,Float16,Float32,Float64}}
+    }
+
     abs_test_cases = [
         (sin, NoTangent),
         (Float16(5.0), Float16),
@@ -1140,6 +1149,7 @@ function tangent_test_cases()
         # Tests for Base.TTY
         (Base.stdout, NoTangent),
         (Base.stdin, NoTangent),
+        (P_union_nothing(1.0), T_union_nothing),
     ]
     # Construct test cases containing circular references. These typically require multiple
     # lines of code to construct, so we build them before adding them to `rel_test_cases`.

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -1140,6 +1140,7 @@ function tangent_test_cases()
         (UnionAll, NoTangent),
         (typeof(<:), NoTangent),
         (IOStream(""), NoTangent),
+        (TestResources.P_union_nothing(1.), TestResources.T_union_nothing),
     ]
     # Construct test cases containing circular references. These typically require multiple
     # lines of code to construct, so we build them before adding them to `rel_test_cases`.

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -1140,7 +1140,6 @@ function tangent_test_cases()
         (UnionAll, NoTangent),
         (typeof(<:), NoTangent),
         (IOStream(""), NoTangent),
-        (TestResources.P_union_nothing(1.), TestResources.T_union_nothing),
     ]
     # Construct test cases containing circular references. These typically require multiple
     # lines of code to construct, so we build them before adding them to `rel_test_cases`.

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -143,6 +143,15 @@ struct OneField{A}
     a::A
 end
 
+# Test for unions involving `Nothing`. See, 
+# https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
+struct P_union_nothing
+    x::Union{Base.IEEEFloat,Nothing}
+end
+T_union_nothing = Mooncake.Tangent{
+    @NamedTuple{x::Union{Mooncake.NoTangent,Base.IEEEFloat}}
+}
+
 function build_big_isbits_struct()
     return FourFields(
         FiveFields(

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -148,9 +148,7 @@ end
 struct P_union_nothing
     x::Union{Base.IEEEFloat,Nothing}
 end
-T_union_nothing = Mooncake.Tangent{
-    @NamedTuple{x::Union{Mooncake.NoTangent,Base.IEEEFloat}}
-}
+T_union_nothing = Mooncake.Tangent{@NamedTuple{x::Union{Mooncake.NoTangent,Base.IEEEFloat}}}
 
 function build_big_isbits_struct()
     return FourFields(

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -27,16 +27,6 @@ end
         TestUtils.test_tangent_splitting(Xoshiro(123456), p)
     end
 
-    # Test for unions involving `Nothing`. See, 
-    # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
-    struct P_union_nothing
-        x::Union{Base.IEEEFloat,Nothing}
-    end
-    T_union_nothing = Mooncake.Tangent{
-        @NamedTuple{x::Union{Mooncake.NoTangent,Base.IEEEFloat}}
-    }
-    TestUtils.test_tangent_splitting(Xoshiro(123456), P_union_nothing(1.0))
-
     @testset "zero_rdata_from_type checks" begin
         @test can_produce_zero_rdata_from_type(Vector) == true
         check_allocs(can_produce_zero_rdata_from_type, Vector)

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -25,11 +25,6 @@ end
     end
     @testset "$(typeof(p))" for (_, p, _...) in Mooncake.tangent_test_cases()
         TestUtils.test_tangent_splitting(Xoshiro(123456), p)
-        # See, https://github.com/chalk-lab/Mooncake.jl/issues/597 
-        T1 = Mooncake.tangent_type(Union{Base.IEEEFloat,Nothing})
-        T2 = Mooncake.tangent_type(Union{Vector{Float32},Nothing})
-        @test Mooncake.tangent_type(Mooncake.fdata_type(T1), Mooncake.rdata_type(T1)) == T1
-        @test Mooncake.tangent_type(Mooncake.fdata_type(T2), Mooncake.rdata_type(T2)) == T2
     end
     @testset "zero_rdata_from_type checks" begin
         @test can_produce_zero_rdata_from_type(Vector) == true

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -26,6 +26,13 @@ end
     @testset "$(typeof(p))" for (_, p, _...) in Mooncake.tangent_test_cases()
         TestUtils.test_tangent_splitting(Xoshiro(123456), p)
     end
+    
+    # Test for unions involving `Nothing`. See, 
+    # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
+    struct P_union_nothing; x::Union{Base.IEEEFloat,Nothing} end
+    T_union_nothing = Mooncake.Tangent{@NamedTuple{x::Union{NoTangent, Base.IEEEFloat}}}
+    TestUtils.test_tangent_splitting(Xoshiro(123456), P_union_nothing(1.))
+
     @testset "zero_rdata_from_type checks" begin
         @test can_produce_zero_rdata_from_type(Vector) == true
         check_allocs(can_produce_zero_rdata_from_type, Vector)

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -32,7 +32,7 @@ end
     struct P_union_nothing
         x::Union{Base.IEEEFloat,Nothing}
     end
-    T_union_nothing = Mooncake.Tangent{@NamedTuple{x::Union{NoTangent,Base.IEEEFloat}}}
+    T_union_nothing = Mooncake.Tangent{@NamedTuple{x::Union{Mooncake.NoTangent,Base.IEEEFloat}}}
     TestUtils.test_tangent_splitting(Xoshiro(123456), P_union_nothing(1.0))
 
     @testset "zero_rdata_from_type checks" begin

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -25,6 +25,11 @@ end
     end
     @testset "$(typeof(p))" for (_, p, _...) in Mooncake.tangent_test_cases()
         TestUtils.test_tangent_splitting(Xoshiro(123456), p)
+        # Test for unions involving `Nothing`. See, 
+        # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
+        # `TestUtils.test_tangent_splitting(p)` # currently JET fails since it is union type 
+        p, T = TestResources.P_union_nothing(1.), TestResources.T_union_nothing
+        @test Mooncake.tangent_type(Mooncake.fdata_type(T), Mooncake.rdata_type(T)) == T
     end
 
     @testset "zero_rdata_from_type checks" begin

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -26,12 +26,14 @@ end
     @testset "$(typeof(p))" for (_, p, _...) in Mooncake.tangent_test_cases()
         TestUtils.test_tangent_splitting(Xoshiro(123456), p)
     end
-    
+
     # Test for unions involving `Nothing`. See, 
     # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
-    struct P_union_nothing; x::Union{Base.IEEEFloat,Nothing} end
-    T_union_nothing = Mooncake.Tangent{@NamedTuple{x::Union{NoTangent, Base.IEEEFloat}}}
-    TestUtils.test_tangent_splitting(Xoshiro(123456), P_union_nothing(1.))
+    struct P_union_nothing
+        x::Union{Base.IEEEFloat,Nothing}
+    end
+    T_union_nothing = Mooncake.Tangent{@NamedTuple{x::Union{NoTangent,Base.IEEEFloat}}}
+    TestUtils.test_tangent_splitting(Xoshiro(123456), P_union_nothing(1.0))
 
     @testset "zero_rdata_from_type checks" begin
         @test can_produce_zero_rdata_from_type(Vector) == true

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -28,7 +28,7 @@ end
         # Test for unions involving `Nothing`. See, 
         # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
         # `TestUtils.test_tangent_splitting(p)` # currently JET fails since it is union type 
-        p, T = TestResources.P_union_nothing(1.), TestResources.T_union_nothing
+        p, T = TestResources.P_union_nothing(1.0), TestResources.T_union_nothing
         @test Mooncake.tangent_type(Mooncake.fdata_type(T), Mooncake.rdata_type(T)) == T
     end
 

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -32,7 +32,9 @@ end
     struct P_union_nothing
         x::Union{Base.IEEEFloat,Nothing}
     end
-    T_union_nothing = Mooncake.Tangent{@NamedTuple{x::Union{Mooncake.NoTangent,Base.IEEEFloat}}}
+    T_union_nothing = Mooncake.Tangent{
+        @NamedTuple{x::Union{Mooncake.NoTangent,Base.IEEEFloat}}
+    }
     TestUtils.test_tangent_splitting(Xoshiro(123456), P_union_nothing(1.0))
 
     @testset "zero_rdata_from_type checks" begin


### PR DESCRIPTION
This PR improved tests initially introduced by #599. 

Only the union of `Nothing` and `Base.IEEEFloat` is supported; these union types are also only supported for struct field annotation. Other use cases may fail.

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
