### PR TITLE
bench: run incremental GC between benchmark samples

### DIFF
--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -194,7 +194,13 @@ function benchmark_rules!!(
                 () -> primals,
                 primals -> (primals[1], _deepcopy(primals[2:end])),
                 (a -> a[1]((a[2]...))),
-                _ -> true;
+                # With evals=1 and seconds=1, Chairmarks collects thousands of samples.
+                # Some benchmarks (e.g. gp_lml) allocate hundreds of KiB per call, so
+                # without GC intervention, garbage accumulates across samples until the GC
+                # fires mid-sample and inflates that sample's time by 2-3x or more. Running
+                # an incremental GC in the teardown (which is excluded from timing) keeps
+                # the heap clean and prevents GC from interrupting timed evaluations.
+                _ -> GC.gc(false);
                 evals=1,
                 seconds=seconds,
             )
@@ -210,7 +216,7 @@ function benchmark_rules!!(
                 () -> (rule, coduals),
                 ((rule, coduals),) -> (rule, copy_coduals(coduals...)),
                 a -> to_benchmark(a[1], a[2]...),
-                _ -> true;
+                _ -> GC.gc(false);
                 evals=1,
                 seconds=seconds,
             )
@@ -225,7 +231,7 @@ function benchmark_rules!!(
                 () -> (rule, duals),
                 ((rule, duals),) -> (rule, copy_coduals(duals...)),
                 a -> to_benchmark(a[1], a[2]...),
-                _ -> true;
+                _ -> GC.gc(false);
                 evals=1,
                 seconds=seconds,
             )


### PR DESCRIPTION
   ## Problem

   Benchmarks that allocate heavily per call (e.g. `gp_lml` allocates ~500 KiB)
   cause GC to fire *during* a timed sample when using `evals=1`. With thousands
   of samples collected over a 1-second run and no GC between them, garbage
   accumulates until the collector interrupts a live sample, inflating its time
   by 2–3× or more.

   ## Fix

   Change the Chairmarks teardown from `_ -> true` (no-op) to `_ -> GC.gc(false)`
   on the primal, reverse-mode, and forward-mode benchmark loops. The teardown
   runs outside the timed region, so an incremental collection between samples
   keeps the heap clean without affecting measured times.

   **Before:** median ~282 μs, max ~200 ms, 30 samples >2× median per 2000-sample run
   **After:** median ~208 μs, max ~0.5 ms, ≤1 sample >2× median per 2000-sample run