### PR TITLE
fix allocation counts for primals (plus `_new_` frule)

### DIFF
--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -841,7 +841,8 @@ function test_rrule_performance(
         @static if VERSION >= v"1.12"
             @test count_allocs(__forwards_and_backwards, rule, f_f̄_fwds, x_x̄_fwds...) == 0
         else
-            @test (@allocations __forwards_and_backwards(rule, f_f̄_fwds, x_x̄_fwds...)) == 0
+            @test (@allocations __forwards_and_backwards(rule, f_f̄_fwds, x_x̄_fwds...)) ==
+                0
         end
     end
 end


### PR DESCRIPTION
This PR fixes failing allocation tests in #714 for a number of primal functions, such as `sum(abs2, ::Vector)` on 1.12, and `rand(::AbstractRNG, Float64)` on 1.10 / 1.11. It also fixes the allocs for forward-mode `_new_`.

YES, it's ugly.

Specifically, this avoids the reporting of spurious allocations by:

1. using `@allocations` on 1.11, which Just Works;

2. creating a closure on 1.12, which effectively does the same as interpolating the arguments with a package like BenchmarkTools, which is needed for `sum(abs2, xs)`.

3. manually splatting the varargs on all versions, which removes allocations which I believe are caused by something like incomplete specialisation. See for example https://discourse.julialang.org/t/specialization-on-vararg-of-types/108251 and also the following example:

```julia
using Random

vararg(f::F, x::Vararg{Any,N}) where {F,N} = nothing
vararg(randn, Xoshiro(468), Float64) # generate the specialisation
Base.specializations(@which vararg(randn, Xoshiro(468), Float64))
# -> Base.MethodSpecializations(MethodInstance for vararg(::typeof(randn), ::Xoshiro, ::Type))

explicit(f::F, x1::X1, x2::X2) where {F,X1,X2} = nothing
explicit(randn, Xoshiro(468), Float32) # generate the specialisation
Base.specializations(@which explicit(randn, Xoshiro(468), Float32))
# -> Base.MethodSpecializations(MethodInstance for explicit(::typeof(randn), ::Xoshiro, ::Type{Float32}))
```

Because `Base.allocations` is also a varargs function (https://github.com/JuliaLang/julia/blob/ba1e628ee49351af0b704afd2b2903d253bd3564/base/timing.jl#L485-L491), going via `Base.allocations` sometimes causes extra allocations (grr). So this PR also just inlines its definition into `count_allocs`.

Effectively, `count_allocs` is now a version of `Base.allocations` that uses a closure + explicit numbered arguments.

---------

Note that I tested various combinations of BenchmarkTools and Chairmarks and I couldn't find a way to correctly get interpolations all the way down to 0, so I _think_ this PR is legitimately the only way to correctly detect zero-allocation function calls. For example:

```julia
using BenchmarkTools
using Mooncake
function allocs()
    local f = Mooncake._new_
    local x = (Mooncake.TestResources.TypeStableMutableStruct{Float64}, 5.0, 4.0)
    display(@btime $f($x...))
    local closure = () -> f(x...)
    display(@btime $closure())
end
allocs() # 3, 3
```