### PR TITLE
Add rrule for BridgeStan's log_density function

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,6 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         test_group: [
+          {test_type: 'ext', label: 'bridgestan'},
           {test_type: 'ext', label: 'differentiation_interface'},
           {test_type: 'ext', label: 'differentiation_interface_second_order'},
           {test_type: 'ext', label: 'dynamic_expressions'},

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [weakdeps]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
+BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DynamicExpressions = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
@@ -33,6 +34,7 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [extensions]
 MooncakeAllocCheckExt = "AllocCheck"
+MooncakeBridgeStanExt = "BridgeStan"
 MooncakeCUDAExt = "CUDA"
 MooncakeDynamicExpressionsExt = "DynamicExpressions"
 MooncakeFluxExt = "Flux"
@@ -49,6 +51,7 @@ ADTypes = "1.9"
 AllocCheck = "0.2"
 Aqua = "0.8.9"
 BenchmarkTools = "1"
+BridgeStan = "2"
 CUDA = "5"
 ChainRules = "1.71.0"
 ChainRulesCore = "1"

--- a/ext/MooncakeBridgeStanExt.jl
+++ b/ext/MooncakeBridgeStanExt.jl
@@ -1,7 +1,17 @@
 module MooncakeBridgeStanExt
 
 using BridgeStan, Mooncake
-import Mooncake: DefaultCtx, rrule!!, @is_primitive, CoDual, zero_fcodual, NoRData, primal, tangent, tangent_type, NoTangent
+import Mooncake:
+    DefaultCtx,
+    rrule!!,
+    @is_primitive,
+    CoDual,
+    zero_fcodual,
+    NoRData,
+    primal,
+    tangent,
+    tangent_type,
+    NoTangent
 
 # StanModel contains C pointers (Ptr{Nothing}) which Mooncake can't recurse into.
 # Declaring its tangent type as NoTangent short-circuits the generic struct machinery.
@@ -19,9 +29,7 @@ end
 
 # Rule for the direct call: log_density(sm, q) — no kwargs, defaults apply.
 @is_primitive DefaultCtx Tuple{
-    typeof(BridgeStan.log_density),
-    BridgeStan.StanModel,
-    AbstractVector{<:Real},
+    typeof(BridgeStan.log_density),BridgeStan.StanModel,AbstractVector{<:Real}
 }
 
 function rrule!!(

--- a/ext/MooncakeBridgeStanExt.jl
+++ b/ext/MooncakeBridgeStanExt.jl
@@ -1,0 +1,67 @@
+module MooncakeBridgeStanExt
+
+using BridgeStan, Mooncake
+import Mooncake: DefaultCtx, rrule!!, @is_primitive, CoDual, zero_fcodual, NoRData, primal, tangent, tangent_type, NoTangent
+
+# StanModel contains C pointers (Ptr{Nothing}) which Mooncake can't recurse into.
+# Declaring its tangent type as NoTangent short-circuits the generic struct machinery.
+Mooncake.tangent_type(::Type{BridgeStan.StanModel}) = NoTangent
+
+# Shared forward pass: compute log density and gradient in a single Stan call.
+# BridgeStan's C interface requires Vector{Float64}; convert is a no-op when the
+# type already matches, so there is no unnecessary copy for the common case.
+function _log_density_fwd(sm, q, propto, jacobian)
+    q_vec = convert(Vector{Float64}, q)
+    grad = Vector{Float64}(undef, length(q_vec))
+    ld, _ = BridgeStan.log_density_gradient!(sm, q_vec, grad; propto, jacobian)
+    return ld, grad
+end
+
+# Rule for the direct call: log_density(sm, q) — no kwargs, defaults apply.
+@is_primitive DefaultCtx Tuple{
+    typeof(BridgeStan.log_density),
+    BridgeStan.StanModel,
+    AbstractVector{<:Real},
+}
+
+function rrule!!(
+    ::CoDual{typeof(BridgeStan.log_density)},
+    sm::CoDual{BridgeStan.StanModel},
+    q::CoDual{<:AbstractVector{<:Real}},
+)
+    ld, grad = _log_density_fwd(primal(sm), primal(q), true, true)
+    function log_density_pb(dld::Float64)
+        tangent(q) .+= dld .* grad
+        return NoRData(), NoRData(), NoRData()
+    end
+    return zero_fcodual(ld), log_density_pb
+end
+
+# Rule for the kwarg call: log_density(sm, q; propto=..., jacobian=...).
+@is_primitive DefaultCtx Tuple{
+    typeof(Core.kwcall),
+    NamedTuple,
+    typeof(BridgeStan.log_density),
+    BridgeStan.StanModel,
+    AbstractVector{<:Real},
+}
+
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    kwargs::CoDual{<:NamedTuple},
+    ::CoDual{typeof(BridgeStan.log_density)},
+    sm::CoDual{BridgeStan.StanModel},
+    q::CoDual{<:AbstractVector{<:Real}},
+)
+    kw = primal(kwargs)
+    propto = get(kw, :propto, true)::Bool
+    jacobian = get(kw, :jacobian, true)::Bool
+    ld, grad = _log_density_fwd(primal(sm), primal(q), propto, jacobian)
+    function log_density_kw_pb(dld::Float64)
+        tangent(q) .+= dld .* grad
+        return NoRData(), NoRData(), NoRData(), NoRData(), NoRData()
+    end
+    return zero_fcodual(ld), log_density_kw_pb
+end
+
+end

--- a/ext/MooncakeBridgeStanExt.jl
+++ b/ext/MooncakeBridgeStanExt.jl
@@ -18,24 +18,21 @@ import Mooncake:
 Mooncake.tangent_type(::Type{BridgeStan.StanModel}) = NoTangent
 
 # Shared forward pass: compute log density and gradient in a single Stan call.
-# BridgeStan's C interface requires Vector{Float64}; convert is a no-op when the
-# type already matches, so there is no unnecessary copy for the common case.
 function _log_density_fwd(sm, q, propto, jacobian)
-    q_vec = convert(Vector{Float64}, q)
-    grad = Vector{Float64}(undef, length(q_vec))
-    ld, _ = BridgeStan.log_density_gradient!(sm, q_vec, grad; propto, jacobian)
+    grad = Vector{Float64}(undef, length(q))
+    ld, _ = BridgeStan.log_density_gradient!(sm, q, grad; propto, jacobian)
     return ld, grad
 end
 
 # Rule for the direct call: log_density(sm, q) — no kwargs, defaults apply.
 @is_primitive DefaultCtx Tuple{
-    typeof(BridgeStan.log_density),BridgeStan.StanModel,AbstractVector{<:Real}
+    typeof(BridgeStan.log_density),BridgeStan.StanModel,Vector{Float64}
 }
 
 function rrule!!(
     ::CoDual{typeof(BridgeStan.log_density)},
     sm::CoDual{BridgeStan.StanModel},
-    q::CoDual{<:AbstractVector{<:Real}},
+    q::CoDual{Vector{Float64}},
 )
     ld, grad = _log_density_fwd(primal(sm), primal(q), true, true)
     function log_density_pb(dld::Float64)
@@ -51,7 +48,7 @@ end
     NamedTuple,
     typeof(BridgeStan.log_density),
     BridgeStan.StanModel,
-    AbstractVector{<:Real},
+    Vector{Float64},
 }
 
 function rrule!!(
@@ -59,7 +56,7 @@ function rrule!!(
     kwargs::CoDual{<:NamedTuple},
     ::CoDual{typeof(BridgeStan.log_density)},
     sm::CoDual{BridgeStan.StanModel},
-    q::CoDual{<:AbstractVector{<:Real}},
+    q::CoDual{Vector{Float64}},
 )
     kw = primal(kwargs)
     propto = get(kw, :propto, true)::Bool

--- a/test/ext/bridgestan/Project.toml
+++ b/test/ext/bridgestan/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
+Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/ext/bridgestan/bridgestan.jl
+++ b/test/ext/bridgestan/bridgestan.jl
@@ -1,0 +1,45 @@
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.develop(; path=joinpath(@__DIR__, "..", "..", ".."))
+
+using BridgeStan, Mooncake, StableRNGs, Test
+using Mooncake.TestUtils: test_rule
+
+# A trivial Stan model with a standard normal prior on one parameter.
+# This exercises log_density with and without the propto/jacobian kwargs.
+const STAN_CODE = """
+data {}
+parameters { real x; }
+model { x ~ normal(0, 1); }
+"""
+
+@testset "bridgestan" begin
+    mktempdir() do dir
+        stan_file = joinpath(dir, "test_model.stan")
+        write(stan_file, STAN_CODE)
+        sm = BridgeStan.StanModel(stan_file=stan_file, data="")
+
+        q = [0.5]
+        rng = StableRNG(123)
+
+        # Direct call (no kwargs) — uses the positional rrule!! with defaults.
+        test_rule(
+            rng, BridgeStan.log_density, sm, q;
+            is_primitive=true, mode=Mooncake.ReverseMode,
+        )
+
+        # Kwarg call — exercises the Core.kwcall rrule!! with explicit kwargs.
+        for (propto, jacobian) in [(true, true), (false, true), (true, false)]
+            test_rule(
+                rng,
+                Core.kwcall,
+                (propto=propto, jacobian=jacobian),
+                BridgeStan.log_density,
+                sm,
+                q;
+                is_primitive=true,
+                mode=Mooncake.ReverseMode,
+            )
+        end
+    end
+end

--- a/test/ext/bridgestan/bridgestan.jl
+++ b/test/ext/bridgestan/bridgestan.jl
@@ -24,8 +24,7 @@ model { x ~ normal(0, 1); }
 
         # Direct call (no kwargs) — uses the positional rrule!! with defaults.
         test_rule(
-            rng, BridgeStan.log_density, sm, q;
-            is_primitive=true, mode=Mooncake.ReverseMode,
+            rng, BridgeStan.log_density, sm, q; is_primitive=true, mode=Mooncake.ReverseMode
         )
 
         # Kwarg call — exercises the Core.kwcall rrule!! with explicit kwargs.


### PR DESCRIPTION
Adds a MooncakeBridgeStanExt package extension providing rrule!! for BridgeStan.log_density.

BridgeStan's log_density calls into compiled Stan C++ code, so Mooncake cannot differentiate through it generically. This extension uses the existing log_density_gradient! API — which Stan already computes analytically — for an exact, efficient reverse-mode rule.

- tangent_type(StanModel) = NoTangent: StanModel holds C pointers Mooncake must not recurse into
- Two rrule!! methods: positional log_density(sm, q) and kwarg log_density(sm, q; propto, jacobian)
- Tests cover both call forms across all propto/jacobian combinations