### PR TITLE
Fix typo in algorithmic_differentiation.md

### DIFF
--- a/docs/src/understanding_mooncake/algorithmic_differentiation.md
+++ b/docs/src/understanding_mooncake/algorithmic_differentiation.md
@@ -86,7 +86,7 @@ This definition of the derivative has a name: the Frechet derivative.
 It is a generalisation of the Total Derivative.
 Formally, we say that a function ``f : \mathcal{X} \to \mathcal{Y}`` is differentiable at a point ``x \in \mathcal{X}`` if there exists a linear operator ``D f [x] : \mathcal{X} \to \mathcal{Y}`` (the derivative) satisfying
 ```math
-\lim_{\text{d} h \to 0} \frac{\| f(x + \text{d} h) - f(x) + D f [x] (\text{d} h)  \|_\mathcal{Y}}{\| \text{d}h \|_\mathcal{X}} = 0,
+\lim_{\text{d} h \to 0} \frac{\| f(x + \text{d} h) - f(x) - D f [x] (\text{d} h)  \|_\mathcal{Y}}{\| \text{d}h \|_\mathcal{X}} = 0,
 ```
 where ``\| \cdot \|_\mathcal{X}`` and ``\| \cdot \|_\mathcal{Y}`` are the norms associated to Hilbert spaces ``\mathcal{X}`` and ``\mathcal{Y}`` respectively.
 (The Frechet derivative does not depend on the choice of norms. All norms are _equivalent_ in finite dimensions, meaning they define the same topology and notion of convergence: if this equation is satisfied for one norm, it holds for all.)


### PR DESCRIPTION
This is just a small typo I found while reading the docs, that btw are awesome! Huge congrats :smile:. 

 As the idea is to approximate $f(x + \text{d} h) \approx f(x) + D f [x] (\text{d} h)$, then

```math
\lim_{\text{d} h \to 0} \frac{\| f(x + \text{d} h) - f(x) {\textcolor{red}-} D f [x] (\text{d} h)  \|_\mathcal{Y}}{\| \text{d}h \|_\mathcal{X}} = 0.
```
Wikipedia also agrees: https://en.wikipedia.org/wiki/Fr%C3%A9chet_derivative

Thanks for this amazing package, we are definitely trying it out :). 