### PR TITLE
Update CUDA functionality check in nnlib.jl

### DIFF
--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -11,9 +11,7 @@ dropout_tester_2(Trng, x, p) = dropout(Trng(1), x, p; dims=2)
 dropout_tester_3(Trng, x, p) = dropout(Trng(1), x, p; dims=(1, 2))
 
 @testset "nnlib" begin
-    # TODO: remove Julia version bound when 
-    #  https://github.com/JuliaGPU/CUDA.jl/issues/2886 is fixed
-    cuda = CUDA.functional() && VERSION < v"1.12-"
+    cuda = CUDA.functional()
 
     _rand = if cuda
         (rng, size...) -> cu(randn(rng, size...))


### PR DESCRIPTION
Removed the Julia version bound check for CUDA functionality since https://github.com/JuliaGPU/CUDA.jl/issues/2946 is fixed. 

Please feel free to takeover and merge if tests pass. 

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
