### PR TITLE
Update CFG Implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.139"
+version = "0.4.140"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -71,7 +71,7 @@ SLEEFPirates = "0.6.43"
 SpecialFunctions = "2"
 StableRNGs = "1"
 Test = "1"
-julia = "~1.10.8, 1.11.3"
+julia = "~1.10.8, 1.11.6"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -454,7 +454,9 @@ function _control_flow_graph(blks::Vector{BBlock})::Core.Compiler.CFG
     succs = map(id -> sort(map(s -> id_to_num[s], succs_ids[id])), block_ids)
 
     # Predecessor of entry block is `0`. This needs to be added in manually.
-    push!(preds[1], 0)
+    @static if VERSION >= v"1.11"
+        push!(preds[1], 0)
+    end
 
     # Compute the statement numbers associated to each basic block.
     index = vcat(0, cumsum(map(length, blks))) .+ 1

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -453,6 +453,10 @@ function _control_flow_graph(blks::Vector{BBlock})::Core.Compiler.CFG
     preds = map(id -> sort(map(p -> id_to_num[p], preds_ids[id])), block_ids)
     succs = map(id -> sort(map(s -> id_to_num[s], succs_ids[id])), block_ids)
 
+    # Predecessor of entry block is `0`. This needs to be added in manually.
+    push!(preds[1], 0)
+
+    # Compute the statement numbers associated to each basic block.
     index = vcat(0, cumsum(map(length, blks))) .+ 1
     basic_blocks = map(eachindex(blks)) do n
         stmt_range = Core.Compiler.StmtRange(index[n], index[n + 1] - 1)


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
It appears that, as of 1.11.6, basic block number `0` is now a predecessor of the first basic block in a `Core.Compiler.CFG`. Per the support policy, this PR drops support for `[1.11.1, 1.11.5]` in order to implement the fix.

edit: fixes #655 