### PR TITLE
Improve error message for replicating rule compilation errors

### DIFF
--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -72,8 +72,8 @@ function Base.show(io::IO, mime::MIME"text/plain", mc::MooncakeInterpreter)
 end
 Base.show(io::IO, mc::MooncakeInterpreter) = _show_interp(io, MIME"text/plain"(), mc)
 
-function _show_interp(io::IO, ::MIME"text/plain", ::MooncakeInterpreter)
-    return print(io, "MooncakeInterpreter()")
+function _show_interp(io::IO, ::MIME"text/plain", ::MooncakeInterpreter{C,M}) where {C,M}
+    return print(io, "MooncakeInterpreter($M)")
 end
 
 MooncakeInterpreter(M::Type{<:Mode}) = MooncakeInterpreter(DefaultCtx, M)

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1041,7 +1041,7 @@ end
 
 function Base.showerror(io::IO, err::MooncakeRuleCompilationError)
     msg =
-        "MooncakeRuleCompilationError: an error occured while Mooncake was compiling a " *
+        "MooncakeRuleCompilationError: an error occurred while Mooncake was compiling a " *
         "rule to differentiate something. If the `caused by` error " *
         "message below does not make it clear to you how the problem can be fixed, " *
         "please open an issue at github.com/chalk-lab/Mooncake.jl describing your " *


### PR DESCRIPTION
Currently the error says something like this:

```
ERROR: MooncakeRuleCompilationError: an error occured while Mooncake was compiling a rule to differentiate something. If the `caused by` error message below does not make it clear to you how the problem can be fixed, please open an issue at github.com/chalk-lab/Mooncake.jl describing your problem.
To replicate this error run the following:

Mooncake.build_rrule(Mooncake.MooncakeInterpreter(), Tuple{typeof(f), Vector{Float64}}; debug_mode=false)

Note that you may need to `using` some additional packages if not all of the names printed in the above signature are available currently in your environment.
```

This PR fixes a couple of things:

1. spelling of 'occurred'
2. `MooncakeInterpreter()` no longer works as is, it also needs to be passed a mode.