### PR TITLE
Add tangent_type for BigInt and rule for generate_dropout_mask

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.138"
+version = "0.4.139"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeLuxLibExt.jl
+++ b/ext/MooncakeLuxLibExt.jl
@@ -40,7 +40,9 @@ end
 end
 
 Mooncake.@zero_adjoint DefaultCtx Tuple{typeof(static_training_mode_check),Vararg}
-Mooncake.@zero_adjoint DefaultCtx Tuple{typeof(LuxLib.Impl.generate_dropout_mask), AbstractRNG, Any, Any, Any, Any}
+Mooncake.@zero_adjoint DefaultCtx Tuple{
+    typeof(LuxLib.Impl.generate_dropout_mask),AbstractRNG,Any,Any,Any,Any
+}
 
 # This is a really horrible hack that we need to do until Mooncake is able to support the
 # call-back-into-ad interface that ChainRules exposes.

--- a/ext/MooncakeLuxLibExt.jl
+++ b/ext/MooncakeLuxLibExt.jl
@@ -40,6 +40,7 @@ end
 end
 
 Mooncake.@zero_adjoint DefaultCtx Tuple{typeof(static_training_mode_check),Vararg}
+Mooncake.@zero_adjoint DefaultCtx Tuple{typeof(LuxLib.Impl.generate_dropout_mask), AbstractRNG, Any, Any, Any, Any}
 
 # This is a really horrible hack that we need to do until Mooncake is able to support the
 # call-back-into-ad interface that ChainRules exposes.

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -340,7 +340,7 @@ tangent_type(::Type{Core.TypeofVararg}) = NoTangent
 
 tangent_type(::Type{P}) where {P<:Union{UInt8,UInt16,UInt32,UInt64,UInt128}} = NoTangent
 
-tangent_type(::Type{P}) where {P<:Union{Int8,Int16,Int32,Int64,Int128}} = NoTangent
+tangent_type(::Type{P}) where {P<:Union{Int8,Int16,Int32,Int64,Int128,BigInt}} = NoTangent
 
 tangent_type(::Type{<:Core.Builtin}) = NoTangent
 
@@ -1194,6 +1194,7 @@ tangents, but they're unable to check that `increment!!` is correct in an absolu
         (UnitRange{Int}(5, 7), NoTangent),
         (Array, NoTangent),
         (Float64, NoTangent),
+        (BigInt, NoTangent),
         (Union{Float64,Float32}, NoTangent),
         (Union, NoTangent),
         (UnionAll, NoTangent),

--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -13,13 +13,13 @@ sr(x) = StableRNG(x)
         (false, Dense(2, 4), randn(sr(1), P, 2, 3)),
         # tests for https://github.com/chalk-lab/Mooncake.jl/issues/563
         (
-            false,
+            true,
             MultiHeadAttention(4; attention_dropout_probability=0.1f0),
             randn(sr(1), P, 4, 4),
         ),
         # tests for https://github.com/chalk-lab/Mooncake.jl/issues/622
         (
-            false,
+            true,
             Chain(Dense(1, 10, relu), Dense(10, 10, relu), Dense(10, 1)),
             randn(sr(2), P, 1, 1_000),
         ),

--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -116,4 +116,16 @@ sr(x) = StableRNG(x)
             rng, f, x, ps, st; is_primitive=false, interface_only, unsafe_perturb=true
         )
     end
+    
+    @testset "Lux dropout #563"
+        rng = sr(123546)
+        x = randn(rng, Float32, 4, 4)
+        fn = sum ∘ sum ∘ first ∘ Lux.apply
+
+        model = MultiHeadAttention(4; attention_dropout_probability=0.1f0)
+        ps, st = Lux.setup(Random.MersenneTwister(123), model)
+
+        cache = Mooncake.build_rrule(fn, model, x, ps, st)
+        value_and_gradient!!(cache, fn, model, x, ps, st)
+    end
 end

--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -123,7 +123,7 @@ sr(x) = StableRNG(x)
         fn = sum ∘ sum ∘ first ∘ Lux.apply
 
         model = MultiHeadAttention(4; attention_dropout_probability=0.1f0)
-        ps, st = Lux.setup(Random.MersenneTwister(123), model)
+        ps, st = Lux.setup(rng, model)
 
         cache = Mooncake.build_rrule(fn, model, x, ps, st)
         value_and_gradient!!(cache, fn, model, x, ps, st)

