### PR TITLE
Add output_tangent to kwargs list

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.165"
+version = "0.4.166"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -827,6 +827,7 @@ __get_primals(xs) = map(x -> x isa Union{Dual,CoDual} ? primal(x) : x, xs)
         debug_mode::Bool=false,
         unsafe_perturb::Bool=false,
         print_results=true,
+        output_tangent=nothing,
     )
 
 Run standardised tests on the `rule` for `x`.


### PR DESCRIPTION
Missed this when I added the option
