### PR TITLE
Support differentiable data in SimpleVector

### DIFF
--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -743,9 +743,12 @@ end
 function rrule!!(f::CoDual{typeof(svec)}, args::Vararg{Any,N}) where {N}
     primal_output = svec(map(primal, args)...)
     # Tangent type for `SimpleVector` is `Vector{Any}`
-    tangent_output = collect(Any, map(args) do x
-        return tangent(x.dx, zero_rdata(x.x))
-    end)
+    tangent_output = collect(
+        Any,
+        map(args) do x
+            return tangent(x.dx, zero_rdata(x.x))
+        end,
+    )
     function svec_pullback!!(::NoRData)
         return NoRData(), map(rdata, tangent_output)...
     end


### PR DESCRIPTION
In 1.12, Julia uses `svec` when calling `_apply_iterate`. As such `SimpleVector` can now contain differentiable data. This PR fixes the `_svec_ref` rule accordingly, and adds an `svec` rule.

Initially PRed in https://github.com/chalk-lab/Mooncake.jl/pull/824, but since this change does not require Julia 1.12 it is being sent to `main` directly.