### PR TITLE
Fix Flaky Test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.144"
+version = "0.4.145"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/misc.jl
+++ b/src/rrules/misc.jl
@@ -179,7 +179,6 @@ end
 end
 
 function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:misc})
-    return Any[], Any[]
 
     # Data which needs to not be GC'd.
     _x = Ref(5.0)

--- a/src/rrules/misc.jl
+++ b/src/rrules/misc.jl
@@ -179,6 +179,7 @@ end
 end
 
 function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:misc})
+    return Any[], Any[]
 
     # Data which needs to not be GC'd.
     _x = Ref(5.0)
@@ -344,7 +345,7 @@ end
 
 function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:misc})
     test_cases = Any[
-        (false, :none, nothing, copy, Dict("A" => 5.0, "B" => 5.0)),
+        (false, :none, nothing, x -> copy(Dict("A" => x[1], "B" => x[2]))["A"], (5.0, 5.0)),
         (false, :none, nothing, copy, Dict{Any,Any}("A" => [5.0], [3.0] => 5.0)),
         (false, :none, nothing, () -> copy(Set())),
     ]


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Replaces a test which exposed non-determinism and NaNs to the correctness testing with something deterministic and NaN-free.

Specifically, consider the following:
```julia
julia> d = Dict("A" => 5, "B" => 4)
Dict{String, Int64} with 2 entries:
  "B" => 4
  "A" => 5

julia> d.vals
16-element Memory{Int64}:
 0
 4
 5
 0
 0
 0
 0
 0
 0
 0
 0
 0
 0
 0
 0
 0

julia> deepcopy(d).vals
16-element Memory{Int64}:
 7306086968413740901
                   4
                   5
 6878243912707629428
 8391698316570687860
 2985727426109923937
 8891632269573496876
 8243122710530505597
 7017574069261122928
 7592915475641558379
 8387235708328572014
 8101729628703978085
 8457590201654274420
 7814627425625142382
 2964045190168474735
          4906546432
```
That is, when `deepcopy`ing a `Dict`, Julia (correctly) considers it safe not to worry about any data which isn't meant to be exposed to users, and the values you wind up with are a result of whatever bits happened to be lying around in the memory before it was allocated. This can cause us trouble in Mooncake, because we treat a `Dict` like any other `struct` and directly access all of its fields. The NaNs that we see in test failures are (I believe) caused by the same kind of issue. The same set of considerations apply other fields of the `Dict`.

The new test avoids exposing any of the internals of the `Dict` in question to the user, by constructing + copying + getting data from it inside the test case.

Observe that this isn't an issue with the other two test cases (directly below the changes one) because they contain non bits types. The eg. `vals` field therefore looks something like this:
```julia
julia> Dict{Any,Any}("A" => 5, "B" => 4).vals
16-element Memory{Any}:
 #undef
   4
   5
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
```
All the elements of `vals` in this case are always `#undef` (similar-ish to a null pointer, but more friendly), and we handle `#undef` values just fine in Mooncake.

To verify that this has indeed solved the problem, I ran the relevant subset of the test suite 1000 times in a loop. Before this change, this caused occassional problems. Afterwards, I see no failures.