### PR TITLE
Some Housekeeping

### DIFF
--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -22,8 +22,8 @@ using AbstractGPs,
 using Mooncake:
     Dual,
     CoDual,
-    generate_hand_written_rrule!!_test_cases,
-    generate_derived_rrule!!_test_cases,
+    hand_written_rule_test_cases,
+    derived_rule_test_cases,
     TestUtils,
     _typeof,
     primal,
@@ -320,7 +320,7 @@ function benchmark_hand_written_rrules!!(rng_ctor)
         :misc,
         :new,
     ]) do s
-        test_cases, memory = generate_hand_written_rrule!!_test_cases(rng_ctor, Val(s))
+        test_cases, memory = hand_written_rule_test_cases(rng_ctor, Val(s))
         ranges = map(x -> x[3], test_cases)
         tags = fill(nothing, length(test_cases))
         return map(x -> x[4:end], test_cases), memory, ranges, tags
@@ -330,7 +330,7 @@ end
 
 function benchmark_derived_rrules!!(rng_ctor)
     test_case_data = map([:test_resources]) do s
-        test_cases, memory = generate_derived_rrule!!_test_cases(rng_ctor, Val(s))
+        test_cases, memory = derived_rule_test_cases(rng_ctor, Val(s))
         ranges = map(x -> x[3], test_cases)
         tags = fill(nothing, length(test_cases))
         return map(x -> x[4:end], test_cases), memory, ranges, tags

--- a/docs/src/developer_documentation/developer_tools.md
+++ b/docs/src/developer_documentation/developer_tools.md
@@ -8,6 +8,7 @@ Since these provide access to internals, they do not follow the usual rules of s
 may change without notice!
 ```@docs; canonical=false
 Mooncake.primal_ir
+Mooncake.dual_ir
 Mooncake.fwd_ir
 Mooncake.rvs_ir
 ```

--- a/src/rrules/array_legacy.jl
+++ b/src/rrules/array_legacy.jl
@@ -505,7 +505,7 @@ function rrule!!(
     return a, fill!_pullback!!
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:array_legacy})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:array_legacy})
     _x = Ref(5.0)
     _dx = randn_tangent(Xoshiro(123456), _x)
 
@@ -649,7 +649,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:array_legacy}
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:array_legacy})
+function derived_rule_test_cases(rng_ctor, ::Val{:array_legacy})
     test_cases = Any[(
         false,
         :none,

--- a/src/rrules/avoiding_non_differentiable_code.jl
+++ b/src/rrules/avoiding_non_differentiable_code.jl
@@ -88,9 +88,7 @@ import Base.CoreLogging as CoreLogging
     }
 )
 
-function generate_hand_written_rrule!!_test_cases(
-    rng_ctor, ::Val{:avoiding_non_differentiable_code}
-)
+function hand_written_rule_test_cases(rng_ctor, ::Val{:avoiding_non_differentiable_code})
     _x = Ref(5.0)
     _dx = Ref(4.0)
     test_cases = vcat(
@@ -156,9 +154,7 @@ function generate_hand_written_rrule!!_test_cases(
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(
-    rng_ctor, ::Val{:avoiding_non_differentiable_code}
-)
+function derived_rule_test_cases(rng_ctor, ::Val{:avoiding_non_differentiable_code})
     function testloggingmacro1(x)
         @warn "Testing @warn macro"
     end

--- a/src/rrules/blas.jl
+++ b/src/rrules/blas.jl
@@ -1219,7 +1219,7 @@ function blas_vectors(rng::AbstractRNG, P::Type{<:BlasFloat}, p::Int)
     return xs
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:blas})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:blas})
     t_flags = ['N', 'T', 'C']
     αs = [1.0, -0.25]
     dαs = [0.0, 0.44]
@@ -1361,7 +1361,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:blas})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:blas})
+function derived_rule_test_cases(rng_ctor, ::Val{:blas})
     t_flags = ['N', 'T', 'C']
     aliased_gemm! = (tA, tB, a, b, A, C) -> BLAS.gemm!(tA, tB, a, A, A, b, C)
     Ps = [Float32, Float64]

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -943,7 +943,7 @@ end
 
 @zero_derivative MinimalCtx Tuple{typeof(typeof),Any}
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:builtins})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:builtins})
     _x = Ref(5.0) # data used in tests which aren't protected by GC.
     _dx = Ref(4.0)
     _a = Vector{Vector{Float64}}(undef, 3)
