### PR TITLE
Tidy up 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.152"
+version = "0.4.153"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -259,11 +259,7 @@ function fdata(t::T) where {T}
 end
 
 function fdata(::Type{T}) where {T}
-    throw(
-        error(
-            "$T is a type. Perhaps you meant fdata_type($T) or fdata(instance_of_tangent)?"
-        ),
-    )
+    error("$T is a type. Perhaps you meant fdata_type($T) or fdata(instance_of_tangent)?")
 end
 
 function fdata(t::T) where {T<:PossiblyUninitTangent}
@@ -539,11 +535,7 @@ function rdata(t::T) where {T}
 end
 
 function rdata(::Type{T}) where {T}
-    throw(
-        error(
-            "$T is a type. Perhaps you meant rdata_type($T) or rdata(instance_of_tangent)?"
-        ),
-    )
+    error("$T is a type. Perhaps you meant rdata_type($T) or rdata(instance_of_tangent)?")
 end
 
 function rdata(t::T) where {T<:PossiblyUninitTangent}

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -182,16 +182,5 @@ end
         @test_throws "Vector{Float64} is a type. Perhaps you meant rdata_type(Vector{Float64}) or rdata(instance_of_tangent)?" rdata(
             Vector{Float64}
         )
-
-        # Verify that existing functionality with instances still works
-        x = 5.0
-        t = zero_tangent(x)
-        @test fdata(t) isa NoFData
-        @test rdata(t) isa Float64
-
-        arr = [1.0, 2.0]
-        t_arr = zero_tangent(arr)
-        @test fdata(t_arr) isa Vector{Float64}
-        @test rdata(t_arr) isa NoRData
     end
 end

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -158,29 +158,8 @@ end
         end
     end
 
-    @testset "Error messages for types passed to accessor functions" begin
-        # Test that passing types to fdata throws helpful error message
-        @test_throws "Float64 is a type. Perhaps you meant fdata_type(Float64) or fdata(instance_of_tangent)?" fdata(
-            Float64
-        )
-        @test_throws "Int64 is a type. Perhaps you meant fdata_type(Int64) or fdata(instance_of_tangent)?" fdata(
-            Int64
-        )
-
-        # Test that passing types to rdata throws helpful error message  
-        @test_throws "Float64 is a type. Perhaps you meant rdata_type(Float64) or rdata(instance_of_tangent)?" rdata(
-            Float64
-        )
-        @test_throws "Int64 is a type. Perhaps you meant rdata_type(Int64) or rdata(instance_of_tangent)?" rdata(
-            Int64
-        )
-
-        # Test with more complex types - using exact string matching since the message is deterministic
-        @test_throws "Vector{Float64} is a type. Perhaps you meant fdata_type(Vector{Float64}) or fdata(instance_of_tangent)?" fdata(
-            Vector{Float64}
-        )
-        @test_throws "Vector{Float64} is a type. Perhaps you meant rdata_type(Vector{Float64}) or rdata(instance_of_tangent)?" rdata(
-            Vector{Float64}
-        )
+    @testset "Helpful error messages for misuse of fdata and rdata" begin
+        @test_throws "Float64 is a type. Perhaps you meant" fdata(Float64)
+        @test_throws "Float64 is a type. Perhaps you meant" rdata(Float64)
     end
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Copilot didn't to the best job in #710 , so I've tidied up a bit. Specificially:
- `error(...)` throws, so you don't need to write `throw(error(...))`
- I've bumped the patch version so we can make a release
- Copilot wrote a bunch of redundant tests. It's enough to check that we hit the errors and roughly the string that we expected is produced when an error occurs. Since the implementation is so simple, there's really no reason to test multiple types etc.