### PR TITLE
More second-order tests

### DIFF
--- a/test/ext/differentiation_interface_second_order/differentiation_interface_second_order.jl
+++ b/test/ext/differentiation_interface_second_order/differentiation_interface_second_order.jl
@@ -9,14 +9,14 @@ EXCLUDED = @static if VERSION ≥ v"1.11-" && VERSION ≤ v"1.12-"
     # testing only :hessian on 1.11 due to opaque closure bug.  
     # This is potentially the same issue as discussed in 
     # https://github.com/chalk-lab/MistyClosures.jl/pull/12#issue-3278662295
-    [FIRST_ORDER..., :hvp, :second_derivative],
+    [FIRST_ORDER..., :hvp, :second_derivative]
 else
-    [FIRST_ORDER...],
+    [FIRST_ORDER...]
 end
 
 # Test second-order differentiation (forward-over-reverse)
 test_differentiation(
     [SecondOrder(AutoMooncakeForward(; config=nothing), AutoMooncake(; config=nothing))];
-    excluded=EXCLUDED
+    excluded=EXCLUDED,
     logging=true,
 )


### PR DESCRIPTION
Enable second-order tests on versions 1.10 and 1.12. Version 1.11 is excluded due to an opaque closure bug.

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
