### PR TITLE
Fix `_copy_to_output!!` for partially-initialised immutable structs

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -334,13 +334,10 @@ function _copy_to_output!!(dst::P, src::P) where {P}
                     getfield(dst, src_sub), getfield(src, src_sub)
                 )
             else
-                nf = src_sub - 1  # Assumes if a undefined field is found, all subsequent fields are undefined.
-                break
+                return src
             end
         end
 
-        # when immutable struct object created by non initializing inner constructor. (Base.deepcopy misses this out)
-        !isassigned(flds, 1) && return src
         return ccall(:jl_new_structv, Any, (Any, Ptr{Any}, UInt32), P, flds, nf)::P
     end
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -296,6 +296,19 @@ end
                 @test isa(err, Mooncake.ValueAndPullbackReturnTypeError)
             end
         end
+
+        # Regression test for https://github.com/chalk-lab/Mooncake.jl/pull/1030:
+        # _copy_to_output!! must not segfault on partially-initialised immutable structs.
+        @testset "_copy_to_output!! on partially-initialised immutable struct (PR#1030)" begin
+            struct _PR1030Struct
+                a::Int
+                b::Vector{Float64}
+            end
+            s = ccall(:jl_new_struct_uninit, Any, (Any,), _PR1030Struct)::_PR1030Struct
+            @test isdefined(s, 1)
+            @test !isdefined(s, 2)
+            @test Mooncake._copy_to_output!!(s, s) === s
+        end
     end
     @testset "forwards mode ($kwargs)" for kwargs in [
         (;),


### PR DESCRIPTION
Fixes #1029.
   
When an undefined field is encountered in the immutable branch, return src early instead of calling `jl_new_structv` 
with a truncated field count. The previous `nf = src_sub - 1`; break approach caused `jl_new_structv` to read uninitialized memory → segfault.