### PR TITLE
fix supported primal checks in prepare_pullback_cache

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.135"
+version = "0.4.136"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -430,7 +430,7 @@ function prepare_pullback_cache(fx...; kwargs...)
     y, rvs!! = rule(map((x, dx) -> CoDual(x, fdata(dx)), fx, tangents)...)
 
     # Handle forward pass's primal exceptions
-    __exclude_unsupported_output(y)
+    __exclude_unsupported_output(primal(y))
 
     # Run reverse-pass in order to reset stacks + state.
     rvs!!(zero_rdata(primal(y)))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -421,9 +421,12 @@ end
 Returns a cache used with [`value_and_pullback!!`](@ref). See that function for more info.
 """
 function prepare_pullback_cache(fx...; kwargs...)
-    # Handle forward pass's primal exceptions before rule construction (zero_tangent is not defined for Ptr)
-    arg_copy = deepcopy.(fx)
-    __exclude_unsupported_output((arg_copy[1])(arg_copy[2:end]...))
+    # Exclude specific primals; this needs to be handled before rule construction because
+    # `zero_tangent` is not defined for some argument types like `Ptr` and will error. 
+    _fx = deepcopy(fx)
+    _func, _args = _fx[1], _fx[2:end]
+    _y = _func(_args...)
+    __exclude_unsupported_output(_y)
 
     # Construct rule and tangents.
     rule = build_rrule(get_interpreter(), Tuple{map(_typeof, fx)...}; kwargs...)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -188,6 +188,7 @@ end
 
         @testset "__exclude_unsupported_output , $(test_set)" for test_set in
                                                                   additional_test_set
+
             try
                 Mooncake.__exclude_unsupported_output(test_set[2])
             catch err
@@ -197,6 +198,7 @@ end
 
         @testset "_copy_output & _copy_to_output!!, $(test_set)" for test_set in
                                                                      additional_test_set
+
             original = test_set[2]
             try
                 if isnothing(Mooncake.__exclude_unsupported_output(original))

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -166,7 +166,7 @@ end
         circ_obj.data = circ_obj  # Self-referential struct
         push!(test_to_fail_cases, (identity, circ_obj))
 
-        # ---- include Ptr Unsupported Types ----
+        # ---- Exclude `Ptr` typed input arguments and returned values ----
         push!(test_to_fail_cases, ((x) -> Ptr{Float64}(x[1]), rand(UInt, 1)))
         push!(
             test_to_fail_cases,

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -144,7 +144,7 @@ end
         test_to_fail_cases = []
 
         # ---- Aliasing Cases ----
-        alias_vector = [rand(Int64, 2), rand(Int64, 2)]
+        alias_vector = [rand(UInt, 2), rand(UInt, 2)]
         alias_vector[2] = alias_vector[1]
         push!(test_to_fail_cases, (identity, alias_vector))
 
@@ -158,7 +158,7 @@ end
             numeric::Int64
         end
 
-        circ_obj = CircularStruct(nothing, rand(Int64, 1)[1])
+        circ_obj = CircularStruct(nothing, rand(UInt, 1)[1])
         circ_obj.data = circ_obj  # Self-referential struct
         push!(test_to_fail_cases, (identity, circ_obj))
 
@@ -167,10 +167,10 @@ end
         push!(test_to_fail_cases, (identity, alias_tuple))
 
         # ---- include Ptr Unsupported Types ----
-        rand_int = push!(test_to_fail_cases, ((x) -> Ptr{Float64}(x[1]), rand(Int64, 1)))
+        push!(test_to_fail_cases, ((x) -> Ptr{Float64}(x[1]), rand(UInt, 1)))
         push!(
             test_to_fail_cases,
-            ((x) -> (rand(Int64, 1), [Ptr{Float64}(x_i) for x_i in x]), rand(Int64, 5)),
+            ((x) -> (rand(UInt, 1), [Ptr{Float64}(x_i) for x_i in x]), rand(UInt, 5)),
         )
 
         @testset "prepare_pullback_cache checks" for (f, test_case) in test_to_fail_cases

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -143,7 +143,7 @@ end
         # Test when function outputs an invalid type. 
         test_to_fail_cases = []
 
-        # ---- Aliasing Cases ----
+        # Aliasing Cases
         alias_vector = [rand(Int64, 2), rand(Int64, 2)]
         alias_vector[2] = alias_vector[1]
         push!(test_to_fail_cases, (identity, alias_vector))
@@ -152,7 +152,7 @@ end
         alias_tuple = (alias_tuple[1], alias_tuple[1])
         push!(test_to_fail_cases, (identity, alias_tuple))
 
-        # ---- Circular Referencing Cases ----
+        # Circular Referencing Cases
         circular_vector = Any[rand(2)]
         push!(circular_vector, circular_vector)
         push!(test_to_fail_cases, (identity, circular_vector))
@@ -166,7 +166,7 @@ end
         circ_obj.data = circ_obj  # Self-referential struct
         push!(test_to_fail_cases, (identity, circ_obj))
 
-        # ---- Exclude `Ptr` typed input arguments and returned values ----
+        # Exclude `Ptr` typed input arguments and returned values
         push!(test_to_fail_cases, ((x) -> Ptr{Float64}(x[1]), rand(UInt, 1)))
         push!(
             test_to_fail_cases,

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -144,9 +144,13 @@ end
         test_to_fail_cases = []
 
         # ---- Aliasing Cases ----
-        alias_vector = [rand(UInt, 2), rand(UInt, 2)]
+        alias_vector = [rand(Int64, 2), rand(Int64, 2)]
         alias_vector[2] = alias_vector[1]
         push!(test_to_fail_cases, (identity, alias_vector))
+
+        alias_tuple = (rand(2), rand(2))
+        alias_tuple = (alias_tuple[1], alias_tuple[1])
+        push!(test_to_fail_cases, (identity, alias_tuple))
 
         # ---- Circular Referencing Cases ----
         circular_vector = Any[rand(2)]
@@ -158,13 +162,9 @@ end
             numeric::Int64
         end
 
-        circ_obj = CircularStruct(nothing, rand(UInt, 1)[1])
+        circ_obj = CircularStruct(nothing, rand(Int64, 1)[1])
         circ_obj.data = circ_obj  # Self-referential struct
         push!(test_to_fail_cases, (identity, circ_obj))
-
-        alias_tuple = (rand(2), rand(2))
-        alias_tuple = (alias_tuple[1], alias_tuple[1])
-        push!(test_to_fail_cases, (identity, alias_tuple))
 
         # ---- include Ptr Unsupported Types ----
         push!(test_to_fail_cases, ((x) -> Ptr{Float64}(x[1]), rand(UInt, 1)))

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -170,10 +170,7 @@ end
         rand_int = push!(test_to_fail_cases, ((x) -> Ptr{Float64}(x[1]), rand(Int64, 1)))
         push!(
             test_to_fail_cases,
-            (
-                (x) -> (rand(Int64, 1), [Ptr{Float64}(x_i) for x_i in eachindex(x)]),
-                rand(Int64, 5),
-            ),
+            ((x) -> (rand(Int64, 1), [Ptr{Float64}(x_i) for x_i in x]), rand(Int64, 5)),
         )
 
         @testset "prepare_pullback_cache checks" for (f, test_case) in test_to_fail_cases


### PR DESCRIPTION
Checking for `Ptr` types etc. can only be done if we primal check before running the forward pass for the derived rules/generate zero_tangent data for the rule's forward pass as it results in `ArgumentError: zero_tangent not defined for Pointers`.
refer : 
![image](https://github.com/user-attachments/assets/0fff2cb7-f3c2-4640-ad2d-ee3a22f16b6c)

Also fixes alias tuple test [case](https://github.com/chalk-lab/Mooncake.jl/blob/f0e3f9a2886782415fd8e2b13c1bc5008b5672d7/test/interface.jl#L151)  (tuples are stored by value, aliasing is not possible unless the elements are address based objects). Broadcasting `__exclude_unsupported_output` [here](https://github.com/chalk-lab/Mooncake.jl/blob/f0e3f9a2886782415fd8e2b13c1bc5008b5672d7/test/interface.jl#L176) gives a false pass on the tests.
refer: 
![image](https://github.com/user-attachments/assets/73f18c33-38d6-4774-a4b4-a46ded676e7c)