### PR TITLE
fix for Base.CoreLogging usage in SciML solvers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.142"
+version = "0.4.143"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.141"
+version = "0.4.142"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -149,9 +149,9 @@ end
 Equivalent to `value_and_pullback!!(rule, 1.0, f, x...)`, and assumes `f` returns a
 `Union{Float16,Float32,Float64}`.
 
-*Note:* There are lots of subtle ways to mis-use `value_and_pullback!!`, so we generally
+*Note:* There are lots of subtle ways to mis-use [`value_and_pullback!!`](@ref), so we generally
 recommend using `Mooncake.value_and_gradient!!` (this function) where possible. The
-docstring for `value_and_pullback!!` is useful for understanding this function though.
+docstring for [`value_and_pullback!!`](@ref) is useful for understanding this function though.
 
 An example:
 ```jldoctest
@@ -198,7 +198,7 @@ end
     __exclude_unsupported_output(y)
     __exclude_func_with_unsupported_output(fx)
 
-Required for the robust design of [`value_and_pullback`](@ref), [`prepare_pullback_cache`](@ref).  
+Required for the robust design of [`value_and_pullback!!`](@ref), [`prepare_pullback_cache`](@ref).  
 Ensures that `y` or returned value of `fx::Tuple{Tf, Targs...}` contains no aliasing, circular references, `Ptr`s or non differentiable datatypes. 
 In the forward pass f(args...) output can only return a "Tree" like datastructure with leaf nodes as primitive types.  
 Refer https://github.com/chalk-lab/Mooncake.jl/issues/517#issuecomment-2715202789 and related issue for details.  

--- a/src/rrules/avoiding_non_differentiable_code.jl
+++ b/src/rrules/avoiding_non_differentiable_code.jl
@@ -184,12 +184,12 @@ function generate_hand_written_rrule!!_test_cases(
             ("hello" => "hi",),
             1,
         ),
-        (false, :stability, nothing, print, "Hello"),
-        (false, :stability, nothing, println, "Hello"),
-        (false, :stability, nothing, show, "Hello"),
+        (false, :none, nothing, print, "Testing print"),
+        (false, :none, nothing, println, "Testing println"),
+        (false, :none, nothing, show, "Testing show"),
 
         # non-kwargs sprint rule test
-        (false, :stability, nothing, sprint, show, "Hello"),
+        (false, :stability, nothing, sprint, show, "Testing sprint"),
 
         # Rules to make Symbol-related functionality work properly.
         (false, :stability_and_allocs, nothing, Symbol, "hello"),

--- a/src/rrules/avoiding_non_differentiable_code.jl
+++ b/src/rrules/avoiding_non_differentiable_code.jl
@@ -27,6 +27,7 @@ import Base.CoreLogging as CoreLogging
 
 # Some Base String related rrules :
 @zero_adjoint MinimalCtx Tuple{typeof(print),Vararg}
+@zero_adjoint MinimalCtx Tuple{typeof(println),Vararg}
 @zero_adjoint MinimalCtx Tuple{typeof(show),Vararg}
 @zero_adjoint MinimalCtx Tuple{typeof(normpath),String}
 
@@ -184,6 +185,7 @@ function generate_hand_written_rrule!!_test_cases(
             1,
         ),
         (false, :none, nothing, print, "Testing print"),
+        (false, :none, nothing, println, "Testing println"),
         (false, :none, nothing, show, "Testing show"),
 
         # non-kwargs sprint rule test
@@ -255,7 +257,6 @@ function generate_derived_rrule!!_test_cases(
             (false, :none, nothing, testloggingmacro7, rand(1:100)),
             (false, :none, nothing, testloggingmacro8, rand(1:100)),
             (false, :none, nothing, testloggingmacro9, rand(1:100)),
-            (false, :none, nothing, println, "Testing println"),
         ],
     )
     return test_cases, Any[]

--- a/src/rrules/avoiding_non_differentiable_code.jl
+++ b/src/rrules/avoiding_non_differentiable_code.jl
@@ -26,7 +26,6 @@ import Base.CoreLogging as CoreLogging
 @zero_adjoint MinimalCtx Tuple{typeof(getindex),Atomic{I}} where {I<:Integer}
 
 # Some Base String related rrules :
-@zero_adjoint MinimalCtx Tuple{typeof(println),Vararg}
 @zero_adjoint MinimalCtx Tuple{typeof(print),Vararg}
 @zero_adjoint MinimalCtx Tuple{typeof(show),Vararg}
 @zero_adjoint MinimalCtx Tuple{typeof(normpath),String}
@@ -185,7 +184,6 @@ function generate_hand_written_rrule!!_test_cases(
             1,
         ),
         (false, :none, nothing, print, "Testing print"),
-        (false, :none, nothing, println, "Testing println"),
         (false, :none, nothing, show, "Testing show"),
 
         # non-kwargs sprint rule test
@@ -257,6 +255,7 @@ function generate_derived_rrule!!_test_cases(
             (false, :none, nothing, testloggingmacro7, rand(1:100)),
             (false, :none, nothing, testloggingmacro8, rand(1:100)),
             (false, :none, nothing, testloggingmacro9, rand(1:100)),
+            (false, :none, nothing, println, "Testing println"),
         ],
     )
     return test_cases, Any[]

--- a/src/rrules/avoiding_non_differentiable_code.jl
+++ b/src/rrules/avoiding_non_differentiable_code.jl
@@ -14,6 +14,107 @@ end
 @zero_adjoint MinimalCtx Tuple{Type{Float16},Any,RoundingMode}
 @zero_adjoint MinimalCtx Tuple{typeof(==),Type,Type}
 
+# logging, String related primitive rules
+using Base: getindex, getproperty
+using Base.Threads: Atomic
+using Mooncake: zero_fcodual, MinimalCtx, @is_primitive, NoPullback, CoDual
+using Base.CoreLogging: LogLevel, handle_message, invokelatest
+import Base.CoreLogging as CoreLogging
+
+# Rule for accessing an Atomic{T} wrapped Integer with Base.getindex as deriving a rule results
+# in encountering a Atomic->Int address bitcast followed by a llvm atomic load call 
+@is_primitive MinimalCtx Tuple{typeof(getindex),Atomic{T}} where {T<:Integer}
+function rrule!!(::CoDual{typeof(getindex)}, x::CoDual{Atomic{T}}) where {T<:Integer}
+    return zero_fcodual(getindex(x.x)), NoPullback()
+end
+
+@is_primitive MinimalCtx Tuple{typeof(Base.normpath),String}
+function rrule!!(::CoDual{typeof(Base.normpath)}, path::CoDual{String})
+    return zero_fcodual(Base.normpath(path.x)), NoPullback()
+end
+
+@is_primitive MinimalCtx Tuple{
+    typeof(Base._replace_init),String,Tuple{Pair{String,String}},Int64
+}
+function rrule!!(
+    ::CoDual{typeof(Base._replace_init)},
+    str::CoDual{String},
+    replacements::CoDual{Tuple{Pair{String,String}}},
+    count::CoDual{Int64},
+)
+    return zero_fcodual(Base._replace_init(str.x, replacements.x, count.x)), NoPullback()
+end
+
+@is_primitive MinimalCtx Tuple{
+    typeof(CoreLogging.current_logger_for_env),LogLevel,Symbol,Module
+}
+function rrule!!(
+    ::CoDual{typeof(CoreLogging.current_logger_for_env)},
+    level::CoDual{LogLevel},
+    group::CoDual{Symbol},
+    _module::CoDual{Module},
+)
+    logger = CoreLogging.current_logger_for_env(level.x, group.x, _module.x)
+    return zero_fcodual(logger), NoPullback()
+end
+
+@is_primitive MinimalCtx Tuple{
+    typeof(Core._call_latest),
+    typeof(Base.CoreLogging.shouldlog),
+    Any,
+    LogLevel,
+    Module,
+    Symbol,
+    Symbol,
+}
+function rrule!!(
+    ::CoDual{typeof(Core._call_latest)},
+    ::CoDual{typeof(Base.CoreLogging.shouldlog)},
+    logger::CoDual,
+    level::CoDual{LogLevel},
+    _module::CoDual{Module},
+    group::CoDual{Symbol},
+    id::CoDual{Symbol},
+)
+    result = Core._call_latest(
+        Base.CoreLogging.shouldlog, logger.x, level.x, _module.x, group.x, id.x
+    )
+    return zero_fcodual(result), NoPullback()
+end
+
+@is_primitive MinimalCtx Tuple{
+    typeof(Core._call_latest),typeof(handle_message),Any,Vararg{Any}
+}
+function rrule!!(
+    ::CoDual{typeof(Core._call_latest)},
+    ::CoDual{typeof(CoreLogging.handle_message)},
+    logger::CoDual,
+    args::Vararg{CoDual},
+)
+    prim_args = map(primal, args)
+    result = Core._call_latest(CoreLogging.handle_message, logger.x, prim_args...)
+    return zero_fcodual(result), NoPullback()
+end
+
+@is_primitive MinimalCtx Tuple{
+    typeof(Core.kwcall),
+    NamedTuple,
+    typeof(CoreLogging.invokelatest),
+    typeof(CoreLogging.handle_message),
+    Vararg{Any},
+}
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    kwargs::CoDual,
+    ::CoDual{typeof(Core._call_latest)},
+    ::CoDual{typeof(CoreLogging.handle_message)},
+    args::Vararg{CoDual},
+)
+    prim_args = map(primal, args)
+    Core._call_latest(CoreLogging.handle_message, logger.x, prim_args...; kwargs...)
+    return zero_fcodual(nothing), NoPullback()
+end
+
 function generate_hand_written_rrule!!_test_cases(
     rng_ctor, ::Val{:avoiding_non_differentiable_code}
 )
@@ -22,7 +123,7 @@ function generate_hand_written_rrule!!_test_cases(
     test_cases = vcat(
         Any[
         # Rules to avoid pointer type conversions.
-            (
+        (
             true,
             :stability_and_allocs,
             nothing,

--- a/src/rrules/avoiding_non_differentiable_code.jl
+++ b/src/rrules/avoiding_non_differentiable_code.jl
@@ -126,50 +126,64 @@ function generate_hand_written_rrule!!_test_cases(
     test_cases = vcat(
         Any[
             # Rules to avoid pointer type conversions.
-            # (
-            #     true,
-            #     :stability_and_allocs,
-            #     nothing,
-            #     +,
-            #     CoDual(
-            #         bitcast(Ptr{Float64}, pointer_from_objref(_x)),
-            #         bitcast(Ptr{Float64}, pointer_from_objref(_dx)),
-            #     ),
-            #     2,
-            # ),
+            (
+                true,
+                :stability_and_allocs,
+                nothing,
+                +,
+                CoDual(
+                    bitcast(Ptr{Float64}, pointer_from_objref(_x)),
+                    bitcast(Ptr{Float64}, pointer_from_objref(_dx)),
+                ),
+                2,
+            ),
 
             # Rules for handling Atomic read operations.
-            (false, :stability_and_allocs, nothing, Base.getindex, Atomic{Int64}(rand(1:100))),
-            # (false, :allocs, nothing, getindex, Atomic{Int32}(rand(1:100))),
-            # (false, :allocs, nothing, getindex, Atomic{Int16}(rand(1:100))),
+            (
+                false,
+                :stability_and_allocs,
+                nothing,
+                Base.getindex,
+                Atomic{Int64}(rand(1:100)),
+            ),
+            (false, :stability_and_allocs, nothing, getindex, Atomic{Int32}(rand(1:100))),
+            (false, :stability_and_allocs, nothing, getindex, Atomic{Int16}(rand(1:100))),
         ],
 
         # Rules in order to avoid introducing determinism.
-        # reduce(
-        #     vcat,
-        #     map([Xoshiro(1), TaskLocalRNG()]) do rng
-        #         return Any[
-        #             (true, :stability_and_allocs, nothing, randn, rng),
-        #             (true, :stability, nothing, randn, rng, 2),
-        #             (true, :stability, nothing, randn, rng, 3, 2),
-        #         ]
-        #     end,
-        # ),
+        reduce(
+            vcat,
+            map([Xoshiro(1), TaskLocalRNG()]) do rng
+                return Any[
+                    (true, :stability_and_allocs, nothing, randn, rng),
+                    (true, :stability, nothing, randn, rng, 2),
+                    (true, :stability, nothing, randn, rng, 3, 2),
+                ]
+            end,
+        ),
 
         # Rules to make string-related functionality work properly.
-        # (false, :stability, nothing, string, 'H'),
+        (false, :stability, nothing, string, 'H'),
         (false, :stability, nothing, Base.normpath, "/home/user/../folder/./file.txt"),
-        (false, :stability, nothing, Base._replace_init, "hello world", ("hello" => "hi",), 1),
+        (
+            false,
+            :stability,
+            nothing,
+            Base._replace_init,
+            "hello world",
+            ("hello" => "hi",),
+            1,
+        ),
 
         # Rules to make Symbol-related functionality work properly.
-        # (false, :stability_and_allocs, nothing, Symbol, "hello"),
-        # (false, :stability_and_allocs, nothing, Symbol, UInt8[1, 2]),
-        # (false, :stability_and_allocs, nothing, Float64, π, RoundDown),
-        # (false, :stability_and_allocs, nothing, Float64, π, RoundUp),
-        # (true, :stability_and_allocs, nothing, Float32, π, RoundDown),
-        # (true, :stability_and_allocs, nothing, Float32, π, RoundUp),
-        # (true, :stability_and_allocs, nothing, Float16, π, RoundDown),
-        # (true, :stability_and_allocs, nothing, Float16, π, RoundUp),
+        (false, :stability_and_allocs, nothing, Symbol, "hello"),
+        (false, :stability_and_allocs, nothing, Symbol, UInt8[1, 2]),
+        (false, :stability_and_allocs, nothing, Float64, π, RoundDown),
+        (false, :stability_and_allocs, nothing, Float64, π, RoundUp),
+        (true, :stability_and_allocs, nothing, Float32, π, RoundDown),
+        (true, :stability_and_allocs, nothing, Float32, π, RoundUp),
+        (true, :stability_and_allocs, nothing, Float16, π, RoundDown),
+        (true, :stability_and_allocs, nothing, Float16, π, RoundUp),
     )
     memory = Any[_x, _dx]
     return test_cases, memory
@@ -197,10 +211,10 @@ function generate_derived_rrule!!_test_cases(
     test_cases = vcat(
         Any[
             # Tests for Base.CoreLogging @logmsg macros
-            (false, :stability, nothing, testloggingmacro1, rand(1:100)),
-            (false, :stability, nothing, testloggingmacro2, rand(1:100)),
-            (false, :stability, nothing, testloggingmacro3, rand(1:100)),
-            (false, :stability, nothing, testloggingmacro4, rand(1:100)),
+            (false, :none, nothing, testloggingmacro1, rand(1:100)),
+            (false, :none, nothing, testloggingmacro2, rand(1:100)),
+            (false, :none, nothing, testloggingmacro3, rand(1:100)),
+            (false, :none, nothing, testloggingmacro4, rand(1:100)),
         ],
     )
     return test_cases, Any[]


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I still need to add tests, but you can verify the usage by running code in issue #657 . @yebai @ChrisRackauckas suggestions on code are welcome.

I've added comments for the LLVM call error above the rule for the same (handle thread safe counters/reads) , the rules following it are specific to Base.CoreLogging's functions that use logstate etc. (specifically when logging selection does NOT affect numerical solver data, handles observation side effects like   @info etc), a few string manipulation Base functions (string operations).

```
julia> using Mooncake, OrdinaryDiffEq, StaticArrays
       function lorenz!(du, u, p, t)
           du[1] = 10.0(u[2] - u[1])
           du[2] = u[1] * (28.0 - u[3]) - u[2]
           du[3] = u[1] * u[2] - (8 / 3) * u[3]
       end

       const _saveat = SA[0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0]

       function f(u0::Array{Float64})
           tspan = (0.0, 3.0)
           prob = ODEProblem{true,SciMLBase.FullSpecialize}(lorenz!, u0, tspan)
           sol = DiffEqBase.solve(prob, Tsit5(), saveat=_saveat, sensealg=DiffEqBase.SensitivityADPassThrough())
           sum(sol)
       end;

       rule = Mooncake.build_rrule(f, u0)
       mooncake_gradient(f, x) = Mooncake.value_and_gradient!!(rule, f, x)[2][2]
       mooncake_gradient(f, u0)
3-element Vector{Float64}:
     2.1072998565112364
   -31.089921681997474
 -1329.570875130246

julia> 
```

Fix https://github.com/chalk-lab/Mooncake.jl/issues/657 
Also covers/closes  #310 .