### PR TITLE
Minor refactoring of `Union{Nothing, Array{<:Base.IEEEFloat}, Base.IEEEFloat}` support 

### DIFF
--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -861,11 +861,11 @@ tangent type. This method must be equivalent to `tangent_type(_typeof(primal))`.
 @foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
 
 # Union types. NOTE: Only `Union{Nothing, Array{<:Base.IEEEFloat}, Base.IEEEFloat}` are supported. 
-@foldable tangent_type(::Type{NoFData}, ::Type{T}) where {T<:Union{NoRData,Base.IEEEFloat}} = Union{
-    NoTangent,tangent_type(T)
+@foldable tangent_type(::Type{NoFData}, ::Type{R}) where {R<:Union{NoRData,Base.IEEEFloat}} = Union{
+    NoTangent,tangent_type(R)
 }
-@foldable tangent_type(::Type{T}, ::Type{NoRData}) where {T<:Union{NoFData,Array{<:Base.IEEEFloat}}} = Union{
-    NoTangent,tangent_type(T)
+@foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Union{NoFData,Array{<:Base.IEEEFloat}}} = Union{
+    NoTangent,tangent_type(F)
 }
 
 # Tuples

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -861,10 +861,10 @@ tangent type. This method must be equivalent to `tangent_type(_typeof(primal))`.
 @foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
 
 # Union types. NOTE: Only `Union{Nothing, Array{<:Base.IEEEFloat}, Base.IEEEFloat}` are supported. 
-@foldable tangent_type(::Type{NoFData}, ::Type{R}) where {R<:Union{NoRData,Base.IEEEFloat}} = Union{
+@foldable tangent_type(::Type{NoFData}, ::Type{Union{NoRData,Base.IEEEFloat}}) = Union{
     NoTangent,tangent_type(R)
 }
-@foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Union{NoFData,Array{<:Base.IEEEFloat}}} = Union{
+@foldable tangent_type(::Type{Union{NoFData,Array{<:Base.IEEEFloat}}}, ::Type{NoRData}) = Union{
     NoTangent,tangent_type(F)
 }
 

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -861,10 +861,10 @@ tangent type. This method must be equivalent to `tangent_type(_typeof(primal))`.
 @foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
 
 # Union types. NOTE: Only `Union{Nothing, Array{<:Base.IEEEFloat}, Base.IEEEFloat}` are supported. 
-@foldable tangent_type(::Type{NoFData}, ::Type{Union{NoRData,Base.IEEEFloat}}) = Union{
+@foldable tangent_type(F::Type{NoFData}, R::Type{Union{NoRData,Base.IEEEFloat}}) = Union{
     NoTangent,tangent_type(R)
 }
-@foldable tangent_type(::Type{Union{NoFData,Array{<:Base.IEEEFloat}}}, ::Type{NoRData}) = Union{
+@foldable tangent_type(F::Type{Union{NoFData,Array{<:Base.IEEEFloat}}}, R::Type{NoRData}) = Union{
     NoTangent,tangent_type(F)
 }
 

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -862,10 +862,10 @@ tangent type. This method must be equivalent to `tangent_type(_typeof(primal))`.
 
 # Union types. NOTE: Only `Union{Nothing, Array{<:Base.IEEEFloat}, Base.IEEEFloat}` are supported. 
 @foldable tangent_type(F::Type{NoFData}, R::Type{Union{NoRData,Base.IEEEFloat}}) = Union{
-    NoTangent,tangent_type(R)
+    NoTangent,tangent_type(Base.IEEEFloat)
 }
 @foldable tangent_type(F::Type{Union{NoFData,Array{<:Base.IEEEFloat}}}, R::Type{NoRData}) = Union{
-    NoTangent,tangent_type(F)
+    NoTangent,tangent_type(Array{<:Base.IEEEFloat})
 }
 
 # Tuples

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -860,14 +860,11 @@ tangent type. This method must be equivalent to `tangent_type(_typeof(primal))`.
 @foldable tangent_type(::Type{NoFData}, ::Type{R}) where {R<:IEEEFloat} = R
 @foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
 
-# Handling union types: `Union{Nothing, T}`
-# NOTE: Only the union of `Nothing`, `Array{<:IEEEFloat}` and `Base.IEEEFloat` are 
-# supported; these union types are also only supported for struct field annotation. 
-# Other use cases may fail.
-@foldable tangent_type(::Type{NoFData}, ::Type{T}) where {T<:Union{NoRData,Base.IEEEFloat,RData}} = Union{
+# Union types. NOTE: Only `Union{Nothing, Array{<:Base.IEEEFloat}, Base.IEEEFloat}` are supported. 
+@foldable tangent_type(::Type{NoFData}, ::Type{T}) where {T<:Union{NoRData,Base.IEEEFloat}} = Union{
     NoTangent,tangent_type(T)
 }
-@foldable tangent_type(::Type{T}, ::Type{NoRData}) where {T<:Union{NoFData,Array,MutableTangent,FData}} = Union{
+@foldable tangent_type(::Type{T}, ::Type{NoRData}) where {T<:Union{NoFData,Array{<:Base.IEEEFloat}}} = Union{
     NoTangent,tangent_type(T)
 }
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1139,7 +1139,7 @@ Ensure that [`test_tangent_interface`](@ref) runs for `p` before running these t
 - [`Mooncake.tangent_type`](@ref) (binary method)
 - [`Mooncake.tangent`](@ref) (binary method)
 """
-function test_tangent_splitting(rng::AbstractRNG, p::P) where {P}
+function test_tangent_splitting(rng::AbstractRNG, p::P; test_opt_flag=true) where {P}
 
     # Check that fdata_type and rdata_type run and produce types.
     T = tangent_type(P)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1122,10 +1122,11 @@ function test_equality_comparison(x)
 end
 
 """
-    test_tangent_splitting(rng::AbstractRNG, p::P) where {P}
+    test_tangent_splitting(rng::AbstractRNG, p::P; test_opt_flag=true) where {P}
 
 Verify that tangent splitting functionality associated to primal `p` works correctly.
 Ensure that [`test_tangent_interface`](@ref) runs for `p` before running these tests.
+`test_opt_flag` controls whether to run JET-based checks. 
 
 # Extended Help
 
@@ -1199,13 +1200,13 @@ function test_tangent_splitting(rng::AbstractRNG, p::P) where {P}
 
     # Check that when the zero element is asked from the primal type alone, the result is
     # either an instance of R _or_ a `CannotProduceZeroRDataFromType`.
-    test_opt(zero_rdata_from_type, Tuple{Type{P}})
+    test_opt_flag && test_opt(zero_rdata_from_type, Tuple{Type{P}})
     rzero_from_type = @inferred zero_rdata_from_type(P)
     @test rzero_from_type isa R || rzero_from_type isa CannotProduceZeroRDataFromType
     @test can_make_zero != isa(rzero_from_type, CannotProduceZeroRDataFromType)
 
     # Check that we can produce a lazy zero rdata, and that it has the correct type.
-    test_opt(lazy_zero_rdata, Tuple{P})
+    test_opt_flag && test_opt(lazy_zero_rdata, Tuple{P})
     lazy_rzero = @inferred lazy_zero_rdata(p)
     @test instantiate(lazy_rzero) isa R
 

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -27,9 +27,9 @@ end
         TestUtils.test_tangent_splitting(Xoshiro(123456), p)
         # Test for unions involving `Nothing`. See, 
         # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
-        # `TestUtils.test_tangent_splitting(p)` # currently JET fails since it is union type 
-        p, T = TestResources.P_union_nothing(1.0), TestResources.T_union_nothing
-        @test Mooncake.tangent_type(Mooncake.fdata_type(T), Mooncake.rdata_type(T)) == T
+        TestUtils.test_tangent_splitting(
+            TestResources.P_union_nothing(1.0); test_opt_flag=false
+        )
     end
 
     @testset "zero_rdata_from_type checks" begin

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -28,6 +28,7 @@ end
         # Test for unions involving `Nothing`. See, 
         # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
         TestUtils.test_tangent_splitting(
+            Xoshiro(123456), 
             TestResources.P_union_nothing(1.0); test_opt_flag=false
         )
     end

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -28,8 +28,7 @@ end
         # Test for unions involving `Nothing`. See, 
         # https://github.com/chalk-lab/Mooncake.jl/issues/597 for the reason.
         TestUtils.test_tangent_splitting(
-            Xoshiro(123456), 
-            TestResources.P_union_nothing(1.0); test_opt_flag=false
+            Xoshiro(123456), TestResources.P_union_nothing(1.0); test_opt_flag=false
         )
     end
 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
