### PR TITLE
Skip certain stability and performance tests for 1.12

### DIFF
--- a/src/rrules/avoiding_non_differentiable_code.jl
+++ b/src/rrules/avoiding_non_differentiable_code.jl
@@ -108,7 +108,7 @@ end
 )
 
 # Julia Base functions have type stability issues in version 1.12
-const PERF_FLAG = @static if VERSION >= v"1.12-" 
+const PERF_FLAG = @static if VERSION >= v"1.12-"
     :none
 else
     :stability_and_allocs


### PR DESCRIPTION
These errors are from Julia Base, not Mooncake, so skipping them. 

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
