### PR TITLE
Fix for TwicePrecision allocs

### DIFF
--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1421,6 +1421,16 @@ const __MAX_ARGS_ALLOCS = 10
                     return Base.gc_alloc_count(diff)
                 end
             end
+            # Needs a special case when `f` itself is a type constructor
+            function count_allocs(::Type{F}, $(sigs...)) where {F,$(types...)}
+                test_hook(count_allocs, F, $(args...)) do
+                    stats = Base.gc_num()
+                    @noinline clos = () -> F($(args...))
+                    clos()
+                    diff = Base.GC_Diff(Base.gc_num(), stats)
+                    return Base.gc_alloc_count(diff)
+                end
+            end
         end
         eval(fexpr)
     end


### PR DESCRIPTION
Tested locally and this should fix it (without breaking any of the other failures), but I'd let CI run to check that it didn't mess _something else_ up too.

I think it should also fix the array tests because those have the same underlying problem of `f` being a type, although I didn't check those myself.