### PR TITLE
Add Flux integration tests for TEST_MODELS

### DIFF
--- a/test/integration_testing/flux/flux.jl
+++ b/test/integration_testing/flux/flux.jl
@@ -51,3 +51,29 @@ test_cases = Any[(loss, ps, st, x, mask), (loss_acl, psacl, stacl, x)]
         mode=Mooncake.ReverseMode,
     )
 end
+
+#
+# Tests from https://github.com/FluxML/Flux.jl/blob/d15c7dc54f080dd67193e8228329d6d127952b81/test/ext_mooncake.jl
+#
+
+using Statistics: mean
+
+include(joinpath(pkgdir(Flux), "test", "test_utils.jl"))
+
+# We only check that the gradient runs (interface_only=true), not correctness
+# against a reference. Correctness is tested separately in Flux's own test suite.
+@testset "mooncake gradient" begin
+    for (model, x, name) in TEST_MODELS
+        @testset "grad check $name" begin
+            Mooncake.TestUtils.test_rule(
+                StableRNG(123),
+                m -> mean(m(x)),
+                model;
+                is_primitive=false,
+                interface_only=true,
+                unsafe_perturb=true,
+                mode=Mooncake.ReverseMode,
+            )
+        end
+    end
+end


### PR DESCRIPTION
Adds two things to the Flux integration test suite:

1. **Refactor existing test** (issue #661 regression): remove the `mlp3` helper, inline the model with `f64`, drop unused imports and warm-up calls, and collect the two `test_rule` calls into a single loop over a `test_cases` array — consistent with the pattern used elsewhere in the codebase.

2. **TEST_MODELS testset**: imports `TEST_MODELS` directly from Flux's own `test/test_utils.jl` and runs each model through `Mooncake.TestUtils.test_rule` with `interface_only=true`. Correctness against a reference AD backend is left to Flux's own test suite. Ported from [FluxML/Flux.jl@d15c7dc](https://github.com/FluxML/Flux.jl/blob/d15c7dc54f080dd67193e8228329d6d127952b81/test/ext_mooncake.jl).

Tested locally on CPU only.