### PR TITLE
fix compat bound for main

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -72,7 +72,7 @@ SpecialFunctions = "2"
 StableRNGs = "1"
 Static = "1.1.1"
 Test = "1"
-julia = "~1.10.8, 1.11.6"
+julia = "~1.10.8, ~1.11.6"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"


### PR DESCRIPTION
Notice that 0.4.174 was never released: https://github.com/JuliaRegistries/General/pull/141069 https://github.com/chalk-lab/Mooncake.jl/commit/1c0a6d03ed07ae15640c55a1d096ffdcd420f814#commitcomment-168672266

The reason is because this came out at a time after 1.12 was released, but the compat bound was not adjusted accordingly. If I'm not wrong, Automerge always tests the lowest + highest Julia versions declared in the compat. Since Mooncake failed to build on 1.12, it never got merged into the General registry.

Merging this and re-triggering the 0.4.174 release should make it go through.

As an alternative solution you could merge #714 and just release the entire thing as 0.4.174.