@@ -1248,7 +1248,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:builtins})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:builtins})
+function derived_rule_test_cases(rng_ctor, ::Val{:builtins})
     test_cases = Any[
         (false, :none, nothing, _apply_iterate_equivalent, Base.iterate, *, 5.0, 4.0),
         (false, :none, nothing, _apply_iterate_equivalent, Base.iterate, *, (5.0, 4.0)),

--- a/src/rrules/fastmath.jl
+++ b/src/rrules/fastmath.jl
@@ -52,7 +52,7 @@ end
 @is_primitive MinimalCtx Tuple{typeof(Base.log),Union{IEEEFloat,Int}}
 @zero_derivative MinimalCtx Tuple{typeof(log),Int}
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:fastmath})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:fastmath})
     test_cases = reduce(
         vcat,
         map([Float64, Float32]) do P
@@ -70,7 +70,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:fastmath})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:fastmath})
+function derived_rule_test_cases(rng_ctor, ::Val{:fastmath})
     test_cases = reduce(
         vcat,
         map([Float64, Float32]) do P

--- a/src/rrules/foreigncall.jl
+++ b/src/rrules/foreigncall.jl
@@ -339,7 +339,7 @@ for name in [
     end
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:foreigncall})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:foreigncall})
     _x = Ref(5.0)
     _dx = randn_tangent(Xoshiro(123456), _x)
 
@@ -400,7 +400,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:foreigncall})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:foreigncall})
+function derived_rule_test_cases(rng_ctor, ::Val{:foreigncall})
     _x = Ref(5.0)
 
     function unsafe_copyto_tester(x::Vector{T}, y::Vector{T}, n::Int) where {T}

--- a/src/rrules/iddict.jl
+++ b/src/rrules/iddict.jl
@@ -229,7 +229,7 @@ function rrule!!(f::CoDual{Type{IdDict{K,V}}}) where {K,V}
     return CoDual(IdDict{K,V}(), IdDict{K,tangent_type(V)}()), NoPullback(f)
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:iddict})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:iddict})
     test_cases = Any[
         (false, :stability, nothing, Base.rehash!, IdDict(true => 5.0, false => 4.0), 10),
         (false, :none, nothing, setindex!, IdDict(true => 5.0, false => 4.0), 3.0, false),
@@ -243,4 +243,4 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:iddict})
     return test_cases, memory
 end
 
-generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:iddict}) = Any[], Any[]
+derived_rule_test_cases(rng_ctor, ::Val{:iddict}) = Any[], Any[]

--- a/src/rrules/lapack.jl
+++ b/src/rrules/lapack.jl
@@ -528,7 +528,7 @@ function rrule!!(
     return _B, potrs_pb!!
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:lapack})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:lapack})
     rng = rng_ctor(123)
     Ps = [Float64, Float32]
     complexPs = [Float64, Float32, ComplexF64, ComplexF32]
@@ -608,7 +608,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:lapack})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:lapack})
+function derived_rule_test_cases(rng_ctor, ::Val{:lapack})
     rng = rng_ctor(123)
     complexPs = [Float64, Float32, ComplexF64, ComplexF32]
     getrf_wrapper!(x, check) = getrf!(x; check)

--- a/src/rrules/linear_algebra.jl
+++ b/src/rrules/linear_algebra.jl
@@ -23,7 +23,7 @@ function rrule!!(::CoDual{typeof(exp)}, X::CoDual{Matrix{P}}) where {P<:IEEEFloa
     return CoDual(Y, Ȳ), ExpPullback{P}(pb, Ȳ, X.dx)
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:linear_algebra})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:linear_algebra})
     rng = rng_ctor(123)
     Ps = [Float64, Float32]
     test_cases = vcat(
@@ -35,6 +35,4 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:linear_algebr
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:linear_algebra})
-    return Any[], Any[]
-end
+derived_rule_test_cases(rng_ctor, ::Val{:linear_algebra}) = Any[], Any[]

