### PR TITLE
Actually run matrix det derived rule test

### DIFF
--- a/src/rrules/linear_algebra.jl
+++ b/src/rrules/linear_algebra.jl
@@ -42,8 +42,7 @@ function derived_rule_test_cases(rng_ctor, ::Val{:linear_algebra})
         map_prod([3, 7], Ps) do (N, P)
             flags = (false, :none, nothing)
             Any[
-                (flags..., inv, randn(rng, P, N, N)),
-                (flags..., det, randn(rng, P, N, N)),
+                (flags..., inv, randn(rng, P, N, N)), (flags..., det, randn(rng, P, N, N))
             ]
         end...,
     )


### PR DESCRIPTION
Fixes an oversight in https://github.com/chalk-lab/Mooncake.jl/pull/812: `return` makes the `det` test not run.