### PR TITLE
Revise documentation for internal `_copy` utility

### DIFF
--- a/docs/src/utilities/debug_mode.md
+++ b/docs/src/utilities/debug_mode.md
@@ -45,7 +45,7 @@ Mooncake.build_rrule
 When using ADTypes.jl, you can choose whether or not to use it via the `debug_mode` kwarg:
 ```jldoctest
 julia> AutoMooncake(; config=Mooncake.Config(; debug_mode=true))
-AutoMooncake{Mooncake.Config}(Mooncake.Config(true, false))
+AutoMooncake(config=Mooncake.Config(true, false))
 ```
 
 ### When Should You Use Debug Mode?

--- a/src/codual.jl
+++ b/src/codual.jl
@@ -15,7 +15,7 @@ end
 primal(x::CoDual) = x.x
 tangent(x::CoDual) = x.dx
 Base.copy(x::CoDual) = CoDual(copy(primal(x)), copy(tangent(x)))
-# CoDual is immutable and can be safely shared without copying
+# CoDual can be safely shared without copying
 _copy(x::P) where {P<:CoDual} = x
 
 """

--- a/src/dual.jl
+++ b/src/dual.jl
@@ -15,7 +15,7 @@ end
 primal(x::Dual) = x.primal
 tangent(x::Dual) = x.tangent
 Base.copy(x::Dual) = Dual(copy(primal(x)), copy(tangent(x)))
-# Dual is immutable and can be safely shared without copying
+# Dual can be safely shared without copying
 _copy(x::P) where {P<:Dual} = x
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -429,14 +429,17 @@ end
 
 Utility for copying AD-related data structures (e.g. rules, caches, and other internals).
 
-# Semantics
+# Examples of current behaviour
 
-`_copy` specifies how different types are duplicated within the AD system:
+Currently, `_copy` has the following behaviours for specific types:
 
-- Immutable AD types (e.g. `CoDual`, `Dual`) → usually return the same object
-- Mutable containers → new instances with copied contents
-- Composite types → recursively applies `_copy` to fields
-- Other types → falls back to `Base.copy`
+- `CoDual`, `Dual` types → no copying needed  
+- `Stack` types → create a new empty instance  
+- Composite types (e.g. `Tuple`) → recursively copy elements  
+- Rule types (e.g. `DerivedRule`) → construct new instances with copied captures and caches  
+- Misty closure reverse data → construct a new Misty closure with deep copy of captured data  
+- Tangent types (`PossiblyUninitTangent`) → copy conditionally based on initialisation state  
+- Forward/reverse data types (i.e., `FData`, `RData`) → recursively copy wrapped data  
 """
 
 # Generic fallback that works with any type

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -422,71 +422,29 @@ end
 """
     _copy(x)
 
-*Note:* this is not part of the public Mooncake.jl interface, and may change without warning.
+!!! warning
+    This is an internal utility, not part of the public `Mooncake.jl` API, and may change
+    without notice. Its behaviour can vary across data types, so the description below
+    should be treated as guidance, not a strict contract.
 
-Internal protocol for creating copies of AD-related data structures. This function is used 
-throughout the automatic differentiation system to create appropriate copies of rules, 
-caches, and other internal data structures when building new AD contexts.
+Utility for copying AD-related data structures (e.g. rules, caches, and other internals).
 
 # Semantics
 
-The `_copy` protocol defines how different types should be copied within the AD system:
+`_copy` specifies how different types are duplicated within the AD system:
 
-- For immutable AD types (like `CoDual`, `Dual`), typically returns the same object
-- For mutable containers, creates new instances with copied contents
-- For composite types, recursively applies `_copy` to fields
-- Falls back to `Base.copy` for general types
-
-# Implementation Requirements
-
-When implementing `_copy` for a new type, consider:
-- Whether the type represents mutable state that needs actual copying
-- Whether fields should be recursively copied or can be shared
-- Performance implications of copying vs. sharing immutable data
-
-# Examples
-
-```julia
-# For immutable AD types - no copying needed
-_copy(x::CoDual) = x
-
-# For `Stack` type - create new empty instance
-_copy(::Stack{T}) where {T} = Stack{T}()
-
-# For composite types - recursive copying
-_copy(x::Tuple) = map(_copy, x)
-
-# For rule types - create new instances with appropriately copied captures/caches
-function _copy(x::DerivedRule)
-    new_captures = _copy(x.fwds_oc.oc.captures)
-    new_fwds_oc = replace_captures(x.fwds_oc, new_captures)
-    new_pb_oc_ref = Ref(replace_captures(x.pb_oc_ref[], new_captures))
-    return typeof(x)(new_fwds_oc, new_pb_oc_ref, x.nargs)
-end
-
-# For misty closure reverse data - deep copy the captures data
-_copy(r::MistyClosureRData) = MistyClosureRData(deepcopy(r.captures_rdata))
-
-# For tangent types - copy conditionally based on initialization state
-_copy(x::PossiblyUninitTangent) = is_init(x) ? typeof(x)(_copy(x.tangent)) : typeof(x)()
-
-# For forwards/reverse data types - recursively copy wrapped data
-_copy(x::FData) = typeof(x)(_copy(x.data))
-_copy(x::RData) = typeof(x)(_copy(x.data))
-_copy(x::LazyZeroRData) = typeof(x)(_copy(x.data))
-
-# Fallback to Base.copy
-_copy(x) = copy(x)
-```
+- Immutable AD types (e.g. `CoDual`, `Dual`) → usually return the same object
+- Mutable containers → new instances with copied contents
+- Composite types → recursively applies `_copy` to fields
+- Other types → falls back to `Base.copy`
 """
 
