### PR TITLE
Improve benchmarks' robustness

### DIFF
--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -287,12 +287,12 @@ end
 
 function combine_results(result, tag, _range, default_range)
     d = result[2]
-    primal_time = minimum(d["primal"]).time
-    mooncake_time = minimum(d["mooncake"]).time
-    mooncake_fwd_time = minimum(d["mooncake_fwd"]).time
-    zygote_time = in("zygote", keys(d)) ? minimum(d["zygote"]).time : missing
-    rd_time = in("rd", keys(d)) ? minimum(d["rd"]).time : missing
-    ez_time = in("enzyme", keys(d)) ? minimum(d["enzyme"]).time : missing
+    primal_time = median(d["primal"]).time
+    mooncake_time = median(d["mooncake"]).time
+    mooncake_fwd_time = median(d["mooncake_fwd"]).time
+    zygote_time = in("zygote", keys(d)) ? median(d["zygote"]).time : missing
+    rd_time = in("rd", keys(d)) ? median(d["rd"]).time : missing
+    ez_time = in("enzyme", keys(d)) ? median(d["enzyme"]).time : missing
     fallback_tag = string((result[1][1], map(Mooncake._typeof, result[1][2:end])...))
     return (
         tag=tag === nothing ? fallback_tag : tag,


### PR DESCRIPTION
Change time calculation from `minimum` to `median` to make `autograd_time / primal_time` ratio more reproduciable.

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