--- a/src/rrules/low_level_maths.jl
+++ b/src/rrules/low_level_maths.jl
@@ -150,7 +150,7 @@ function rrule!!(::CoDual{typeof(Base.eps)}, x::CoDual{P}) where {P<:IEEEFloat}
     return zero_fcodual(y), eps_pb!!
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:low_level_maths})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:low_level_maths})
     test_cases = vcat(
         map([Float32, Float64]) do P
             cases = [
@@ -224,4 +224,4 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:low_level_mat
     return test_cases, memory
 end
 
-generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:low_level_maths}) = Any[], Any[]
+derived_rule_test_cases(rng_ctor, ::Val{:low_level_maths}) = Any[], Any[]

--- a/src/rrules/memory.jl
+++ b/src/rrules/memory.jl
@@ -898,7 +898,7 @@ function generate_data_test_cases(rng_ctor, ::Val{:memory})
     return vcat(_mems()[1], _mem_refs()[1], [randn(2), Any[]])
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:memory})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:memory})
     rng = rng_ctor(123)
     mems, _ = _mems()
     mem_refs, sample_mem_ref_values = _mem_refs()
@@ -1058,7 +1058,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:memory})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:memory})
+function derived_rule_test_cases(rng_ctor, ::Val{:memory})
     rng = rng_ctor(123)
     x = Memory{Float64}(randn(rng, 10))
     test_cases = Any[

--- a/src/rrules/misc.jl
+++ b/src/rrules/misc.jl
@@ -223,7 +223,7 @@ end
     end
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:misc})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:misc})
 
     # Data which needs to not be GC'd.
     _x = Ref(5.0)