--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -11,7 +11,10 @@ sr(x) = StableRNG(x)
     P = Float32
     @testset "$(typeof(f))" for (interface_only, f, x_f32) in Any[
         (false, Dense(2, 4), randn(sr(1), P, 2, 3)),
+        # tests for https://github.com/chalk-lab/Mooncake.jl/issues/563
         (false, MultiHeadAttention(4; attention_dropout_probability=0.1f0), randn(sr(1), P, 4, 4)),
+        # tests for https://github.com/chalk-lab/Mooncake.jl/issues/622
+        (false, Chain(Dense(1, 10, relu), Dense(10, 10, relu), Dense(10, 1)), randn(sr(2), P, 1, 1_000)),
         (false, Dense(2, 4, gelu), randn(sr(2), P, 2, 3)),
         (false, Dense(2, 4, gelu; use_bias=false), randn(sr(3), P, 2, 3)),
         (false, Chain(Dense(2, 4, relu), Dense(4, 3)), randn(sr(4), P, 2, 3)),

--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -116,8 +116,8 @@ sr(x) = StableRNG(x)
             rng, f, x, ps, st; is_primitive=false, interface_only, unsafe_perturb=true
         )
     end
-    
-    @testset "Lux dropout #563"
+
+    @testset "Lux dropout #563" begin
         rng = sr(123546)
         x = randn(rng, Float32, 4, 4)
         fn = sum ∘ sum ∘ first ∘ Lux.apply

--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -12,9 +12,17 @@ sr(x) = StableRNG(x)
     @testset "$(typeof(f))" for (interface_only, f, x_f32) in Any[
         (false, Dense(2, 4), randn(sr(1), P, 2, 3)),
         # tests for https://github.com/chalk-lab/Mooncake.jl/issues/563
-        (false, MultiHeadAttention(4; attention_dropout_probability=0.1f0), randn(sr(1), P, 4, 4)),
+        (
+            false,
+            MultiHeadAttention(4; attention_dropout_probability=0.1f0),
+            randn(sr(1), P, 4, 4),
+        ),
         # tests for https://github.com/chalk-lab/Mooncake.jl/issues/622
-        (false, Chain(Dense(1, 10, relu), Dense(10, 10, relu), Dense(10, 1)), randn(sr(2), P, 1, 1_000)),
+        (
+            false,
+            Chain(Dense(1, 10, relu), Dense(10, 10, relu), Dense(10, 1)),
+            randn(sr(2), P, 1, 1_000),
+        ),
         (false, Dense(2, 4, gelu), randn(sr(2), P, 2, 3)),
         (false, Dense(2, 4, gelu; use_bias=false), randn(sr(3), P, 2, 3)),
         (false, Chain(Dense(2, 4, relu), Dense(4, 3)), randn(sr(4), P, 2, 3)),

--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -11,6 +11,7 @@ sr(x) = StableRNG(x)
     P = Float32
     @testset "$(typeof(f))" for (interface_only, f, x_f32) in Any[
         (false, Dense(2, 4), randn(sr(1), P, 2, 3)),
+        (false, MultiHeadAttention(4; attention_dropout_probability=0.1f0), randn(sr(1), P, 4, 4)),
         (false, Dense(2, 4, gelu), randn(sr(2), P, 2, 3)),
         (false, Dense(2, 4, gelu; use_bias=false), randn(sr(3), P, 2, 3)),
         (false, Chain(Dense(2, 4, relu), Dense(4, 3)), randn(sr(4), P, 2, 3)),
@@ -115,17 +116,5 @@ sr(x) = StableRNG(x)
         test_rule(
             rng, f, x, ps, st; is_primitive=false, interface_only, unsafe_perturb=true
         )
-    end
-
-    @testset "Lux dropout #563" begin
-        rng = sr(123546)
-        x = randn(rng, Float32, 4, 4)
-        fn = sum ∘ sum ∘ first ∘ Lux.apply
-
-        model = MultiHeadAttention(4; attention_dropout_probability=0.1f0)
-        ps, st = Lux.setup(rng, model)
-
-        cache = Mooncake.build_rrule(fn, model, x, ps, st)
-        value_and_gradient!!(cache, fn, model, x, ps, st)
     end
 end


### PR DESCRIPTION
This PR fixes a Lux issue with dropout (https://github.com/chalk-lab/Mooncake.jl/issues/563) and adds a test for https://github.com/chalk-lab/Mooncake.jl/issues/622

Close https://github.com/chalk-lab/Mooncake.jl/issues/563 and add tests. 
