### PR TITLE
Add AD rules for det/logdet/logabsdet on Symmetric matrices (fixes #819)

### DIFF
--- a/src/rules/blas.jl
+++ b/src/rules/blas.jl
@@ -27,6 +27,17 @@ const TangentOrFData = Union{Tangent,FData}
 Return the primal field of `x`, and convert its fdata into an array of the same type as the
 primal. This operation is not guaranteed to be possible for all array types, but seems to be
 possible for all array types of interest so far.
+
+## Convention
+
+Every `arrayify` overload preserves the wrapper type: the returned tangent is always wrapped
+in the same concrete type as the primal (e.g. `Diagonal` → `Diagonal`, `Adjoint` → `Adjoint`,
+`Symmetric` → `Symmetric`). Rules that need to write into the tangent in-place must account
+for whether the wrapper supports `setindex!`; if it does not (e.g. `Symmetric`), a dedicated
+helper should extract the backing store (see `_accum_sym_logdet!`).
+
+`matrixify` and `viewify` are thin wrappers built on top of `arrayify` and share the same
+convention.
 """
 function arrayify(
     x::Union{Dual{A},CoDual{A}}
@@ -66,9 +77,7 @@ function arrayify(
     x::Symmetric{T,<:StridedMatrix{T}}, dx::TangentOrFData
 ) where {T<:Union{IEEEFloat,BlasFloat}}
     _, _dx = arrayify(x.data, _fields(dx).data)
-    # Returns the raw backing matrix, not Symmetric(_dx, ...), because the rrule
-    # accumulates gradients in-place (setindex!), which Symmetric does not support.
-    return x, _dx
+    return x, Symmetric(_dx, Symbol(x.uplo))
 end
 function arrayify(
     x::Adjoint{T,<:AbstractArray{T}}, dx::TangentOrFData

--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -644,7 +644,7 @@ function _add_to_primal_internal(
 end
 
 """
-    _accum_sym_logdet!(ddata, Sinv, ȳ, uplo)
+    _accum_sym_logdet!(ddata::StridedMatrix, Sinv::StridedMatrix, ȳ, uplo)
 
 Accumulate `ȳ * ∂logdet(Symmetric(A, uplo))/∂A` into `ddata` in-place, where
 `Sinv = inv(Symmetric(A, uplo))`.
@@ -662,9 +662,12 @@ This accumulator is shared by the `logdet`, `det`, and `logabsdet` rules:
 - `logdet`:     calls with scalar `ȳ`
 - `det`:        calls with scalar `ȳ * det(S)`  (chain rule through `exp ∘ logdet`)
 - `logabsdet`:  calls with scalar `ȳ[1]`        (sign component has zero derivative)
+
+When `ddata` is a `Symmetric` matrix, `uplo` and the backing store are extracted
+automatically via the two-argument overload below.
 """
 function _accum_sym_logdet!(
-    ddata::AbstractMatrix{P}, Sinv::AbstractMatrix{P}, ȳ::P, uplo::Char
+    ddata::StridedMatrix{P}, Sinv::StridedMatrix{P}, ȳ::P, uplo::Char
 ) where {P}
     n = size(ddata, 1)
     if uplo == 'U'
@@ -683,6 +686,9 @@ function _accum_sym_logdet!(
         end
     end
     return nothing
+end
+function _accum_sym_logdet!(ddata::Symmetric{P}, Sinv::StridedMatrix{P}, ȳ::P) where {P}
+    _accum_sym_logdet!(ddata.data, Sinv, ȳ, ddata.uplo)
 end
 
 """
@@ -707,7 +713,7 @@ function frule!!(
     S, d_data = arrayify(_S)
     F = bunchkaufman(S)
     Sinv = inv(F)
-    return Dual(logdet(F), dot(Sinv, Symmetric(d_data, Symbol(S.uplo))))
+    return Dual(logdet(F), dot(Sinv, d_data))
 end
 function rrule!!(
     ::CoDual{typeof(logdet)}, _S::CoDual{<:Symmetric{P,<:StridedMatrix{P}}}
@@ -717,7 +723,7 @@ function rrule!!(
     ld = logdet(F)
     Sinv = inv(F)
     function logdet_sym_pb!!(ȳ::P)
-        _accum_sym_logdet!(ddata, Sinv, ȳ, S.uplo)
+        _accum_sym_logdet!(ddata, Sinv, ȳ)
         return NoRData(), NoRData()
     end
     return CoDual(ld, NoFData()), logdet_sym_pb!!
@@ -749,7 +755,7 @@ function frule!!(
     # measure-zero in practice.
     iszero(d) && return Dual(d, zero(P))
     Sinv = inv(F)
-    return Dual(d, d * dot(Sinv, Symmetric(d_data, Symbol(S.uplo))))
+    return Dual(d, d * dot(Sinv, d_data))
 end
 function rrule!!(
     ::CoDual{typeof(det)}, _S::CoDual{<:Symmetric{P,<:StridedMatrix{P}}}
@@ -761,7 +767,7 @@ function rrule!!(
     function det_sym_pb!!(ȳ::P)
         # Zero gradient for singular S (approximate; see frule!! for details).
         isnothing(Sinv) && return NoRData(), NoRData()
-        _accum_sym_logdet!(ddata, Sinv, ȳ * d, S.uplo)
+        _accum_sym_logdet!(ddata, Sinv, ȳ * d)
         return NoRData(), NoRData()
     end
     return CoDual(d, NoFData()), det_sym_pb!!
@@ -792,7 +798,7 @@ function frule!!(
     ld, s = logabsdet(F)
     iszero(s) && return Dual((ld, s), (zero(P), zero(P)))
     Sinv = inv(F)
-    return Dual((ld, s), (dot(Sinv, Symmetric(d_data, Symbol(S.uplo))), zero(P)))
+    return Dual((ld, s), (dot(Sinv, d_data), zero(P)))
 end
 function rrule!!(
     ::CoDual{typeof(logabsdet)}, _S::CoDual{<:Symmetric{P,<:StridedMatrix{P}}}
@@ -803,7 +809,7 @@ function rrule!!(
     Sinv = iszero(s) ? nothing : inv(F)
     function logabsdet_sym_pb!!(ȳ::Tuple{P,P})
         isnothing(Sinv) && return NoRData(), NoRData()
-        _accum_sym_logdet!(ddata, Sinv, ȳ[1], S.uplo)
+        _accum_sym_logdet!(ddata, Sinv, ȳ[1])
         return NoRData(), NoRData()
     end
     return CoDual((ld, s), NoFData()), logabsdet_sym_pb!!


### PR DESCRIPTION
## Summary

Closes #819. Adds forward- and reverse-mode AD rules for `logdet`, `det`, and `logabsdet` on `Symmetric{P,<:AbstractMatrix{P}}` where `P <: BlasRealFloat`.

### Problem

`logdet(Symmetric(A))` (and `det`/`logabsdet`) failed during AD because the call path goes through `LAPACK.sytrf!` (Bunch–Kaufman factorisation), which had no AD rule.

## Technical Details

The gradient of $\log(\det(S))$ with respect to a symmetric matrix $S$ is $S^{-1}$. However, since `Symmetric(A, uplo)` wraps a standard matrix $A$, the gradient must be mapped back to the underlying storage $A$.
We use the following identity for the gradient w.r.t the data array $A$:
* **Diagonal:** $\frac{\partial \mathcal{L}}{\partial A_{ii}} = S^{-1}_{ii}$
* **Off-diagonal:** $\frac{\partial \mathcal{L}}{\partial A_{ij}} = 2 \cdot S^{-1}_{ij}$ (for $i, j$ in the active triangle)

This is implemented in the internal helper `_accum_sym_logdet!`.

### Type Handling & `Symmetric` Constructor
The `Symmetric` type stores its `uplo` field as a `Char` ('U' or 'L'), but the standard constructor expects a `Symbol` (:U or :L). This causes issues during the tangent accumulation phase in Mooncake. This PR includes an override for `_add_to_primal_internal` to correctly cast the `Char` back to a `Symbol` during reconstruction.

### References

* Seeger et al. (arXiv:1710.08717) provides rules for Cholesky and Symmetric Eigendecomposition but explicitly omits pivoted $LDL^T$.
* No existing public implementation currently exists in **ChainRules.jl**, **PyTorch**, or **JAX** for a direct rule of `sytrf!`. This PR provides a robust "Strategy 1" (direct rules for user-facing functions).

## Coverage Matrix

| Use Case | Implementation Path | Rule Status |
| :--- | :--- | :--- |
| `logdet(Symmetric(A))` | `frule!!` / `rrule!!` | **Added** |
| `det(Symmetric(A))` | `frule!!` / `rrule!!` | **Added** |
| `logabsdet(Symmetric(A))` | `frule!!` / `rrule!!` | **Added** |
| `inv(Symmetric(A))` | Bunch-Kaufman path | Unsupported |
| `Symmetric(A) \ b` | Bunch-Kaufman path | Unsupported |


### Limitations

Strategy 1 only covers `logdet`/`det`/`logabsdet`. Full coverage of `inv`, `\`, `factorize`, and `bunchkaufman` requires a rule for `bunchkaufman(::Symmetric)` or `LAPACK.sytrf!` directly — left for future work.