@@ -387,7 +387,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:misc})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:misc})
+function derived_rule_test_cases(rng_ctor, ::Val{:misc})
     test_cases = Any[
         (false, :none, nothing, x -> copy(Dict("A" => x[1], "B" => x[2]))["A"], (5.0, 5.0)),
         (false, :none, nothing, copy, Dict{Any,Any}("A" => [5.0], [3.0] => 5.0)),

--- a/src/rrules/new.jl
+++ b/src/rrules/new.jl
@@ -100,7 +100,7 @@ Function which replaces instances of `:splatnew`.
 """
 _splat_new_(::Type{P}, x::Tuple) where {P} = _new_(P, x...)
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:new})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:new})
 
     # Specialised test cases for _new_.
     specific_test_cases = Any[
@@ -208,8 +208,4 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:new})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:new})
-    test_cases = Any[]
-    memory = Any[]
-    return test_cases, memory
-end
+derived_rule_test_cases(rng_ctor, ::Val{:new}) = Any[], Any[]

--- a/src/rrules/performance_patches.jl
+++ b/src/rrules/performance_patches.jl
@@ -46,7 +46,7 @@ function rrule!!(
     return zero_fcodual(sum(abs2, x.x)), sum_abs2_pb!!
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:performance_patches})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:performance_patches})
     rng = rng_ctor(123)
     sizes = [(11,), (11, 3)]
     precisions = [Float64, Float32, Float16]
@@ -68,4 +68,4 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:performance_p
     return test_cases, memory
 end
 
-generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:performance_patches}) = Any[], Any[]
+derived_rule_test_cases(rng_ctor, ::Val{:performance_patches}) = Any[], Any[]

--- a/src/rrules/random.jl
+++ b/src/rrules/random.jl
@@ -33,7 +33,7 @@ for f in [randn!, randexp!]
     end
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:random})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:random})
     rngs = [MersenneTwister(123), TaskLocalRNG(), Xoshiro(123)]
     all_rngs = vcat(rngs, RandomDevice())
     test_cases = vcat(
@@ -56,7 +56,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:random})
     return test_cases, Any[]
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:random})
+function derived_rule_test_cases(rng_ctor, ::Val{:random})
     test_cases = Any[
 
         # Random number generation.

--- a/src/rrules/tasks.jl
+++ b/src/rrules/tasks.jl
@@ -113,7 +113,7 @@ set_tangent_field!(t::TaskTangent, f, ::NoTangent) = NoTangent()
 
 __verify_fdata_value(::IdDict{Any,Nothing}, ::Task, ::TaskTangent) = nothing
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:tasks})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:tasks})
     test_cases = Any[
         (false, :none, nothing, lgetfield, Task(() -> nothing), Val(:rngState1)),
         (false, :none, nothing, getfield, Task(() -> nothing), :rngState1),
@@ -132,7 +132,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:tasks})
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:tasks})
+function derived_rule_test_cases(rng_ctor, ::Val{:tasks})
     test_cases = Any[(
         false,
         :none,

--- a/src/rrules/twice_precision.jl
+++ b/src/rrules/twice_precision.jl
@@ -381,7 +381,7 @@ end
     end
 end
 
-function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:twice_precision})
+function hand_written_rule_test_cases(rng_ctor, ::Val{:twice_precision})
     test_cases = Any[
         (
             false,
@@ -454,7 +454,7 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:twice_precisi
     return test_cases, memory
 end
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:twice_precision})
+function derived_rule_test_cases(rng_ctor, ::Val{:twice_precision})
     test_cases = Any[
 
         # Functionality in base/twiceprecision.jl

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -989,6 +989,6 @@ end
 
 using .TestResources
 
-function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:test_resources})
+function derived_rule_test_cases(rng_ctor, ::Val{:test_resources})
     return TestResources.generate_test_functions(), Any[]
 end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -986,10 +986,9 @@ function test_rule(
 end
 
 function run_hand_written_rule_test_cases(rng_ctor, v::Val, mode::Type{<:Mode})
-    test_cases, memory =
-        test_hook(Mooncake.generate_hand_written_rrule!!_test_cases, rng_ctor, v) do
-            Mooncake.generate_hand_written_rrule!!_test_cases(rng_ctor, v)
-        end
+    test_cases, memory = test_hook(Mooncake.hand_written_rule_test_cases, rng_ctor, v) do
+        Mooncake.hand_written_rule_test_cases(rng_ctor, v)
+    end
     GC.@preserve memory @testset "$f, $(_typeof(x))" for (
         interface_only, perf_flag, _, f, x...
     ) in test_cases
@@ -1000,10 +999,9 @@ function run_hand_written_rule_test_cases(rng_ctor, v::Val, mode::Type{<:Mode})
 end
 
 function run_derived_rule_test_cases(rng_ctor, v::Val, mode::Type{<:Mode})
-    test_cases, memory =
-        test_hook(Mooncake.generate_derived_rrule!!_test_cases, rng_ctor, v, mode) do
-            Mooncake.generate_derived_rrule!!_test_cases(rng_ctor, v)
-        end
+    test_cases, memory = test_hook(Mooncake.derived_rule_test_cases, rng_ctor, v, mode) do
+        Mooncake.derived_rule_test_cases(rng_ctor, v)
+    end
     GC.@preserve memory @testset "$mode, $f, $(typeof(x))" for (
         interface_only, perf_flag, _, f, x...
     ) in test_cases

--- a/test/integration_testing/dispatch_doctor/dispatch_doctor.jl
+++ b/test/integration_testing/dispatch_doctor/dispatch_doctor.jl
@@ -7,15 +7,11 @@ using DispatchDoctor: allow_unstable, type_instability
 
 TestUtils.test_hook(::Any, ::typeof(TestUtils.test_opt), ::Any...) = nothing
 TestUtils.test_hook(::Any, ::typeof(TestUtils.report_opt), tt) = nothing
-function TestUtils.test_hook(
-    f, ::typeof(Mooncake.generate_hand_written_rrule!!_test_cases), ::Any...
-)
-    allow_unstable(f)
+function TestUtils.test_hook(f, ::typeof(Mooncake.hand_written_rule_test_cases), ::Any...)
+    return allow_unstable(f)
 end
-function TestUtils.test_hook(
-    f, ::typeof(Mooncake.generate_derived_rrule!!_test_cases), ::Any...
-)
-    allow_unstable(f)
+function TestUtils.test_hook(f, ::typeof(Mooncake.derived_rule_test_cases), ::Any...)
+    return allow_unstable(f)
 end
 
 # Automatically skip instability checks for types which are themselves unstable,


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
1. adds `dual_ir` to the dev docs, alongisde `primal_ir`, `fwd_ir`, and `rvs_ir`.
2. renames the test case functions, since they're now used for both forward-mode and reverse-mode.