-# Generic implementations that work with any type
+# Generic fallback that works with any type
+_copy(x) = copy(x)
+
 _copy(::Nothing) = nothing
 _copy(x::Symbol) = x
 _copy(x::Tuple) = map(_copy, x)
 _copy(x::NamedTuple) = map(_copy, x)
 _copy(x::Ref{T}) where {T} = isassigned(x) ? Ref{T}(_copy(x[])) : Ref{T}()
 _copy(x::Type) = x
-
-# Fallback to Base.copy for all other types
-_copy(x) = copy(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -445,7 +445,7 @@ Currently, `_copy` has the following behaviours for specific types:
 - `DynamicFRule`, `DynamicDerivedRule` → construct new dynamic rules with an empty cache and the same debug mode  
 """
 
-# Generic fallback that works with any type
+# Generic fallback to Base.copy
 _copy(x) = copy(x)
 
 _copy(::Nothing) = nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -435,8 +435,8 @@ Currently, `_copy` has the following behaviours for specific types:
 
 - `CoDual`, `Dual` types → no copying needed  
 - `Stack` types → create a new empty instance  
-- Composite types (e.g. `Tuple`) → recursively copy elements  
-- Misty closure reverse data → construct a new Misty closure with deep copy of captured data  
+- Composite types (e.g. `Tuple`, `NamedTuple`) → recursively copy elements  
+- Misty closure → construct a new Misty closure with deep copy of captured data  
 - Tangent types (`PossiblyUninitTangent`) → copy conditionally based on initialisation state  
 - Forward/reverse data types (e.g. `FData`, `RData`, `LazyZeroRData`) → recursively copy wrapped data  
 - `RRuleZeroWrapper` → recursively copy the wrapped rule into a new instance

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -439,7 +439,10 @@ Currently, `_copy` has the following behaviours for specific types:
 - Rule types (e.g. `DerivedRule`) → construct new instances with copied captures and caches  
 - Misty closure reverse data → construct a new Misty closure with deep copy of captured data  
 - Tangent types (`PossiblyUninitTangent`) → copy conditionally based on initialisation state  
-- Forward/reverse data types (i.e., `FData`, `RData`) → recursively copy wrapped data  
+- Forward/reverse data types (e.g. `FData`, `RData`, `LazyZeroRData`) → recursively copy wrapped data  
+- `RRuleZeroWrapper` → recursively copy the wrapped rule into a new instance  
+- `LazyFRule`, `LazyDerivedRule` → construct new lazy rules with the same method instance and debug mode  
+- `DynamicFRule`, `DynamicDerivedRule` → construct new dynamic rules with an empty cache and the same debug mode  
 """
 
 # Generic fallback that works with any type

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -436,11 +436,11 @@ Currently, `_copy` has the following behaviours for specific types:
 - `CoDual`, `Dual` types → no copying needed  
 - `Stack` types → create a new empty instance  
 - Composite types (e.g. `Tuple`) → recursively copy elements  
-- Rule types (e.g. `DerivedRule`) → construct new instances with copied captures and caches  
 - Misty closure reverse data → construct a new Misty closure with deep copy of captured data  
 - Tangent types (`PossiblyUninitTangent`) → copy conditionally based on initialisation state  
 - Forward/reverse data types (e.g. `FData`, `RData`, `LazyZeroRData`) → recursively copy wrapped data  
-- `RRuleZeroWrapper` → recursively copy the wrapped rule into a new instance  
+- `RRuleZeroWrapper` → recursively copy the wrapped rule into a new instance
+- `DerivedRule` → construct new instances with copied captures and caches  
 - `LazyFRule`, `LazyDerivedRule` → construct new lazy rules with the same method instance and debug mode  
 - `DynamicFRule`, `DynamicDerivedRule` → construct new dynamic rules with an empty cache and the same debug mode  
 """


### PR DESCRIPTION
The PR cleans up docs on `_copy` and adds an overview of `_copy`'s current behaviour for different types

Replacing and closes https://github.com/chalk-lab/Mooncake.jl/pull/760
