### PR TITLE
Extend arrayify for complex numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.150"
+version = "0.4.151"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1746,7 +1746,7 @@ DynamicDerivedRule(debug_mode::Bool) = DynamicDerivedRule(Dict{Any,Any}(), debug
 _copy(x::P) where {P<:DynamicDerivedRule} = P(Dict{Any,Any}(), x.debug_mode)
 
 function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
-    sig = Tuple{map(_typeof ∘ primal, args)...}
+    sig = Tuple{map(typeof ∘ primal, args)...}
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
         interp = get_interpreter(ReverseMode)

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1746,7 +1746,7 @@ DynamicDerivedRule(debug_mode::Bool) = DynamicDerivedRule(Dict{Any,Any}(), debug
 _copy(x::P) where {P<:DynamicDerivedRule} = P(Dict{Any,Any}(), x.debug_mode)
 
 function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
-    sig = Tuple{map(typeof ∘ primal, args)...}
+    sig = Tuple{map(Base._stable_typeof ∘ primal, args)...}
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
         interp = get_interpreter(ReverseMode)

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -35,13 +35,13 @@ arrayify(x::Array{P}, dx::Array{P}) where {P<:BlasRealFloat} = (x, dx)
 function arrayify(x::Array{P}, dx::Array{<:Tangent}) where {P<:BlasComplexFloat}
     return x, reinterpret(P, dx)
 end
-function arrayify(x::A, dx::TangentOrFData) where {A<:SubArray{<:BlasRealFloat}}
+function arrayify(x::SubArray{P,B,C,D,E}, dx::TangentOrFData) where {P<:BlasFloat,B,C,D,E}
     _, _dx = arrayify(x.parent, _fields(dx).parent)
-    return x, A(_dx, x.indices, x.offset1, x.stride1)
+    return x, SubArray{P, B, typeof(_dx), D, E}(_dx, x.indices, x.offset1, x.stride1)
 end
-function arrayify(x::A, dx::TangentOrFData) where {A<:Base.ReshapedArray{<:BlasRealFloat}}
+function arrayify(x::Base.ReshapedArray{P,B,C,D}, dx::TangentOrFData) where {P<:BlasFloat,B,C,D}
     _, _dx = arrayify(x.parent, _fields(dx).parent)
-    return x, A(_dx, x.dims, x.mi)
+    return x, Base.ReshapedArray{P,B,typeof(_dx),D}(_dx, x.dims, x.mi)
 end
 function arrayify(x::Base.ReinterpretArray{T}, dx::TangentOrFData) where {T<:BlasFloat}
     _, _dx = arrayify(x.parent, _fields(dx).parent)

--- a/test/rrules/blas.jl
+++ b/test/rrules/blas.jl
@@ -1,4 +1,32 @@
 @testset "blas" begin
-    @test_throws "Encountered unexpected array type" Mooncake.arrayify(5, 4)
-    TestUtils.run_rule_test_cases(StableRNG, Val(:blas))
+
+    # Problems with arrayify tend to get picked up by tests for rules which use arrayify.
+    # However, such problems can be quite tricky to diagnose from these failures alone, so
+    # it is worth unit testing some properties (eg. aliasing).
+    @testset "arrayify" begin
+
+        # Verify that an unexpected type throws a sensible error.
+        @test_throws "Encountered unexpected array type" Mooncake.arrayify(5, 4)
+
+        # Verify all test cases can be array-ified.
+        @testset "$P" for P in [Float32, Float64, ComplexF32, ComplexF64]
+            xs = Mooncake.blas_matrices(StableRNG(123), P, 2, 3)
+            @testset "$(typeof(x)), $f" for x in xs, f in [identity, fdata]
+                t = f(Mooncake.randn_tangent(StableRNG(123), x))
+                _x, _t = Mooncake.arrayify(Mooncake.CoDual(x, t))
+
+                # The primal should be the same thing.
+                @test _x === x
+
+                # The data underlying the tangent / fdata returned from arrayify must alias
+                # the original. To check that this happens, we check that if we run arrayify a
+                # second time on the same input, and mutate the tangent, the values in `_t`
+                # are modified in exactly the same way.
+                _, _t2 = Mooncake.arrayify(Mooncake.CoDual(x, t))
+                _t2 .= zero(P)
+                @test _t == _t2
+            end
+        end
+    end
+    # TestUtils.run_rule_test_cases(StableRNG, Val(:blas))
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Extends arrayify to handle `ComplexF32` and `ComplexF64` element types. There was a subtle aliasing bug that the current implementation contained when extended to these types, so I've added tests which iterate over all of the array types that we test on.

This should address https://github.com/chalk-lab/Mooncake.jl/pull/664 .