### PR TITLE
Add OrdinaryDiffEqCore extension with zero-derivative rules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 LuxLib = "82251201-b29d-42c6-8e01-566dec8acb11"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
@@ -42,6 +43,7 @@ MooncakeLogExpFunctionsExt = "LogExpFunctions"
 MooncakeLuxLibExt = ["LuxLib", "MLDataDevices", "Static"]
 MooncakeLuxLibSLEEFPiratesExtension = ["LuxLib", "SLEEFPirates"]
 MooncakeNNlibExt = ["NNlib", "GPUArraysCore"]
+MooncakeOrdinaryDiffEqCoreExt = "OrdinaryDiffEqCore"
 MooncakeSpecialFunctionsExt = "SpecialFunctions"
 
 [compat]
@@ -68,6 +70,7 @@ LuxLib = "1.11"
 MLDataDevices = "1.10.0"
 MistyClosures = "2"
 NNlib = "0.9"
+OrdinaryDiffEqCore = "3"
 Pkg = "1"
 Random = "1"
 Revise = "3.0 - 3.12"

--- a/ext/MooncakeOrdinaryDiffEqCoreExt.jl
+++ b/ext/MooncakeOrdinaryDiffEqCoreExt.jl
@@ -1,0 +1,22 @@
+module MooncakeOrdinaryDiffEqCoreExt
+
+using OrdinaryDiffEqCore
+import Mooncake: DefaultCtx, @zero_derivative
+
+# These functions handle bookkeeping, logging, and error checking rather than
+# numerical computations that need gradient information. Marking them as
+# zero-derivative prevents unnecessary differentiation through non-differentiable code.
+# This mirrors the inactive_noinl rules in the Enzyme extension.
+
+@zero_derivative DefaultCtx Tuple{typeof(OrdinaryDiffEqCore.increment_nf!),Vararg}
+@zero_derivative DefaultCtx Tuple{
+    typeof(OrdinaryDiffEqCore.fixed_t_for_floatingpoint_error!),Vararg
+}
+@zero_derivative DefaultCtx Tuple{typeof(OrdinaryDiffEqCore.increment_accept!),Vararg}
+@zero_derivative DefaultCtx Tuple{typeof(OrdinaryDiffEqCore.increment_reject!),Vararg}
+@zero_derivative DefaultCtx Tuple{typeof(OrdinaryDiffEqCore.check_error!),Vararg}
+@zero_derivative DefaultCtx Tuple{typeof(OrdinaryDiffEqCore.log_step!),Vararg}
+@zero_derivative DefaultCtx Tuple{typeof(OrdinaryDiffEqCore.final_progress),Vararg}
+@zero_derivative DefaultCtx Tuple{typeof(OrdinaryDiffEqCore.ode_determine_initdt),Vararg}
+
+end


### PR DESCRIPTION
## Summary

- Adds a package extension `MooncakeOrdinaryDiffEqCoreExt` that marks OrdinaryDiffEqCore bookkeeping functions as having zero derivatives
- Mirrors the `inactive_noinl` rules from the Enzyme extension in OrdinaryDiffEqCore
- Enables automatic differentiation through ODE solvers by skipping non-differentiable logging/error-checking code

## Functions marked with `@zero_derivative`

These functions handle bookkeeping, logging, and error checking rather than numerical computations:

- `increment_nf!`
- `fixed_t_for_floatingpoint_error!`
- `increment_accept!`
- `increment_reject!`
- `check_error!`
- `log_step!`
- `final_progress`
- `ode_determine_initdt`

## Context

This addresses the issue raised in https://github.com/SciML/OrdinaryDiffEq.jl/pull/2993#discussion_r2701366380 where it was noted that the Mooncake extension in OrdinaryDiffEqCore needed to be updated to cover the same rules as the Enzyme extension.

By adding these rules directly to Mooncake, users who have both packages loaded will automatically benefit from derivative skipping without needing custom extensions.

## Test plan

- [x] Verified extension loads correctly when both Mooncake and OrdinaryDiffEqCore are loaded
- [x] Verified `is_primitive` returns `true` for the marked functions
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)