### PR TITLE
[1.12] svec now used for differentiable data

### DIFF
--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -820,12 +820,14 @@ end
 
 function frule!!(f::Dual{typeof(svec)}, args::Vararg{Any,N}) where {N}
     primal_output = svec(map(primal, args)...)
+    # Tangent type for `SimpleVector` is `Vector{Any}`
     dual_output = collect(Any, map(tangent, args))
     return Dual(primal_output, dual_output)
 end
 
 function rrule!!(f::CoDual{typeof(svec)}, args::Vararg{Any,N}) where {N}
     primal_output = svec(map(primal, args)...)
+    # Tangent type for `SimpleVector` is `Vector{Any}`
     tangent_output = collect(Any, map(args) do x
         return tangent(x.dx, zero_rdata(x.x))
     end)


### PR DESCRIPTION
It looks like Julia now uses `svec` when calling `_apply_iterate`. As such `svec` can now contain differentiable data. This PR fixes the `_svec_ref` rule accordingly.

Additionally, I fixed the rrule for `svec` returning the wrong FData type. I think that the `svec` rules are still incorrect, but at least this PR manages to fix `sig_argcount_mismatch` and `large_tuple_inference` in my local testing. It would be good to add more tests.

BTW I am interested in helping with 1.12 support in general. Is there a place where this is discussed more actively, or is the corresponding PR the right place?