### PR TITLE
Relax some blas dispatches to `AbstractVecOrMat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.170"
+version = "0.4.171"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -1237,11 +1237,11 @@ function positive_definite_blas_matrices(rng::AbstractRNG, P::Type{<:BlasFloat},
     end
 end
 
-function blas_vectors(rng::AbstractRNG, P::Type{<:BlasFloat}, p::Int)
+function blas_vectors(rng::AbstractRNG, P::Type{<:BlasFloat}, p::Int; only_contiguous=false)
     xs = Any[
         randn(rng, P, p),
         view(randn(rng, P, p + 5), 3:(p + 2)),
-        view(randn(rng, P, 3p, 3), 1:2:(2p), 2),
+        (only_contiguous ? copy : identity)(view(randn(rng, P, 3p, 3), 1:2:(2p), 2)),
         reshape(view(randn(rng, P, 1, p + 5), 1:1, 1:p), p),
     ]
     @assert all(x -> length(x) == p, xs)

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -1292,7 +1292,7 @@ function blas_vectors(rng::AbstractRNG, P::Type{<:BlasFloat}, p::Int; only_conti
     xs = Any[
         randn(rng, P, p),
         view(randn(rng, P, p + 5), 3:(p + 2)),
-        (only_contiguous ? copy : identity)(view(randn(rng, P, 3p, 3), 1:2:(2p), 2)),
+        (only_contiguous ? collect : identity)(view(randn(rng, P, 3p, 3), 1:2:(2p), 2)),
         reshape(view(randn(rng, P, 1, p + 5), 1:1, 1:p), p),
     ]
     @assert all(x -> length(x) == p, xs)

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -1288,9 +1288,12 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:blas})
         ) do (tA, M, N, P, α, β)
             P <: BlasRealFloat && (imag(α) > 0 || imag(β) > 0) && return []
 
-            As = blas_matrices(rng, P, tA == 'N' ? M : N, tA == 'N' ? N : M)
-            xs = blas_vectors(rng, P, N)
-            ys = blas_vectors(rng, P, M)
+            As = [
+                blas_matrices(rng, P, tA == 'N' ? M : N, tA == 'N' ? N : M)
+                blas_vectors(rng, P, M; only_contiguous=true)
+            ]
+            xs = [blas_vectors(rng, P, N); blas_vectors(rng, P, tA == 'N' ? 1 : M)]
+            ys = [blas_vectors(rng, P, M); blas_vectors(rng, P, tA == 'N' ? M : 1)]
             flags = (false, :stability, (lb=1e-3, ub=10.0))
             return map(As, xs, ys) do A, x, y
                 (flags..., BLAS.gemv!, tA, P(α), A, x, P(β), y)


### PR DESCRIPTION
Tries to fix #622, and perhaps [#1392.](https://github.com/LuxDL/Lux.jl/issues/1392).
We check [blas.jl from LinearAlgebra](https://github.com/JuliaLang/LinearAlgebra.jl/blob/2c3fe9b7e0ca4e2c7bf506bd16ae5900f04a8023/src/blas.jl#LL1633C1-L1637C51) to check which of the operations and parameters need `AbstractVecOrMat`:


``` julia
$ rg -B8 AbstractVecOrMat LinearAlgebra/src/blas.jl | rg "function"
        function gemv!(trans::AbstractChar, alpha::Union{($elty), Bool},
        function gemmt!(uplo::AbstractChar, transA::AbstractChar, transB::AbstractChar,
        function gemm!(transA::AbstractChar, transB::AbstractChar,
        function syrk!(uplo::AbstractChar, trans::AbstractChar,
function syrk(uplo::AbstractChar, trans::AbstractChar, alpha::Number, A::AbstractVecOrMat)
        function herk!(uplo::AbstractChar, trans::AbstractChar,
        function herk(uplo::AbstractChar, trans::AbstractChar, α::$relty, A::AbstractVecOrMat{$elty})
        function syr2k!(uplo::AbstractChar, trans::AbstractChar,
function syr2k(uplo::AbstractChar, trans::AbstractChar, alpha::Number, A::AbstractVecOrMat, B::AbstractVecOrMat)
        function her2k!(uplo::AbstractChar, trans::AbstractChar, alpha::($elty1),
        function her2k(uplo::AbstractChar, trans::AbstractChar, alpha::($elty1), A::AbstractVecOrMat{$elty1}, B::AbstractVecOrMat{$elty1})
```
We can also check which of these are implemented in Mooncake:

``` bash
$ rg "BLAS\.((gemv)|(gemmt)|(gemm)|(syrk)|(herk)|(syr2k)|(her2k))" Mooncake/src/rrules/blas.jl -o | uniq 
BLAS.gemv
BLAS.gemm
BLAS.syrk
BLAS.syr2k
BLAS.syrk
BLAS.gemv
BLAS.gemm
BLAS.syrk
BLAS.gemm
```

| Function | taken care of |
|:---------|:--------------|
| `gemv`   | ✔️             |
| `gemm`   |             |
| `syrk`   |             |