### PR TITLE
Fix Formatter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.162"
+version = "0.4.163"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/lapack.jl
+++ b/src/rrules/lapack.jl
@@ -393,9 +393,7 @@ function frule!!(
     return Dual((A, info), (tangent(A_dA), NoTangent()))
 end
 function rrule!!(
-    ::CoDual{typeof(potrf!)},
-    _uplo::CoDual{Char},
-    _A::CoDual{<:AbstractMatrix{P}},
+    ::CoDual{typeof(potrf!)}, _uplo::CoDual{Char}, _A::CoDual{<:AbstractMatrix{P}}
 ) where {P<:BlasRealFloat}
 
     # Extract args and take a copy of A.

--- a/src/rrules/low_level_maths.jl
+++ b/src/rrules/low_level_maths.jl
@@ -108,12 +108,16 @@ function rrule!!(::CoDual{typeof(hypot)}, x::CoDual{P}, y::CoDual{P}) where {P<:
 end
 
 @is_primitive MinimalCtx Tuple{typeof(hypot),P,P,Vararg{P}} where {P<:IEEEFloat}
-function frule!!(::Dual{typeof(hypot)}, x::Dual{P}, y::Dual{P}, xs::Vararg{Dual{P}, N}) where {P<:IEEEFloat, N}
+function frule!!(
+    ::Dual{typeof(hypot)}, x::Dual{P}, y::Dual{P}, xs::Vararg{Dual{P},N}
+) where {P<:IEEEFloat,N}
     h = hypot(primal(x), primal(y), map(primal, xs)...)
     dh = sum(primal(a) * tangent(a) for a in (x, y, xs...)) / h
     return Dual(h, dh)
 end
-function rrule!!(::CoDual{typeof(hypot)}, x::CoDual{P}, y::CoDual{P}, xs::Vararg{CoDual{P}, N}) where {P<:IEEEFloat, N}
+function rrule!!(
+    ::CoDual{typeof(hypot)}, x::CoDual{P}, y::CoDual{P}, xs::Vararg{CoDual{P},N}
+) where {P<:IEEEFloat,N}
     h = hypot(primal(x), primal(y), map(primal, xs)...)
     function hypot_pb!!(dh::P)
         grads = map(a -> dh * (primal(a) / h), (x, y, xs...))

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -505,7 +505,9 @@ function test_frule_correctness(rng::AbstractRNG, x_ẋ...; frule, unsafe_pertur
 end
 
 # Assumes that the interface has been tested, and we can simply check for numerical issues.
-function test_rrule_correctness(rng::AbstractRNG, x_x̄...; rrule, unsafe_perturb::Bool, output_tangent=nothing)
+function test_rrule_correctness(
+    rng::AbstractRNG, x_x̄...; rrule, unsafe_perturb::Bool, output_tangent=nothing
+)
     @nospecialize rng x_x̄
 
     x_x̄ = map(_deepcopy, x_x̄) # defensive copy
@@ -560,7 +562,8 @@ function test_rrule_correctness(rng::AbstractRNG, x_x̄...; rrule, unsafe_pertur
     @test address_maps_are_consistent(inputs_address_map, outputs_address_map)
 
     # Run reverse-pass.
-    ȳ_delta = isnothing(output_tangent) ? randn_tangent(rng, primal(y_ȳ_rule)) : output_tangent
+    ȳ_delta =
+        isnothing(output_tangent) ? randn_tangent(rng, primal(y_ȳ_rule)) : output_tangent
     x̄_delta = map(Base.Fix1(randn_tangent, rng) ∘ primal, x_x̄_rule)
 
     ȳ_init = set_to_zero!!(zero_tangent(primal(y_ȳ_rule), tangent(y_ȳ_rule)))

--- a/test/integration_testing/format/format.jl
+++ b/test/integration_testing/format/format.jl
@@ -11,6 +11,6 @@ Pkg.instantiate()
 using JuliaFormatter
 
 @testset "quality" begin
-    path = joinpath(@__DIR__, "..", "..")
+    path = joinpath(@__DIR__, "..", "..", "..")
     @test JuliaFormatter.format(path; verbose=false, overwrite=false)
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I messed up the formatter in https://github.com/chalk-lab/Mooncake.jl/pull/770 -- it was pointing to the `test` folder only, rather than the entire package. As a result, a couple of recent PRs were merged without proper formatting.

This PR
1. fixes the formatter, making sure that it checks code in all directories in the package
2. fixes formatting of PRs that were merged while the formatter was not doing the right thing
3. bumps the patch version so that we can merge the updated code.