### PR TITLE
tangent types and docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.156"
+version = "0.4.157"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -44,7 +44,7 @@ Observe that while it has correctly computed the identity function, the gradient
 The takehome: do not attempt to differentiate functions which modify global state. Uses of globals which does not involve mutating them is fine though.
 
 
-## Passing Differetiable Data as a Type
+## Passing Differentiable Data as a Type
 
 Credit goes to Guillaume Dalle for noticing this limitation.
 

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -43,12 +43,10 @@ Observe that while it has correctly computed the identity function, the gradient
 
 The takehome: do not attempt to differentiate functions which modify global state. Uses of globals which does not involve mutating them is fine though.
 
-## Circular References
+## Circular References in Type Declarations
 
-To a large extent, Mooncake.jl does not presently support circular references in an automatic fashion.
-It is generally possible to hand-write solutions, so we explain some of the problems here, and the general approach to resolving them.
-
-### Tangent Types
+Mooncake.jl's default `tangent_type` implementation cannot support types which refer to themselves either directly or indirectly in their definition.
+Below is an example in which a type refers to iself directly in its definition.
 
 _**The Problem**_
 
@@ -88,35 +86,6 @@ end
 The point here is that you can manually resolve the circular dependency using a data structure which mimics the primal type.
 You will, however, need to implement similar methods for `zero_tangent`, `randn_tangent`, etc, and presumably need to implement additional `getfield` and `setfield` rules which are specific to this type.
 An example implementation of this is provided [here](developer_documentation/custom_tangent_type.md).
-
-### Circular References in General
-
-_**The Problem**_
-
-Consider a type of the form
-```julia
-mutable struct Foo
-    x
-    Foo() = new()
-end
-```
-In this instance, `tangent_type` will work fine because `Foo` does not directly reference itself in its definition.
-Moreover, general uses of `Foo` will be fine.
-
-However, it's possible to construct an instance of `Foo` with a circular reference:
-```julia
-f = Foo()
-f.x = f
-```
-This is actually fine provided we never attempt to call `zero_tangent` / `randn_tangent` / similar functionality on `f` once we've set its `x` field to itself.
-If we attempt to call such a function, we'll find ourselves with a stack overflow.
-
-_**The Solution**_
-This is a little tricker to handle.
-You could specialise `zero_tangent` etc for `Foo`, but this is something of a pain.
-Fortunately, it seems to be incredibly rare that this is ever a problem in practice.
-If we gain evidence that this _is_ often a problem in practice, we'll look into supporting `zero_tangent` etc automatically for this case.
-
 
 ## Tangent Generation and Pointers
 

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -372,6 +372,10 @@ tangent_type(::Type{<:IOStream}) = NoTangent
 
 tangent_type(::Type{<:Base.CoreLogging.AbstractLogger}) = NoTangent
 
+tangent_type(::Type{Core.CodeInstance}) = NoTangent
+
+tangent_type(::Type{Core.MethodInstance}) = NoTangent
+
 function split_union_tuple_type(tangent_types)
 
     # Create first split.

--- a/test/tangents.jl
+++ b/test/tangents.jl
@@ -5,6 +5,8 @@
         (Cstring, NoTangent),
         (Cwstring, NoTangent),
         (Union{}, Union{}),
+        (Core.CodeInstance, NoTangent),
+        (Core.MethodInstance, NoTangent),
 
         ## Tuples
 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
This PR
- declares `Core.MethodInstance` and `Core.CodeInstance` to be non-differentiable types
- removes a section of the docs which was outdated (a problem resolved a while ago!)
- adds a new example to the docs
- bumps the patch version