### PR TITLE
Remove obsolete conversion function for complex tangents.

### DIFF
--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -332,11 +332,6 @@ to_cr_tangent(t::MutableTangent) = CRC.Tangent{Any}(; map(to_cr_tangent, t.field
 to_cr_tangent(t::Tuple) = CRC.Tangent{Any}(map(to_cr_tangent, t)...)
 to_cr_tangent(nt::NamedTuple) = CRC.Tangent{Any}(; map(to_cr_tangent, nt)...)
 
-# Convert Mooncake complex tangents to ChainRulesCore-style tangents.
-function to_cr_tangent(c::Tangent{@NamedTuple{re::T,im::T}}) where {T<:IEEEFloat}
-    return Complex(c.fields.re, c.fields.im)
-end
-
 function to_cr_tangent(t)
     throw(
         ArgumentError(


### PR DESCRIPTION
Noticed this obsolete function from #944 while reading the code. 

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
