### PR TITLE
Remove disclaimer from Forwards mode docs

### DIFF
--- a/docs/src/developer_documentation/forwards_mode_design.md
+++ b/docs/src/developer_documentation/forwards_mode_design.md
@@ -1,7 +1,5 @@
 # Forwards-Mode Design
 
-**Disclaimer**: this document refers to an as-yet-unimplemented forwards-mode AD. This will disclaimer will be removed once it has been implemented.
-
 The purpose of this document is to explain how forwards-mode AD in Mooncake.jl is implemented.
 It should do so to a sufficient level of depth to enable the interested reader to read to the forwards-mode AD code in Mooncake.jl and understand what is going on.
 


### PR DESCRIPTION
The docs still claim that Forwards Mode hasn't been implemented yet, so this message should be removed. Not sure if there's any other things in this document that need updating now that it actually exists 