### PR TITLE
PR 2a: GPU AD infrastructure — NDual type for GPU chunk-mode forward-mode AD

### DIFF
--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -10,9 +10,9 @@ using CUDA:
     CuContext,
     CuStream,
     CUmemPoolHandle_st,
+    CuArrayStyle,
     CUdevice_attribute_enum,
-    cudaError_enum,
-    libraryPropertyType,
+    cu,
     TaskLocalState,
     task_local_state!,
     active_state,
@@ -21,11 +21,13 @@ using CUDA:
     cuDeviceGetAttribute,
     DeviceMemory,
     UnifiedMemory,
-    HostMemory
+    HostMemory,
+    is_capturing,
+    capture_status
 using CUDA: CUBLAS
 using CUDA: CUSPARSE
 using CUDA: CUSOLVER
-
+using Base.Broadcast: Broadcasted
 import Mooncake:
     MinimalCtx,
     DefaultCtx,
@@ -59,21 +61,28 @@ import Mooncake:
     NoTangent,
     NoPullback,
     NoFData,
+    FData,
+    Tangent,
     to_cr_tangent,
     mooncake_tangent,
     increment_and_get_rdata!,
     MaybeCache,
     IncCache,
     NoRData,
-    arrayify
+    arrayify,
+    _fields,
+    zero_rdata,
+    RData
 
 import Mooncake.TestUtils:
     populate_address_map_internal, AddressMap, __increment_should_allocate
 
+include("ndual.jl")
+
 const CuFloatArray = CuArray{<:IEEEFloat}
 const CuComplexArray = CuArray{<:Complex{<:IEEEFloat}}
 const CuMaybeComplexArray = Union{CuFloatArray,CuComplexArray}
-
+const CuFloatOrComplex = Union{IEEEFloat,Complex{<:IEEEFloat}}
 # CuArray{T,N,M}.data is a DataRef — a reference-counted handle to the GPU memory buffer.
 # Operations like reshape and view reconstruct a CuArray from its components:
 #   `y = _new_(typeof(y), getfield(x, :data), getfield(x, :maxsize), getfield(x, :offset), dims)`.
@@ -88,25 +97,45 @@ const CuMaybeComplexArray = Union{CuFloatArray,CuComplexArray}
 # CuArray{T,N,M} combination.  Missing a variant causes Mooncake to fall through to the
 # generic struct handler, which tries to build tangents for DataRef's internal Ptr fields.
 const CuDataRef = Union{
-    fieldtype(CuArray{Float32,1,DeviceMemory}, :data),
-    fieldtype(CuArray{Float32,1,UnifiedMemory}, :data),
-    fieldtype(CuArray{Float32,1,HostMemory}, :data),
+    fieldtype(CuArray{Float32,1,DeviceMemory}, :data),   # DataRef{Managed{DeviceMemory}}
+    fieldtype(CuArray{Float32,1,UnifiedMemory}, :data),   # DataRef{Managed{UnifiedMemory}}
+    fieldtype(CuArray{Float32,1,HostMemory}, :data),   # DataRef{Managed{HostMemory}}
 }
 
-# DataRef values are mutable reference-counted handles; preserve them as-is for fdata.
+# DataRef is treated as an opaque handle: its tangent type is DataRef itself.
+# The three fields (:rc, :freed, :cached) are reference-counting internals — not
+# differentiable.  lgetfield rules return NoTangent/NoFData for all field accesses.
 @foldable tangent_type(::Type{P}) where {P<:CuDataRef} = P
 @foldable tangent_type(::Type{P}, ::Type{NoRData}) where {P<:CuDataRef} = P
 tangent(p::CuDataRef, ::NoRData) = p
 Mooncake.__verify_fdata_value(::IdDict{Any,Nothing}, ::CuDataRef, ::CuDataRef) = nothing
 
-@foldable fdata_type(::Type{CuPtr{T}}) where {T} = CuPtr{T}
+# CuPtr and CuArray tangent types.
+# CuPtr carries no differentiable content (it's a device address), so rdata is NoRData.
+# CuMaybeComplexArray (float/complex GPU arrays) is its own tangent — gradient arrays
+# have the same shape and element type as the primal.
+
+# For CuPtr{T}: if T has no differentiable content (tangent_type(T) = NoTangent) then the
+# pointer itself carries no gradient — e.g. CuPtr{Nothing} is a raw void pointer used only
+# for memory management.  For differentiable T (e.g. Float32) the CuPtr IS the fdata
+# (pointing to the tangent buffer on-device), so fdata = primal CuPtr.
+@unstable @foldable tangent_type(::Type{CuPtr{P}}) where {P} =
+    tangent_type(P) === NoTangent ? NoTangent : CuPtr{tangent_type(P)}
+@foldable fdata_type(::Type{CuPtr{T}}) where {T} =
+    tangent_type(T) === NoTangent ? NoFData : CuPtr{T}
 @foldable rdata_type(::Type{CuPtr{T}}) where {T} = NoRData
 @foldable tangent_type(::Type{P}) where {P<:CuMaybeComplexArray} = P
 @foldable tangent_type(::Type{P}, ::Type{NoRData}) where {P<:CuMaybeComplexArray} = P
-@unstable @foldable tangent_type(::Type{CuPtr{P}}) where {P} = CuPtr{tangent_type(P)}
 @unstable @foldable tangent_type(::Type{CuRefValue{P}}) where {P} = CuRefValue{
     tangent_type(P)
 }
+
+# CuPtr{T} wraps a device address (an integer).  The generic zero_tangent_internal for
+# immutable structs does not apply here — construct a null device pointer directly.
+function zero_tangent_internal(x::CuPtr{T}, ::MaybeCache) where {T}
+    tangent_type(T) === NoTangent && return NoTangent()
+    CuPtr{tangent_type(T)}(UInt64(0))
+end
 
 # Non-differentiable CUDA handle, enum, and state types.
 #
@@ -114,7 +143,8 @@ Mooncake.__verify_fdata_value(::IdDict{Any,Nothing}, ::CuDataRef, ::CuDataRef) =
 # Ptr{tangent_type(P)}, and zero_tangent_internal(::Ptr, ::MaybeCache) throws
 # unconditionally.  Both must be overridden for each concrete opaque pointer type.
 #
-# Plain struct/enum types: only tangent_type needs overriding (NoTangent stops traversal).
+# Only the non-primitive opaque C pointer types need explicit registration here; all
+# @cenum (primitive) types are handled by the programmatic loop further below.
 for (_cuda_opaque_t, _is_ptr) in [
     # --- opaque C handle/descriptor Ptr types (CUBLAS) ---
     (CUmemPoolHandle_st, true),
@@ -140,18 +170,6 @@ for (_cuda_opaque_t, _is_ptr) in [
     (CUSPARSE.cusparseSpSMDescr, true),
     (CUSPARSE.cusparseSpGEMMDescr, true),
     (CUSPARSE.cusparseSpMMOpPlan, true),
-    # --- CUBLAS enum/status types ---
-    (CUBLAS.cublasOperation_t, false),
-    (CUBLAS.cublasComputeType_t, false),
-    (CUBLAS.cublasStatus_t, false),
-    (CUBLAS.cublasGemmAlgo_t, false),
-    # --- other non-differentiable CUDA types ---
-    (libraryPropertyType, false),
-    (CUdevice_attribute_enum, false),
-    (CUBLAS.cublasPointerMode_t, false),
-    (CUBLAS.cublasFillMode_t, false),
-    (CUBLAS.cublasDiagType_t, false),
-    (cudaError_enum, false),
     # CuStream contains Ptr/Bool/CuContext fields; without NoTangent, Mooncake generates a
     # MutableTangent that propagates into task-local CUDA state → SIGILL at runtime.
     (CuStream, false),
@@ -166,17 +184,6 @@ for (_cuda_opaque_t, _is_ptr) in [
     (CUSOLVER.cusolverDnIRSParams_t, true),
     (CUSOLVER.cusolverDnIRSInfos_t, true),
     (CUSOLVER.cusolverDnParams_t, true),
-    # --- CUSOLVER enum/status types ---
-    (CUSOLVER.cusolverDnFunction_t, false),
-    (CUSOLVER.cusolverEigMode_t, false),
-    (CUSOLVER.cusolverEigType_t, false),
-    (CUSOLVER.cusolverEigRange_t, false),
-    (CUSOLVER.cusolverNorm_t, false),
-    (CUSOLVER.cusolverIRSRefinement_t, false),
-    (CUSOLVER.cusolverAlgMode_t, false),
-    (CUSOLVER.cusolverStorevMode_t, false),
-    (CUSOLVER.cusolverDirectMode_t, false),
-    (CUSOLVER.cusolverDeterministicMode_t, false),
 ]
     if _is_ptr
         @eval tangent_type(::Type{Ptr{$_cuda_opaque_t}}) = NoTangent
@@ -186,18 +193,116 @@ for (_cuda_opaque_t, _is_ptr) in [
     end
 end
 
+# CUDA @cenum types are primitive types (integer-backed C enums) — never differentiable.
+# Mooncake's generic tangent_type @generated function errors on primitive types with no
+# registered method, so we register all of them here programmatically.
+# Filter: parentmodule(T) must be one of the CUDA family modules, to avoid accidentally
+# re-registering standard Julia primitive types (Bool, Int32, Float64, ...) that happen
+# to be visible in the CUDA namespace.
+let _cuda_family = (parentmodule(CUBLAS), CUBLAS, CUSPARSE, CUSOLVER)
+    _cenum_seen = Set{DataType}()
+    for _mod in _cuda_family
+        for _nm in names(_mod; all=true)
+            _T = try
+                getfield(_mod, _nm)
+            catch
+                nothing
+            end
+            _T isa DataType || continue
+            isprimitivetype(_T) || continue
+            parentmodule(_T) in _cuda_family || continue
+            _T in _cenum_seen && continue
+            push!(_cenum_seen, _T)
+            # tangent_type throws for unregistered primitives — catch means not yet registered
+            (
+                try
+                    tangent_type(_T) === NoTangent
+                catch
+                    false
+                end
+            ) && continue
+            @eval tangent_type(::Type{$_T}) = NoTangent
+        end
+    end
+end
+
+# Concrete field types of each CuDataRef (e.g. RefCounted, Managed, ...) are also
+# non-differentiable memory-management internals.  Without this, Mooncake infers
+# MutableTangent for them structurally, conflicting with the NoFData our lgetfield rules
+# return and causing a TypeError typeassert at runtime.  We recurse into each registered
+# type's fields to catch arbitrarily nested mutable structs (e.g. Managed inside
+# RefCounted).
+#
+# _seen is pre-seeded with the CuDataRef root types — those are already registered with
+# tangent_type = P (opaque/self) above, so must not be overwritten with NoTangent here.
+# The tangent_type(T) === NoTangent guard additionally skips types already registered by
+# the main opaque-types loop (e.g. CuStream), preventing duplicate-method errors.
+let _seen = Set{DataType}(Base.uniontypes(CuDataRef))
+    function _register_cuda_internal!(T)
+        T isa DataType || return nothing
+        T ∈ _seen && return nothing
+        push!(_seen, T)
+        isconcretetype(T) && ismutabletype(T) || return nothing
+        already_registered = try
+            tangent_type(T) === NoTangent
+        catch
+            false
+        end
+        already_registered && return nothing
+        @eval tangent_type(::Type{$T}) = NoTangent
+        @eval tangent_type(::Type{$T}, ::Type{NoRData}) = NoTangent
+        for _i in 1:fieldcount(T)
+            _register_cuda_internal!(fieldtype(T, _i))
+        end
+    end
+    for _T in Base.uniontypes(CuDataRef)
+        for _i in 1:fieldcount(_T)
+            _register_cuda_internal!(fieldtype(_T, _i))
+        end
+    end
+end
+
 # CUDA runtime state functions — non-differentiable, must be registered as primitives.
+# Without this, Mooncake's forward-mode interpreter traces into CUDA's task-local-storage
+# machinery.  Those internals contain type assertions on the concrete stored types; when
+# called with Dual-wrapped arguments the assertions fail, producing `Unreachable` in
+# generated IR → SIGILL at runtime.
+#
+# task_local_state!() is the root entry point: all library handle() functions and
+# active_state() call it to retrieve the per-task device/context/stream state.
 @zero_derivative MinimalCtx Tuple{typeof(task_local_state!)}
+# active_state() wraps task_local_state!() and returns a NamedTuple{device,context,stream,
+# math_mode}.  Registering it separately covers call sites that bypass task_local_state!.
 @zero_derivative MinimalCtx Tuple{typeof(active_state)}
+# CUBLAS.version() queries the runtime library version via cublasGetProperty (a ccall).
+# Returns a constant VersionNumber — not differentiable.
 @zero_derivative MinimalCtx Tuple{typeof(CUBLAS.version)}
+# Library handle() functions retrieve per-task C pointers to CUBLAS/CUSPARSE contexts.
 @zero_derivative MinimalCtx Tuple{typeof(CUBLAS.handle)}
 @zero_derivative MinimalCtx Tuple{typeof(CUSPARSE.handle)}
+# cuDeviceGetAttribute queries a static integer device property (e.g. warp size, max
+# threads per block).  Returns an Int — not differentiable.  Signature matches the
+# internal call: cuDeviceGetAttribute(Ref{Cint}(), attrib, dev) from CUDA.attribute.
 @zero_derivative MinimalCtx Tuple{
     typeof(cuDeviceGetAttribute),Base.RefValue{Int32},CUdevice_attribute_enum,CuDevice
 }
+# attribute() is the public wrapper around cuDeviceGetAttribute; registering it avoids
+# tracing into the ccall at call sites that use the high-level API.
 @zero_derivative MinimalCtx Tuple{typeof(attribute),CuDevice,CUdevice_attribute_enum}
-
+# is_capturing / capture_status query whether the current stream is being graph-captured.
+# They create Ref{CUstreamCaptureStatus_enum}() locally for a ccall output parameter.
+# Without these rules, Mooncake traces into them and attempts to compute
+# tangent_type(CUstreamCaptureStatus_enum), which fails for primitive types with no
+# registered method.  Registering @cenum types above handles the type-level issue, but
+# these @zero_derivative rules additionally avoid any tracing overhead.
+@zero_derivative MinimalCtx Tuple{typeof(is_capturing)}
+@zero_derivative MinimalCtx Tuple{typeof(is_capturing),CuStream}
+@zero_derivative MinimalCtx Tuple{typeof(capture_status)}
+@zero_derivative MinimalCtx Tuple{typeof(capture_status),CuStream}
 # CuArray{<:Integer} and CuArray{<:Bool} are index/mask arrays — not differentiable.
+# Assigning NoTangent stops Mooncake from building a struct tangent from CuArray's
+# internal fields (data::CuDataRef, maxsize::Int, offset::Int, dims::NTuple).
+# The CuMaybeComplexArray rule above takes priority for float and complex arrays.
 tangent_type(::Type{<:CuArray{<:Union{Integer,Bool}}}) = NoTangent
 tangent_type(::Type{<:CuArray{<:Union{Integer,Bool}}}, ::Type{NoRData}) = NoTangent
 
@@ -225,6 +330,13 @@ function TestUtils.has_equal_data_internal(
     # allow nan comparisons to return true, real() to cover complex case
     return isapprox(x, y; atol=(√eps(real(eltype(P)))), nans=true)
 end
+function TestUtils.has_equal_data_internal(
+    x::P, y::P, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+) where {P<:CuArray{<:Union{Integer,Bool}}}
+    # For integer/bool CuArrays, compare by content by downloading to CPU.
+    size(x) != size(y) && return false
+    return Array(x) == Array(y)
+end
 function increment_internal!!(c::IncCache, x::A, y::A) where {A<:CuMaybeComplexArray}
     (x === y || haskey(c, x)) && return x
     c[x] = true
@@ -240,7 +352,7 @@ function _add_to_primal_internal(
     key = (x, y, unsafe)
     haskey(c, key) && return c[key]::P
     x′ = x + y
-    c[(x, y, unsafe)] = x′
+    c[key] = x′
     return x′
 end
 function primal_to_tangent_internal!!(t, x::CuMaybeComplexArray, c::MaybeCache)
@@ -280,9 +392,8 @@ function Mooncake.__verify_fdata_value(::IdDict{Any,Nothing}, p::CuArray, f::CuA
     return nothing
 end
 
-# @from_chainrules tools
-# CuArray is its own tangent type and ChainRules also uses CuArray directly as the
-# tangent, so mooncake_tangent is the identity.
+# ChainRules interop.  CuArray is its own tangent in both Mooncake and ChainRules,
+# so to_cr_tangent and mooncake_tangent are identity operations.
 mooncake_tangent(::CuMaybeComplexArray, t::CuMaybeComplexArray) = t
 to_cr_tangent(x::CuMaybeComplexArray) = x
 function increment_and_get_rdata!(f::T, ::NoRData, t::T) where {T<:CuMaybeComplexArray}
@@ -290,7 +401,7 @@ function increment_and_get_rdata!(f::T, ::NoRData, t::T) where {T<:CuMaybeComple
     return NoRData()
 end
 
-# Basic rules for operating on CuArrays.
+# CuArray construction and reshape.
 
 # Primitive (not _new_) because GPU allocation happens inside the constructor body before
 # the `new` call; tracing through it would hit CUDA-internal machinery.
@@ -343,8 +454,9 @@ function rrule!!(
     return CoDual(y, dy), NoPullback(ntuple(_ -> NoRData(), 6))
 end
 
-# getfield / lgetfield rules for CuArray.
-# CuArray has 4 fields: data (1, differentiable DataRef), maxsize (2), offset (3), dims (4).
+# lgetfield rules for CuArray.  CuArray has 4 fields:
+#   :data (field 1) — the DataRef handle; tangent flows here
+#   :maxsize (field 2), :offset (field 3), :dims (field 4) — non-differentiable metadata
 function frule!!(
     ::Dual{typeof(lgetfield)},
     x::Dual{<:CuArray,<:CuArray},
@@ -384,8 +496,6 @@ function rrule!!(
     dy = is_data ? x.dx.data : NoFData()
     return CoDual(y, dy), NoPullback(ntuple(_ -> NoRData(), 3))
 end
-
-# Rule for `sum` is defined as a performance rule.
 # See also `src/rules/performance_patches`.
 @is_primitive(DefaultCtx, Tuple{typeof(sum),CuFloatArray})
 function frule!!(::Dual{typeof(sum)}, x::Dual{<:CuFloatArray})

--- a/ext/MooncakeCUDAExt/ndual.jl
+++ b/ext/MooncakeCUDAExt/ndual.jl
@@ -1,0 +1,833 @@
+# ── NDual: N-wide dual number for GPU kernel forward-mode AD ──────────────────────
+# This type lives entirely within the CUDA extension and is not exported from
+# Mooncake core.  All GPU broadcast forward-mode rules use it internally.
+#
+# ── Role of `ntuple` ──────────────────────────────────────────────────────────────
+# `ntuple(f, Val(N))` is the workhorse for constructing and transforming NDual
+# partials.  Its role differs by context:
+#
+#   On the CPU (rule setup, before kernel launch):
+#     ntuple(f, Val(N)) also unrolls at compile time — Julia's Base implementation
+#     is @generated and emits N independent expressions, which LLVM then sees as a
+#     fixed-size tuple and may vectorise (e.g. a single <N x double> select for the
+#     standard-basis seed).  So seed construction:
+#       NDual{T,N}(x, ntuple(i -> i == k ? one(T) : zero(T), Val(N)))
+#     is branchless on CPU too.  Performance is not critical here because this runs
+#     once per input slot (host code), not once per array element.
+#
+#   Inside GPU kernels (arithmetic rules):
+#     ntuple(f, Val(N)) with a statically-known N unrolls to N independent PTX
+#     instructions at compile time — no loop, no heap allocation, no runtime
+#     dispatch.  LLVM/NVVM sees a fixed-size tuple and vectorises each partial
+#     slot independently, keeping everything in registers.  This is the key reason
+#     N is a *type parameter* and not a runtime integer: the unrolling requires N
+#     to be a compile-time constant.
+#
+# !! GPU KERNEL ARITHMETIC — PREFER BRANCHLESS OPERATIONS !!
+# NDual arithmetic executes inside GPU kernels. Prefer `ifelse(cond, a, b)` over
+# `cond ? a : b` or `if/else` blocks: `ifelse` evaluates both branches
+# unconditionally and reliably lowers to a single PTX `selp` instruction.
+# `?:` may also be optimised to `selp` by LLVM for simple scalar expressions,
+# but this is not guaranteed — for data-dependent conditions (values that differ
+# across threads) an unoptimised branch causes warp divergence.
+
+"""
+    NDual{T<:IEEEFloat, N} <: Real
+
+An N-wide dual number: carries one primal `value::T` and `N` partial derivatives
+`partials::NTuple{N,T}`.  It is a plain `isbits` type — lives in GPU registers and
+compiles to PTX without heap allocation.
+
+## Analogy to ForwardDiff chunk mode
+
+ForwardDiff's chunk mode computes N directional derivatives simultaneously by using
+`ForwardDiff.Dual{Tag,T,N}` — a dual number with N partial slots.  `NDual{T,N}` is
+the same idea, stripped of the tag parameter and defined entirely within Mooncake:
+
+| Type                         | Tangent width | Tag parameter | Use case                        |
+|------------------------------|---------------|---------------|---------------------------------|
+| `Dual{P,T}`                  | 1             | n/a           | Standard `frule!!` dispatch     |
+| `ForwardDiff.Dual{Tag,T,N}`  | N             | yes           | ForwardDiff chunk mode          |
+| `NDual{T,N}`                 | N             | no            | GPU kernel widening (this type) |
+
+`NDual` is a drop-in replacement for `ForwardDiff.Dual` in GPU broadcast kernels.
+Removing the tag simplifies the type signature and eliminates the ForwardDiff
+dependency from GPU AD.  The arithmetic rules are identical: each operation applies
+the chain rule to all N slots at once.
+
+## NDual vs Dual: scalar leaves and flattening
+
+`Dual{P,T}` wraps any differentiable value `P` — it threads through Mooncake's
+tangent system and handles arbitrary structs transparently.
+
+`NDual{T,N}` only wraps **scalar IEEEFloat (or Complex{IEEEFloat}) leaves**.
+For a complex input type (e.g. a struct with several float fields), you must
+**flatten** it to its scalar leaves before wrapping:
+
+```
+struct S; a::Float64; b::ComplexF64; end   # dof = 3 slots
+
+S(a, b) → flatten → [a, re(b), im(b)]
+             ↓ wrap each leaf as NDual{Float64,3}(x, eₖ)
+             ↓ kernel runs
+             ↓ extract partials
+             ↓ unflatten → Tangent{S}(∂a, Complex(∂re_b, ∂im_b))
+```
+
+GPU kernels cannot receive a Dict or arbitrary struct; flattening to scalars
+must happen on the CPU before launch, and gradient reassembly happens on the
+CPU after.  The broadcast rule in `MooncakeCUDAExt.jl` implements this for the
+specific node types that appear in a `Broadcasted` tree
+(`_gpu_bcast_leaves` / `_gpu_fill_args_rdata`).
+
+## Complex support
+
+For complex inputs the kernel uses `Complex{NDual{T,N}}` where each component
+(`re`, `im`) carries its own N partials.  Julia's generic `Complex` arithmetic
+(`+`, `*`, `sin`, etc.) composes with `NDual` naturally because `NDual <: Real`.
+
+## Usage in GPU kernels
+
+```julia
+# Wrap input scalar at slot k (1-indexed) out of N total slots
+d = NDual{T,N}(x, ntuple(j -> T(j == k), Val(N)))
+
+# After kernel: extract primal and k-th partial
+v  = ndual_value(d)
+dk = ndual_partial(d, k)
+```
+
+To extend to a new scalar type S (non-IEEEFloat): define `_broadcast_elem_dof_type(::Type{S})`
+and handle the wrapping / gradient extraction in `_leaf_effective_tangent`,
+`materialize_pb!!`, and `_gpu_fill_args_rdata` in `MooncakeCUDAExt.jl`.
+
+## Chunk-mode AD via NForwardMode{N}
+
+### Background: Mooncake forward mode is width-1
+
+Mooncake's forward mode computes one JVP per pass. `DerivedFRule` is called **once**
+with all arguments seeded simultaneously:
+
+```julia
+value_and_derivative!!(cache, (f, df), (x, dx), (y, dy))
+# computes:  ḟ = ∂f/∂f·df + ∂f/∂x·dx + ∂f/∂y·dy  — one direction
+```
+
+To recover the full Jacobian of `f : ℝⁿ → ℝᵐ`, the caller must invoke the rule **n
+times**, once per basis vector `eₖ`.  There is no built-in chunk loop.  This is why
+reverse mode is preferred for many-input scalar-output functions, and why NDual's GPU
+trick — packing N directions into one kernel launch — is only worthwhile at GPU kernel
+boundaries where each pass would otherwise incur a full launch overhead.
+
+### Why standard `frule!!` cannot carry NDual tangents
+
+`Dual{P,T}` enforces `T = tangent_type(P)`.  For `P = Float64`, `tangent_type` returns
+`Float64` (width-1).  Stuffing `NDual{Float64,N}` into the tangent slot would require
+`tangent_type(Float64) = NDual{Float64,N}` globally, infecting every `frule!!` in the
+call graph and breaking type coherence throughout.
+
+### NForwardMode{N}: NDual as the tangent type
+
+The clean solution is a new AD context that overrides `tangent_type` for scalar leaves:
+
+```julia
+struct NForwardMode{N} end
+
+# NDual is the tangent type — value field=0 by convention, partials carry N directions
+tangent_type(::NForwardMode{N}, ::Type{T}) where {N, T<:IEEEFloat}          = NDual{T,N}
+tangent_type(::NForwardMode{N}, ::Type{Complex{T}}) where {N, T<:IEEEFloat} = Complex{NDual{T,N}}
+
+zero_ntangent(::Val{N}, ::Type{T}) where {N,T<:IEEEFloat} =
+    NDual{T,N}(zero(T), ntuple(_ -> zero(T), Val(N)))
+seed_ntangent(::Val{N}, ::Type{T}, k::Int) where {N,T<:IEEEFloat} =
+    NDual{T,N}(zero(T), ntuple(i -> i == k ? one(T) : zero(T), Val(N)))
+```
+
+**The transform change is surgical**: `generate_dual_ir` calls `dual_type(P)` at 7
+sites to assign IR argument types.  Threading the mode through those calls is the only
+required modification — all statement rewriting (PhiNode, ReturnNode, GotoIfNot, …) is
+tangent-type-agnostic.  `is_primitive` dispatch is unchanged (it operates on primal
+signatures, not tangent types).
+
+### Scalar `frule!!`s and CPU compatibility
+
+Rules written generically in the tangent require no changes:
+
+```julia
+# Existing frule!! for sin — tangent(x)::NDual{T,N} in NForwardMode
+frule!!(::Dual{typeof(sin)}, x::Dual{T}) where {T<:IEEEFloat} =
+    Dual(sin(primal(x)), cos(primal(x)) * tangent(x))
+#                        ^^^^^^^^^^^^^^^^ T (scalar) * NDual{T,N} → NDual{T,N}  ✓
+```
+
+`cos(x) * NDual` scales the partials — already defined on NDual.  All chain rules
+composed of scalar multiplication and addition propagate the N directions automatically.
+
+**Two categories of CPU scalar rules:**
+
+1. **`@from_chainrules` rules** (`sin`, `cos`, `exp`, …) — routed through `frule_wrapper`
+   → `CRC.frule(tangents, primal...)`.  The ChainRules rule body does arithmetic like
+   `cos(x) * ẋ` where `ẋ::NDual`.  These work transparently with NDual because NDual
+   defines all the required scalar operations.
+
+2. **Hand-coded rules using `nan_tangent_guard`** (`log`, `sqrt`, `cbrt`, …) —
+   `nan_tangent_guard` is explicitly constrained to `IEEEFloat | Complex{<:IEEEFloat}`.
+   Passing an NDual tangent would produce a `MethodError`.  An `NDual` overload of
+   `nan_tangent_guard` would be needed to use these functions inside `NForwardMode{N}`.
+
+In practice `NForwardMode{N}` is designed for **GPU kernel boundaries** where each
+width-1 pass costs a full kernel launch.  For CPU scalar ops the overhead is negligible
+and there is no motivation to use chunk mode.
+
+### `frule!!` template in NForwardMode
+
+This pattern applies at any opaque boundary — most commonly a GPU kernel, but equally
+valid for any CPU operation that needs an explicit N-wide rule (e.g. to override a
+hand-coded rule that uses `nan_tangent_guard`, or to differentiate through an external
+library call).  The only difference between GPU and CPU versions is the array type
+(`CuArray` vs `Array`) and the absence of a kernel launch on CPU.
+
+In NForwardMode the tangent of a `CuArray{T}` arg is `CuArray{NDual{T,N}}`, so the
+NDual kernel input is built by a trivial merge — no `flatten_to_ndual` needed:
+
+```julia
+function frule!!(
+    ::Dual{typeof(my_kernel!)},
+    _out::Dual{<:CuArray{T}, <:CuArray{NDual{T,N}}},
+    _x  ::Dual{<:CuArray{T}, <:CuArray{NDual{T,N}}},
+) where {T<:IEEEFloat, N}
+    out, ∂out = primal(_out), tangent(_out)   # ∂out updated in-place
+    x,   ∂x  = primal(_x),   tangent(_x)
+
+    # Merge primal values with tangent directions into NDual kernel input.
+    # ∂x[i].value == 0 (convention); ∂x[i].partials holds the N seed directions.
+    x_nd   = map((v, t) -> NDual{T,N}(v, t.partials), x, ∂x)
+    out_nd = similar(out, NDual{T,N})
+    my_kernel!(out_nd, x_nd)   # one launch — all N directions at once
+
+    out  .= ndual_value.(out_nd)
+    ∂out .= map(d -> NDual{T,N}(zero(T), d.partials), out_nd)
+    return _out
+end
+```
+
+### Full Jacobian in one call
+
+```julia
+function full_jacobian(f!, out::CuArray{T}, x::CuArray{T}) where {T}
+    N  = length(x)
+    ∂x  = CuArray([seed_ntangent(Val(N), T, i) for i in 1:N])
+    ∂out = fill!(similar(out, NDual{T,N}), zero_ntangent(Val(N), T))
+
+    rule = build_frule(NForwardMode{N}(), typeof(f!), CuArray{T}, CuArray{T})
+    rule(Dual(f!, NoTangent()), Dual(out, ∂out), Dual(x, ∂x))
+
+    # ∂out[i].partials == (∂out[i]/∂x[1], …, ∂out[i]/∂x[N]) — full m×N Jacobian
+    J = [ndual_partial.(∂out, k) for k in 1:N]
+    return ndual_value.(out), J
+end
+```
+
+Versus N separate width-1 passes, NForwardMode{N} needs **one** pass.  NDual is the
+natural tangent type because its arithmetic is already register-friendly and no
+conversion is needed at the kernel boundary.
+
+### Open challenges
+
+- Non-float leaves (`Int`, `Bool`, …) carry zero partial and must bypass NDual wrapping.
+- Mixed-precision structs (`Float32` + `Float64` fields) require a promoted `T` or
+  separate NDual blocks per precision group.
+- `NForwardMode{N}` requires N to be chosen before compilation; adaptive chunk sizing
+  (as in ForwardDiff) would need dynamic dispatch or recompilation.
+"""
+struct NDual{T<:IEEEFloat,N} <: Real
+    value::T
+    partials::NTuple{N,T}
+end
+
+# ── Constructors ─────────────────────────────────────────────────────────────────
+
+# Promote a plain scalar to a NDual with zero partials (acts as a constant).
+NDual{T,N}(x::Real) where {T<:IEEEFloat,N} = NDual{T,N}(T(x), ntuple(_ -> zero(T), Val(N)))
+
+# ── Accessors ────────────────────────────────────────────────────────────────────
+
+@inline ndual_value(d::NDual) = d.value
+@inline ndual_partial(d::NDual, k::Int) = d.partials[k]
+@inline ndual_partials(d::NDual) = d.partials
+
+# ── NTuple arithmetic helpers ─────────────────────────────────────────────────────
+# All fully unrolled at compile time via Val(N) — safe for GPU registers.
+
+@inline _pt_scale(p::NTuple{N,T}, s::T) where {N,T} = ntuple(i -> s * p[i], Val(N))
+@inline _pt_add(p::NTuple{N,T}, q::NTuple{N,T}) where {N,T} = ntuple(
+    i -> p[i] + q[i], Val(N)
+)
+@inline _pt_sub(p::NTuple{N,T}, q::NTuple{N,T}) where {N,T} = ntuple(
+    i -> p[i] - q[i], Val(N)
+)
+@inline _pt_neg(p::NTuple{N,T}) where {N,T} = ntuple(i -> -p[i], Val(N))
+@inline _pt_zero(::Val{N}, ::Type{T}) where {N,T} = ntuple(_ -> zero(T), Val(N))
+
+# ── AbstractFloat traits (needed for promote_rule with Complex etc.) ──────────────
+
+Base.float(a::NDual) = a
+Base.AbstractFloat(a::NDual) = a
+Base.floatmin(::Type{NDual{T,N}}) where {T,N} = NDual{T,N}(floatmin(T))
+Base.floatmax(::Type{NDual{T,N}}) where {T,N} = NDual{T,N}(floatmax(T))
+Base.typemin(::Type{NDual{T,N}}) where {T,N} = NDual{T,N}(typemin(T))
+Base.typemax(::Type{NDual{T,N}}) where {T,N} = NDual{T,N}(typemax(T))
+
+# ── Zero / One ────────────────────────────────────────────────────────────────────
+
+Base.zero(::NDual{T,N}) where {T,N} = NDual{T,N}(zero(T), _pt_zero(Val(N), T))
+Base.one(::NDual{T,N}) where {T,N} = NDual{T,N}(one(T), _pt_zero(Val(N), T))
+Base.zero(::Type{NDual{T,N}}) where {T,N} = NDual{T,N}(zero(T), _pt_zero(Val(N), T))
+Base.one(::Type{NDual{T,N}}) where {T,N} = NDual{T,N}(one(T), _pt_zero(Val(N), T))
+
+# ── Promotion / Conversion ────────────────────────────────────────────────────────
+
+function Base.convert(::Type{NDual{T,N}}, x::Real) where {T,N}
+    NDual{T,N}(T(x), _pt_zero(Val(N), T))
+end
+Base.convert(::Type{NDual{T,N}}, d::NDual{T,N}) where {T,N} = d
+
+function Base.promote_rule(::Type{NDual{T,N}}, ::Type{S}) where {T,N,S<:Real}
+    NDual{promote_type(T, S),N}
+end
+Base.promote_rule(::Type{NDual{T,N}}, ::Type{NDual{T,N}}) where {T,N} = NDual{T,N}
+# Cross-precision: NDual{Float32,N} op NDual{Float64,N} → NDual{Float64,N}
+function Base.promote_rule(::Type{NDual{T1,N}}, ::Type{NDual{T2,N}}) where {T1,T2,N}
+    NDual{promote_type(T1, T2),N}
+end
+function Base.convert(::Type{NDual{T,N}}, d::NDual{S,N}) where {T,N,S<:IEEEFloat}
+    NDual{T,N}(T(d.value), ntuple(i -> T(d.partials[i]), Val(N)))
+end
+
+# ── Arithmetic ────────────────────────────────────────────────────────────────────
+
+function Base.:+(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    NDual{T,N}(a.value + b.value, _pt_add(a.partials, b.partials))
+end
+function Base.:-(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    NDual{T,N}(a.value - b.value, _pt_sub(a.partials, b.partials))
+end
+Base.:-(a::NDual{T,N}) where {T,N} = NDual{T,N}(-a.value, _pt_neg(a.partials))
+
+# Product rule: d(a*b) = a*db + b*da
+function Base.:*(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    return NDual{T,N}(
+        a.value * b.value,
+        _pt_add(_pt_scale(a.partials, b.value), _pt_scale(b.partials, a.value)),
+    )
+end
+
+# Quotient rule: d(a/b) = (da - (a/b)*db) / b
+function Base.:/(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    v = a.value / b.value
+    return NDual{T,N}(
+        v, _pt_scale(_pt_sub(a.partials, _pt_scale(b.partials, v)), inv(b.value))
+    )
+end
+
+Base.inv(a::NDual{T,N}) where {T,N} = one(NDual{T,N}) / a
+
+Base.muladd(a::NDual{T,N}, b::NDual{T,N}, c::NDual{T,N}) where {T,N} = a * b + c
+
+# ── Integer and real power ────────────────────────────────────────────────────────
+
+# d(x^n) = n * x^(n-1) * dx  (ifelse keeps this branchless; see file header)
+function Base.:^(a::NDual{T,N}, n::Integer) where {T,N}
+    v = a.value^n
+    dv = ifelse(iszero(n), zero(T), T(n) * a.value^(n - 1))
+    return NDual{T,N}(v, _pt_scale(a.partials, dv))
+end
+
+function Base.:^(a::NDual{T,N}, b::Real) where {T,N}
+    v = a.value^T(b)
+    dv = ifelse(iszero(T(b)), zero(T), T(b) * a.value^(T(b) - one(T)))
+    return NDual{T,N}(v, _pt_scale(a.partials, dv))
+end
+
+function Base.:^(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    # d(a^b) = a^b * (b/a * da + log(a) * db)
+    v = a.value^b.value
+    coeff_a = b.value / a.value
+    coeff_b = log(a.value)
+    return NDual{T,N}(
+        v,
+        _pt_scale(
+            _pt_add(_pt_scale(a.partials, coeff_a), _pt_scale(b.partials, coeff_b)), v
+        ),
+    )
+end
+
+# d(b^a)/da = b^a * log(b)  (b a plain Real, a the NDual)
+function Base.:^(b::Real, a::NDual{T,N}) where {T,N}
+    v = T(b)^a.value
+    NDual{T,N}(v, _pt_scale(a.partials, v * T(log(b))))
+end
+
+# ── Math functions ─────────────────────────────────────────────────────────────────
+# Each follows: f(Dual(v,p)) = Dual(f(v), f'(v)*p)
+
+# Trig
+function Base.sin(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(sin(a.value), _pt_scale(a.partials, cos(a.value)))
+end
+function Base.cos(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(cos(a.value), _pt_scale(a.partials, -sin(a.value)))
+end
+function Base.tan(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(tan(a.value), _pt_scale(a.partials, inv(cos(a.value))^2))
+end
+function Base.asin(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(asin(a.value), _pt_scale(a.partials, inv(sqrt(one(T) - a.value^2))))
+end
+function Base.acos(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(acos(a.value), _pt_scale(a.partials, -inv(sqrt(one(T) - a.value^2))))
+end
+function Base.atan(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(atan(a.value), _pt_scale(a.partials, inv(one(T) + a.value^2)))
+end
+function Base.atan(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    r2 = a.value^2 + b.value^2
+    return NDual{T,N}(
+        atan(a.value, b.value),
+        _pt_scale(
+            _pt_sub(_pt_scale(a.partials, b.value), _pt_scale(b.partials, a.value)), inv(r2)
+        ),
+    )
+end
+
+# Hyperbolic
+function Base.sinh(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(sinh(a.value), _pt_scale(a.partials, cosh(a.value)))
+end
+function Base.cosh(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(cosh(a.value), _pt_scale(a.partials, sinh(a.value)))
+end
+function Base.tanh(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(tanh(a.value), _pt_scale(a.partials, one(T) - tanh(a.value)^2))
+end
+function Base.asinh(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(asinh(a.value), _pt_scale(a.partials, inv(sqrt(a.value^2 + one(T)))))
+end
+function Base.acosh(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(acosh(a.value), _pt_scale(a.partials, inv(sqrt(a.value^2 - one(T)))))
+end
+function Base.atanh(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(atanh(a.value), _pt_scale(a.partials, inv(one(T) - a.value^2)))
+end
+
+# Reciprocal hyperbolic: sech, csch, coth and their inverses.
+function Base.sech(a::NDual{T,N}) where {T,N}
+    sv = sech(a.value)
+    NDual{T,N}(sv, _pt_scale(a.partials, -tanh(a.value) * sv))
+end
+function Base.csch(a::NDual{T,N}) where {T,N}
+    cv = csch(a.value)
+    NDual{T,N}(cv, _pt_scale(a.partials, -coth(a.value) * cv))
+end
+function Base.coth(a::NDual{T,N}) where {T,N}
+    sv = csch(a.value)
+    NDual{T,N}(coth(a.value), _pt_scale(a.partials, -(sv^2)))
+end
+function Base.asech(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(
+        asech(a.value), _pt_scale(a.partials, -inv(a.value * sqrt(one(T) - a.value^2)))
+    )
+end
+function Base.acsch(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(
+        acsch(a.value), _pt_scale(a.partials, -inv(abs(a.value) * sqrt(one(T) + a.value^2)))
+    )
+end
+function Base.acoth(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(acoth(a.value), _pt_scale(a.partials, inv(one(T) - a.value^2)))
+end
+
+# Exp / Log
+function Base.exp(a::NDual{T,N}) where {T,N}
+    (ev=exp(a.value); NDual{T,N}(ev, _pt_scale(a.partials, ev)))
+end
+function Base.exp2(a::NDual{T,N}) where {T,N}
+    (ev=exp2(a.value); NDual{T,N}(ev, _pt_scale(a.partials, ev * T(log(2)))))
+end
+function Base.exp10(a::NDual{T,N}) where {T,N}
+    (ev=exp10(a.value); NDual{T,N}(ev, _pt_scale(a.partials, ev * T(log(10)))))
+end
+function Base.log(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(log(a.value), _pt_scale(a.partials, inv(a.value)))
+end
+function Base.log2(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(log2(a.value), _pt_scale(a.partials, inv(a.value * T(log(2)))))
+end
+function Base.log10(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(log10(a.value), _pt_scale(a.partials, inv(a.value * T(log(10)))))
+end
+function Base.log1p(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(log1p(a.value), _pt_scale(a.partials, inv(one(T) + a.value)))
+end
+function Base.expm1(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(expm1(a.value), _pt_scale(a.partials, exp(a.value)))
+end
+
+# Two-argument log: log(b, x) = log(x)/log(b); d/dx = inv(x * log(b)).
+function Base.log(b::Real, a::NDual{T,N}) where {T,N}
+    NDual{T,N}(log(b, a.value), _pt_scale(a.partials, inv(a.value * T(log(b)))))
+end
+
+# ldexp(a, n) = a * 2^n — linear; derivative = 2^n.
+function Base.ldexp(a::NDual{T,N}, n::Integer) where {T,N}
+    NDual{T,N}(ldexp(a.value, n), _pt_scale(a.partials, T(exp2(n))))
+end
+
+# Roots
+function Base.sqrt(a::NDual{T,N}) where {T,N}
+    (sv=sqrt(a.value); NDual{T,N}(sv, _pt_scale(a.partials, inv(2 * sv))))
+end
+function Base.cbrt(a::NDual{T,N}) where {T,N}
+    (cv=cbrt(a.value); NDual{T,N}(cv, _pt_scale(a.partials, inv(3 * cv^2))))
+end
+
+# Absolute value and sign
+function Base.abs(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(abs(a.value), _pt_scale(a.partials, sign(a.value)))
+end
+function Base.abs2(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(abs2(a.value), _pt_scale(a.partials, 2 * a.value))
+end
+Base.sign(a::NDual{T,N}) where {T,N} = NDual{T,N}(sign(a.value), _pt_zero(Val(N), T))
+
+# sincos — fused sin+cos; returns (sin(a), cos(a)) as a tuple of NDuals.
+function Base.sincos(a::NDual{T,N}) where {T,N}
+    sv, cv = sincos(a.value)
+    NDual{T,N}(sv, _pt_scale(a.partials, cv)), NDual{T,N}(cv, _pt_scale(a.partials, -sv))
+end
+
+# sinpi / cospi — sin(π·x) and cos(π·x); derivative gains a π factor.
+function Base.sinpi(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(sinpi(a.value), _pt_scale(a.partials, T(π) * cospi(a.value)))
+end
+function Base.cospi(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(cospi(a.value), _pt_scale(a.partials, -T(π) * sinpi(a.value)))
+end
+
+# Reciprocal trigonometric: sec, csc, cot and their inverses.
+function Base.sec(a::NDual{T,N}) where {T,N}
+    sv = sec(a.value)
+    NDual{T,N}(sv, _pt_scale(a.partials, sv * tan(a.value)))
+end
+function Base.csc(a::NDual{T,N}) where {T,N}
+    cv = csc(a.value)
+    NDual{T,N}(cv, _pt_scale(a.partials, -cv * cot(a.value)))
+end
+function Base.cot(a::NDual{T,N}) where {T,N}
+    cv = cot(a.value)
+    NDual{T,N}(cv, _pt_scale(a.partials, -(one(T) + cv^2)))
+end
+function Base.asec(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(
+        asec(a.value), _pt_scale(a.partials, inv(abs(a.value) * sqrt(a.value^2 - one(T))))
+    )
+end
+function Base.acsc(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(
+        acsc(a.value), _pt_scale(a.partials, -inv(abs(a.value) * sqrt(a.value^2 - one(T))))
+    )
+end
+function Base.acot(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(acot(a.value), _pt_scale(a.partials, -inv(one(T) + a.value^2)))
+end
+
+# Degree-based trigonometric functions — argument in degrees, derivative gains π/180.
+function Base.sind(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(sind(a.value), _pt_scale(a.partials, T(deg2rad(cosd(a.value)))))
+end
+function Base.cosd(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(cosd(a.value), _pt_scale(a.partials, T(-deg2rad(sind(a.value)))))
+end
+function Base.tand(a::NDual{T,N}) where {T,N}
+    tv = tand(a.value)
+    NDual{T,N}(tv, _pt_scale(a.partials, T(deg2rad(one(T) + tv^2))))
+end
+function Base.secd(a::NDual{T,N}) where {T,N}
+    sv = secd(a.value)
+    NDual{T,N}(sv, _pt_scale(a.partials, T(deg2rad(sv * tand(a.value)))))
+end
+function Base.cscd(a::NDual{T,N}) where {T,N}
+    cv = cscd(a.value)
+    NDual{T,N}(cv, _pt_scale(a.partials, T(-deg2rad(cv * cotd(a.value)))))
+end
+function Base.cotd(a::NDual{T,N}) where {T,N}
+    cv = cotd(a.value)
+    NDual{T,N}(cv, _pt_scale(a.partials, T(-deg2rad(one(T) + cv^2))))
+end
+function Base.asind(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(
+        asind(a.value), _pt_scale(a.partials, inv(T(deg2rad(sqrt(one(T) - a.value^2)))))
+    )
+end
+function Base.acosd(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(
+        acosd(a.value), _pt_scale(a.partials, -inv(T(deg2rad(sqrt(one(T) - a.value^2)))))
+    )
+end
+function Base.atand(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(atand(a.value), _pt_scale(a.partials, inv(T(deg2rad(one(T) + a.value^2)))))
+end
+function Base.asecd(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(
+        asecd(a.value),
+        _pt_scale(a.partials, inv(T(deg2rad(abs(a.value) * sqrt(a.value^2 - one(T)))))),
+    )
+end
+function Base.acscd(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(
+        acscd(a.value),
+        _pt_scale(a.partials, -inv(T(deg2rad(abs(a.value) * sqrt(a.value^2 - one(T)))))),
+    )
+end
+function Base.acotd(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(acotd(a.value), _pt_scale(a.partials, -inv(T(deg2rad(one(T) + a.value^2)))))
+end
+
+# Angle unit conversions — linear transforms; derivative is the constant scale factor.
+function Base.deg2rad(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(deg2rad(a.value), _pt_scale(a.partials, T(deg2rad(one(T)))))
+end
+function Base.rad2deg(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(rad2deg(a.value), _pt_scale(a.partials, T(rad2deg(one(T)))))
+end
+
+# sinc(x) = sin(πx)/(πx) for x≠0, 1 at x=0; derivative = cosc(x).
+function Base.sinc(a::NDual{T,N}) where {T,N}
+    NDual{T,N}(sinc(a.value), _pt_scale(a.partials, T(cosc(a.value))))
+end
+
+# hypot — d/da hypot(a,b) = a / hypot(a,b), d/db = b / hypot(a,b).
+function Base.hypot(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    h = hypot(a.value, b.value)
+    NDual{T,N}(
+        h, _pt_add(_pt_scale(a.partials, a.value / h), _pt_scale(b.partials, b.value / h))
+    )
+end
+
+# min / max — subgradient: select the tangent of the winning branch.
+function Base.max(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    a.value >= b.value ? a : b
+end
+function Base.min(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    a.value <= b.value ? a : b
+end
+
+# clamp — subgradient: zero tangent at the clamped endpoints.
+function Base.clamp(a::NDual{T,N}, lo::NDual{T,N}, hi::NDual{T,N}) where {T,N}
+    a.value <= lo.value ? lo : (a.value >= hi.value ? hi : a)
+end
+function Base.clamp(a::NDual{T,N}, lo::Real, hi::Real) where {T,N}
+    a.value <= T(lo) ? NDual{T,N}(T(lo)) : (a.value >= T(hi) ? NDual{T,N}(T(hi)) : a)
+end
+
+# flipsign / copysign — sign of result determined by primal; tangent follows.
+function Base.flipsign(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    signbit(b.value) ? -a : a
+end
+function Base.copysign(a::NDual{T,N}, b::NDual{T,N}) where {T,N}
+    signbit(a.value) == signbit(b.value) ? a : -a
+end
+
+# ── Real / imag / conj — for Complex{NDual} to compose generically ────────────────
+# A NDual is always the "real part" of itself; conj is the identity for reals.
+
+Base.real(a::NDual) = a
+Base.imag(a::NDual{T,N}) where {T,N} = zero(NDual{T,N})
+Base.conj(a::NDual) = a
+Base.reim(a::NDual{T,N}) where {T,N} = (a, zero(NDual{T,N}))
+Base.isreal(::NDual) = true
+
+# ── Comparisons (on value only — for control flow in kernels) ──────────────────────
+
+Base.:<(a::NDual, b::NDual) = a.value < b.value
+Base.:>(a::NDual, b::NDual) = a.value > b.value
+Base.:<=(a::NDual, b::NDual) = a.value <= b.value
+Base.:>=(a::NDual, b::NDual) = a.value >= b.value
+Base.:(==)(a::NDual, b::NDual) = a.value == b.value
+Base.isless(a::NDual, b::NDual) = isless(a.value, b.value)
+Base.isnan(a::NDual) = isnan(a.value)
+Base.isinf(a::NDual) = isinf(a.value)
+Base.isfinite(a::NDual) = isfinite(a.value)
+Base.signbit(a::NDual) = signbit(a.value)
+
+# ── Utility ───────────────────────────────────────────────────────────────────────
+Base.eps(d::NDual) = eps(d.value)
+Base.eps(::Type{NDual{T,N}}) where {T,N} = eps(T)
+function Base.iszero(d::NDual{T,N}) where {T,N}
+    iszero(d.value) && all(iszero, d.partials)
+end
+Base.hash(d::NDual, hsh::UInt) = hash(d.value, hsh)
+
+# ── ifelse ────────────────────────────────────────────────────────────────────────
+# Standard subgradient convention: branch on primal, propagate selected tangent.
+
+Base.ifelse(c::Bool, a::NDual{T,N}, b::NDual{T,N}) where {T,N} = c ? a : b
+Base.complex(re::NDual{T,N}, im::NDual{T,N}) where {T,N} = Complex{NDual{T,N}}(re, im)
+
+# ── Complex{NDual} math — explicit GPU-safe implementations ───────────────────────
+# Julia's generic Complex math (sin, cos, exp, log, sqrt) calls float(T::Type) and
+# has isnan-guard branches that do not compile cleanly to PTX for custom T.
+# Explicit implementations use only NDual scalar ops and compile without issues.
+
+function Base.abs(z::Complex{NDual{T,N}}) where {T,N}
+    hypot(real(z), imag(z))
+end
+function Base.abs2(z::Complex{NDual{T,N}}) where {T,N}
+    real(z)^2 + imag(z)^2
+end
+function Base.conj(z::Complex{NDual{T,N}}) where {T,N}
+    Complex(real(z), -imag(z))
+end
+
+# sin(a + bi) = sin(a)cosh(b) + i·cos(a)sinh(b)
+function Base.sin(z::Complex{NDual{T,N}}) where {T,N}
+    a, b = real(z), imag(z)
+    sa, ca = sincos(a)
+    Complex(sa * cosh(b), ca * sinh(b))
+end
+
+# cos(a + bi) = cos(a)cosh(b) - i·sin(a)sinh(b)
+function Base.cos(z::Complex{NDual{T,N}}) where {T,N}
+    a, b = real(z), imag(z)
+    sa, ca = sincos(a)
+    Complex(ca * cosh(b), -(sa * sinh(b)))
+end
+
+# exp(a + bi) = exp(a)·(cos(b) + i·sin(b))
+function Base.exp(z::Complex{NDual{T,N}}) where {T,N}
+    a, b = real(z), imag(z)
+    er = exp(a)
+    sb, cb = sincos(b)
+    Complex(er * cb, er * sb)
+end
+
+# log(a + bi) = log(|z|) + i·atan(b, a)
+function Base.log(z::Complex{NDual{T,N}}) where {T,N}
+    a, b = real(z), imag(z)
+    Complex(log(hypot(a, b)), atan(b, a))
+end
+
+# sqrt(a + bi) = sqrt((|z|+a)/2) + i·sign(b)·sqrt((|z|-a)/2)
+function Base.sqrt(z::Complex{NDual{T,N}}) where {T,N}
+    a, b = real(z), imag(z)
+    r = hypot(a, b)
+    re = sqrt((r + a) * NDual{T,N}(T(0.5)))
+    im = copysign(one(NDual{T,N}), b) * sqrt((r - a) * NDual{T,N}(T(0.5)))
+    Complex(re, im)
+end
+
+# tan(z) = sin(z)/cos(z)
+function Base.tan(z::Complex{NDual{T,N}}) where {T,N}
+    sin(z) / cos(z)
+end
+
+# ── Unsupported-operation error ───────────────────────────────────────────────────
+# Operations that would silently destroy partial information (integer/rounding ops,
+# integer division, modulo) throw a clear error instead of falling through to a
+# confusing MethodError or, worse, silently dropping gradients.
+#
+# If you hit this from a GPU broadcast kernel, the function you are differentiating
+# calls one of these non-differentiable operations on a floating-point argument.
+# Options:
+#   • Replace the operation with a differentiable approximation.
+#   • Mark that argument as non-differentiable so NDual wrapping is skipped.
+#   • Open an issue if you believe the operation should have a subgradient rule.
+
+struct NDualUnsupportedError <: Exception
+    op::Symbol
+end
+function Base.showerror(io::IO, e::NDualUnsupportedError)
+    print(
+        io,
+        "NDual does not support `$(e.op)`. ",
+        "This operation cannot propagate partial derivatives through a GPU broadcast kernel. ",
+        "Use a differentiable alternative, or open an issue if a subgradient rule makes sense.",
+    )
+end
+
+for _op in (:floor, :ceil, :round, :trunc, :div, :fld, :cld, :mod, :rem, :gcd, :lcm)
+    @eval Base.$_op(::NDual, args...) = throw(NDualUnsupportedError($(QuoteNode(_op))))
+    @eval Base.$_op(::Type, ::NDual, args...) = throw(
+        NDualUnsupportedError($(QuoteNode(_op)))
+    )
+end
+
+# ── Future: tiled GPU kernels with NDual ──────────────────────────────────────────
+#
+# The current broadcast AD uses one NDual{T,N} per thread: every thread computes
+# the primal and all N partials in registers in a single kernel pass.  This is
+# already efficient for small N and element-wise functions.  For larger N or
+# functions with cross-element data reuse (reductions, softmax, layer norm),
+# *tiled* kernels offer further gains:
+#
+# ── Conceptual note: tiling applied to the Dual itself ──────────────────────
+# An NDual{T,N} is a tile in the partial-derivative dimension.  Just as spatial
+# tiling partitions an M-element array into ceil(M/K) tiles of width K — each
+# processed in one pass with data reuse in shared memory — slot-tiling partitions
+# the N-wide Dual into ceil(N/K) tiles of width K, each processed in one kernel
+# launch:
+#
+#   Jf = [∂f/∂x₁  ∂f/∂x₂  …  ∂f/∂xₙ]          (1×N Jacobian row per element)
+#
+#   tile b covers columns  [(b-1)K+1, min(bK, N)]
+#   each thread carries   NDual{T,K}  with those K slots live, rest zero
+#
+# The primal f(x) is recomputed in each of the ceil(N/K) launches (cost), but
+# register usage per thread drops from O(N) to O(K), restoring warp occupancy.
+# This is the GPU spatial analogue of ForwardDiff's CPU chunk mode, where N is
+# the Jacobian width and K is the chunk size.
+#
+# ── N vs D ───────────────────────────────────────────────────────────────────
+# With D differentiable input parameters, the total slot count is
+#   N = Σᵢ dof(inputᵢ),   dof = 1 (real),  dof = 2 (complex)
+# so N ≥ D in general.  For all-real inputs dof = 1 for every input and N = D
+# exactly — this is a consequence of the slot definition, not a separate choice.
+# The tiling logic is uniform over N regardless; the real/complex distinction
+# only affects how N is computed from D (via _broadcast_elem_dof_type).
+#
+# ── Slot-tiled execution (reduce register pressure for large N) ───────────────
+#    Background: with D differentiable inputs, the total slot count is
+#    N = Σᵢ dof(inputᵢ) where dof = 1 (real) or 2 (complex).  Currently every
+#    thread carries ONE NDual{T,N} whose N partials cover ALL D inputs at once.
+#
+#    Slot-tiling partitions those N slots across ceil(N/K) kernel launches:
+#      batch b → slots (b-1)K+1 .. bK:  only these inputs wrapped as NDual{T,K},
+#                                        all others passed as plain T.
+#    Each thread carries NDual{T,K} instead of NDual{T,N}, using (K+1)·(sizeof T/4)
+#    registers instead of (N+1)·(sizeof T/4).  Partial results from each batch are
+#    assembled into the full gradient vector after all ceil(N/K) launches complete.
+#
+#    Cost: ceil(N/K) re-evaluations of f on the same input data.
+#    Useful when N > ~8 and register pressure is reducing warp occupancy.
+#    Ref: CUDA occupancy calculator —
+#    https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#occupancy
+#
+# ── Memory complexity: forward (NDual) vs reverse mode ───────────────────────
+# Let M = number of output elements in the broadcast (length of y in y .= f.(args...)).
+# Each of the M output elements is computed by one GPU thread carrying NDual{T,N},
+# so the output dual array has M·(N+1) scalars.  For N total slots (one pass, K=N):
+#
+#   Forward (NDual):   O(M·N·sizeof T)   — write N gradient arrays of length M;
+#                                          no tape, sequential coalesced access.
+#   Reverse mode:      O(M·N·sizeof T)   — same gradient storage,
+#                      + O(M·depth)       — forward tape for backward pass
+#                                          (random-access reads, cache-unfriendly).
+#
+# Both are O(M·N) in gradient storage, but reverse mode carries an additional
+# tape term proportional to the computation graph depth.  For shallow element-wise
+# broadcasts (depth ~ constant) this is negligible; for deep networks it dominates.
+# NDual avoids the tape entirely at the cost of recomputing the primal ceil(N/K)
+# times when tiling is used:
+#
+#   Tiled forward:     O(M·K·sizeof T)   peak memory per launch (K < N),
+#                      ceil(N/K) passes  over input data.

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -12,6 +12,13 @@ using Mooncake.TestUtils:
     test_rrule_interface
 using LinearAlgebra
 
+# Access NDual and friends from the CUDA extension (they are not exported from Mooncake core).
+const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
+const NDual = _MooncakeCUDAExt.NDual
+const ndual_value = _MooncakeCUDAExt.ndual_value
+const ndual_partial = _MooncakeCUDAExt.ndual_partial
+const NDualUnsupportedError = _MooncakeCUDAExt.NDualUnsupportedError
+
 @testset "cuda" begin
     cuda = CUDA.functional()
     if cuda
@@ -148,4 +155,6 @@ using LinearAlgebra
     else
         println("Tests are skipped because no CUDA device was found.")
     end
+
+    include("ndual.jl")
 end

--- a/test/ext/cuda/ndual.jl
+++ b/test/ext/cuda/ndual.jl
@@ -1,0 +1,468 @@
+# NDual unit tests — these test pure arithmetic on the NDual type defined in the
+# CUDA extension; no GPU device is required.
+@testset "NDual" begin
+    # helpers
+    _d(v, p1) = NDual{Float64,1}(v, (p1,))
+    _d2(v, p1, p2) = NDual{Float64,2}(v, (p1, p2))
+    _d32(v, p1) = NDual{Float32,1}(Float32(v), (Float32(p1),))
+
+    @testset "construction and accessors" begin
+        d = NDual{Float64,2}(3.0, (1.0, 0.0))
+        @test ndual_value(d) === 3.0
+        @test ndual_partial(d, 1) === 1.0
+        @test ndual_partial(d, 2) === 0.0
+        @test d.partials === (1.0, 0.0)
+
+        # scalar constructor (zero partials)
+        dc = NDual{Float64,2}(3.0)
+        @test ndual_value(dc) === 3.0
+        @test dc.partials === (0.0, 0.0)
+
+        # isbits — critical for GPU register allocation
+        @test isbits(NDual{Float64,2}(1.0, (0.0, 0.0)))
+        @test isbits(NDual{Float32,3}(1.0f0, (0.0f0, 0.0f0, 0.0f0)))
+    end
+
+    @testset "zero / one" begin
+        @test zero(NDual{Float64,2}) == NDual{Float64,2}(0.0, (0.0, 0.0))
+        @test one(NDual{Float64,2}) == NDual{Float64,2}(1.0, (0.0, 0.0))
+        @test zero(_d(1.0, 2.0)) == NDual{Float64,1}(0.0, (0.0,))
+        @test one(_d(1.0, 2.0)) == NDual{Float64,1}(1.0, (0.0,))
+    end
+
+    @testset "promote / convert" begin
+        d = NDual{Float64,1}(2.0, (1.0,))
+        @test convert(NDual{Float64,1}, 3) == NDual{Float64,1}(3.0, (0.0,))
+        @test convert(NDual{Float64,1}, d) === d
+        @test promote_type(NDual{Float64,1}, Int) === NDual{Float64,1}
+        @test promote_type(NDual{Float64,1}, Float32) === NDual{Float64,1}
+
+        # Cross-precision: NDual{Float32,N} op NDual{Float64,N} → NDual{Float64,N}
+        @test promote_type(NDual{Float32,2}, NDual{Float64,2}) === NDual{Float64,2}
+        @test promote_type(NDual{Float64,2}, NDual{Float32,2}) === NDual{Float64,2}
+
+        d32 = NDual{Float32,2}(2.0f0, (1.0f0, 0.0f0))
+        d64 = convert(NDual{Float64,2}, d32)
+        @test d64 isa NDual{Float64,2}
+        @test ndual_value(d64) === 2.0
+        @test ndual_partial(d64, 1) === 1.0
+        @test ndual_partial(d64, 2) === 0.0
+
+        # Arithmetic between different precisions auto-promotes
+        a32 = NDual{Float32,1}(2.0f0, (1.0f0,))
+        b64 = NDual{Float64,1}(3.0, (0.0,))
+        r = a32 + b64
+        @test r isa NDual{Float64,1}
+        @test ndual_value(r) ≈ 5.0
+        @test ndual_partial(r, 1) ≈ 1.0
+
+        r2 = a32 * b64
+        @test r2 isa NDual{Float64,1}
+        @test ndual_value(r2) ≈ 6.0
+        @test ndual_partial(r2, 1) ≈ 3.0  # b.value * da
+
+        # Float64 literal mixed with NDual{Float32} (GPU broadcast scenario)
+        lit = 2.0  # Float64
+        r3 = lit * a32
+        @test r3 isa NDual{Float64,1}
+        @test ndual_value(r3) ≈ 4.0
+        @test ndual_partial(r3, 1) ≈ 2.0
+    end
+
+    @testset "arithmetic" begin
+        a = _d2(2.0, 1.0, 0.0)   # represents 2 + 1*e1
+        b = _d2(3.0, 0.0, 1.0)   # represents 3 + 1*e2
+
+        @test a + b == _d2(5.0, 1.0, 1.0)
+        @test a - b == _d2(-1.0, 1.0, -1.0)
+        @test -a == _d2(-2.0, -1.0, 0.0)
+
+        # product rule: d(a*b) = a*db + b*da
+        r = a * b
+        @test ndual_value(r) ≈ 6.0
+        @test ndual_partial(r, 1) ≈ 3.0  # b.value * da/de1
+        @test ndual_partial(r, 2) ≈ 2.0  # a.value * db/de2
+
+        # quotient rule: d(a/b) = (da - (a/b)*db) / b
+        r = a / b
+        @test ndual_value(r) ≈ 2.0 / 3.0
+        @test ndual_partial(r, 1) ≈ 1.0 / 3.0
+        @test ndual_partial(r, 2) ≈ -(2.0 / 3.0) / 3.0
+
+        # mixing with plain numbers via promotion
+        @test ndual_value(a + 1.0) ≈ 3.0
+        @test ndual_partial(a + 1.0, 1) ≈ 1.0
+        @test ndual_value(2.0 * a) ≈ 4.0
+        @test ndual_partial(2.0 * a, 1) ≈ 2.0
+    end
+
+    @testset "power" begin
+        x = _d(3.0, 1.0)
+        # d(x^2)/dx = 2x
+        @test ndual_value(x^2) ≈ 9.0
+        @test ndual_partial(x^2, 1) ≈ 6.0
+        # d(x^3)/dx = 3x^2
+        @test ndual_value(x^3) ≈ 27.0
+        @test ndual_partial(x^3, 1) ≈ 27.0
+        # x^0
+        @test ndual_value(x^0) ≈ 1.0
+        @test ndual_partial(x^0, 1) ≈ 0.0
+        # real exponent
+        @test ndual_value(x^2.0) ≈ 9.0
+        @test ndual_partial(x^2.0, 1) ≈ 6.0
+        # real exponent b=0.0: d(x^0)/dx = 0 everywhere, including x=0 (no NaN)
+        @test ndual_partial(_d(0.0, 1.0)^0.0, 1) === 0.0
+        @test !isnan(ndual_partial(_d(0.0, 1.0)^0.0, 1))
+    end
+
+    @testset "math functions" begin
+        # Test each f(Dual(v,1)) matches f'(v) analytically
+        for (v, fns) in [
+            (
+                0.5,
+                [
+                    (sin, cos),
+                    (cos, x -> -sin(x)),
+                    (tan, x -> inv(cos(x))^2),
+                    (exp, exp),
+                    (log, inv),
+                    (sqrt, x -> inv(2sqrt(x))),
+                    (abs, sign),
+                    (abs2, x -> 2x),
+                ],
+            ),
+            (
+                0.3,
+                [
+                    (asin, x -> inv(sqrt(1 - x^2))),
+                    (acos, x -> -inv(sqrt(1 - x^2))),
+                    (atan, x -> inv(1 + x^2)),
+                    (tanh, x -> 1 - tanh(x)^2),
+                    (sinh, cosh),
+                    (cosh, sinh),
+                ],
+            ),
+        ]
+            for (f, df) in fns
+                d = _d(v, 1.0)
+                r = f(d)
+                @test ndual_value(r) ≈ f(v)
+                @test ndual_partial(r, 1) ≈ df(v) rtol=1e-10
+            end
+        end
+
+        # exp2 / exp10 / log2 / log10
+        x = _d(2.0, 1.0)
+        @test ndual_value(exp2(x)) ≈ exp2(2.0)
+        @test ndual_partial(exp2(x), 1) ≈ exp2(2.0) * log(2)
+
+        # two-argument atan(y, x): ∂/∂y = x/(x²+y²), ∂/∂x = -y/(x²+y²)
+        ya, xa = 3.0, 4.0  # r² = 25
+        ay = _d2(ya, 1.0, 0.0)
+        ax = _d2(xa, 0.0, 1.0)
+        r = atan(ay, ax)
+        @test ndual_value(r) ≈ atan(ya, xa)
+        @test ndual_partial(r, 1) ≈ xa / (xa^2 + ya^2)   # ∂atan/∂y
+        @test ndual_partial(r, 2) ≈ -ya / (xa^2 + ya^2)   # ∂atan/∂x
+
+        @test ndual_value(log2(x)) ≈ log2(2.0)
+        @test ndual_partial(log2(x), 1) ≈ inv(2.0 * log(2))
+
+        @test ndual_value(log10(x)) ≈ log10(2.0)
+        @test ndual_partial(log10(x), 1) ≈ inv(2.0 * log(10))
+
+        # expm1 / log1p
+        xe = _d(0.5, 1.0)
+        @test ndual_value(expm1(xe)) ≈ expm1(0.5)
+        @test ndual_partial(expm1(xe), 1) ≈ exp(0.5)
+        @test ndual_value(log1p(xe)) ≈ log1p(0.5)
+        @test ndual_partial(log1p(xe), 1) ≈ inv(1.0 + 0.5)
+
+        # inverse hyperbolic
+        for (v, fns) in [
+            (0.5, [(asinh, x -> inv(sqrt(x^2 + 1))), (atanh, x -> inv(1 - x^2))]),
+            (1.5, [(acosh, x -> inv(sqrt(x^2 - 1)))]),
+        ]
+            for (f, df) in fns
+                d = _d(v, 1.0)
+                r = f(d)
+                @test ndual_value(r) ≈ f(v)
+                @test ndual_partial(r, 1) ≈ df(v) rtol = 1e-10
+            end
+        end
+
+        # sincos
+        xs = _d(1.0, 1.0)
+        sv, cv = sincos(xs)
+        @test ndual_value(sv) ≈ sin(1.0)
+        @test ndual_partial(sv, 1) ≈ cos(1.0)
+        @test ndual_value(cv) ≈ cos(1.0)
+        @test ndual_partial(cv, 1) ≈ -sin(1.0)
+
+        # sinpi / cospi
+        xp = _d(0.25, 1.0)
+        @test ndual_value(sinpi(xp)) ≈ sinpi(0.25)
+        @test ndual_partial(sinpi(xp), 1) ≈ π * cospi(0.25)
+        @test ndual_value(cospi(xp)) ≈ cospi(0.25)
+        @test ndual_partial(cospi(xp), 1) ≈ -π * sinpi(0.25)
+
+        # hypot
+        xh, yh = _d(3.0, 1.0), _d(4.0, 0.0)
+        h = hypot(xh, yh)
+        @test ndual_value(h) ≈ 5.0
+        @test ndual_partial(h, 1) ≈ 3.0 / 5.0  # d/dx hypot(x,y) = x/h
+
+        # max / min / clamp
+        a, b = _d(3.0, 1.0), _d(1.0, 0.0)
+        @test ndual_value(max(a, b)) ≈ 3.0
+        @test ndual_partial(max(a, b), 1) ≈ 1.0  # a wins
+        @test ndual_value(min(a, b)) ≈ 1.0
+        @test ndual_partial(min(a, b), 1) ≈ 0.0  # b wins
+
+        xc = _d(2.0, 1.0)
+        @test ndual_value(clamp(xc, 0.0, 1.0)) ≈ 1.0
+        @test ndual_partial(clamp(xc, 0.0, 1.0), 1) ≈ 0.0  # clamped
+        @test ndual_value(clamp(xc, 0.0, 3.0)) ≈ 2.0
+        @test ndual_partial(clamp(xc, 0.0, 3.0), 1) ≈ 1.0  # pass-through
+
+        # flipsign / copysign
+        xf = _d(2.0, 1.0)
+        @test ndual_value(flipsign(xf, _d(-1.0, 0.0))) ≈ -2.0
+        @test ndual_partial(flipsign(xf, _d(-1.0, 0.0)), 1) ≈ -1.0
+        @test ndual_value(copysign(xf, _d(-1.0, 0.0))) ≈ -2.0
+        @test ndual_partial(copysign(xf, _d(-1.0, 0.0)), 1) ≈ -1.0
+    end
+
+    @testset "Float32" begin
+        x = _d32(2.0, 1.0)
+        @test ndual_value(sin(x)) ≈ sin(2.0f0)
+        @test ndual_partial(sin(x), 1) ≈ cos(2.0f0)
+        @test x isa NDual{Float32,1}
+    end
+
+    @testset "real / imag / conj" begin
+        d = _d(3.0, 1.0)
+        @test real(d) === d
+        @test imag(d) == zero(d)
+        @test conj(d) === d
+        @test isreal(d)
+    end
+
+    @testset "comparisons" begin
+        a, b = _d(1.0, 5.0), _d(2.0, -3.0)
+        @test a < b
+        @test b > a
+        @test a <= a
+        @test !isnan(a)
+        @test !isinf(a)
+        @test isfinite(a)
+        @test signbit(_d(-1.0, 1.0))
+    end
+
+    @testset "unsupported operations" begin
+        d = _d(2.5, 1.0)
+        for op in (floor, ceil, round, trunc, div, mod, rem)
+            @test_throws NDualUnsupportedError op(d)
+        end
+        @test_throws NDualUnsupportedError floor(Int, d)
+        @test_throws NDualUnsupportedError round(Int, d)
+        err = try
+            floor(d)
+        catch e
+            e
+        end
+        @test occursin("floor", sprint(showerror, err))
+        @test occursin("NDual", sprint(showerror, err))
+    end
+
+    @testset "Complex{NDual}" begin
+        # Complex{NDual{T,N}} — each component carries its own partials.
+        # Slot 1 = Re(z), slot 2 = Im(z).
+        re = NDual{Float64,2}(3.0, (1.0, 0.0))
+        im_ = NDual{Float64,2}(4.0, (0.0, 1.0))
+        z = complex(re, im_)
+        a, b = 3.0, 4.0  # primal values
+
+        # isbits — critical for GPU register allocation
+        @test isbitstype(typeof(z))
+
+        # abs2(z) = re^2 + im^2, d/dRe = 2*re, d/dIm = 2*im
+        r = abs2(z)
+        @test ndual_value(r) ≈ 25.0
+        @test ndual_partial(r, 1) ≈ 6.0   # 2 * re
+        @test ndual_partial(r, 2) ≈ 8.0   # 2 * im
+
+        # abs(z) = hypot(re, im)
+        r = abs(z)
+        @test ndual_value(r) ≈ 5.0
+        @test ndual_partial(r, 1) ≈ a / 5.0   # re/|z|
+        @test ndual_partial(r, 2) ≈ b / 5.0   # im/|z|
+
+        # conj(z) = re - im*i — partials flip sign on imag part
+        cz = conj(z)
+        @test ndual_value(real(cz)) ≈ 3.0
+        @test ndual_value(imag(cz)) ≈ -4.0
+        @test ndual_partial(real(cz), 1) ≈ 1.0
+        @test ndual_partial(imag(cz), 2) ≈ -1.0
+
+        # z * conj(z) = abs2(z) as a real NDual
+        r2 = real(z * conj(z))
+        @test ndual_value(r2) ≈ 25.0
+
+        # Helper: check value and 2-slot Jacobian against reference complex function
+        function _check_cx(f, z, zv)
+            r = f(z)
+            rv = f(zv)
+            @test ndual_value(real(r)) ≈ real(rv) rtol=1e-10
+            @test ndual_value(imag(r)) ≈ imag(rv) rtol=1e-10
+            ε = 1e-7
+            ∂re_re = (real(f(complex(real(zv)+ε, imag(zv)))) - real(rv)) / ε
+            ∂re_im = (real(f(complex(real(zv), imag(zv)+ε))) - real(rv)) / ε
+            ∂im_re = (imag(f(complex(real(zv)+ε, imag(zv)))) - imag(rv)) / ε
+            ∂im_im = (imag(f(complex(real(zv), imag(zv)+ε))) - imag(rv)) / ε
+            @test ndual_partial(real(r), 1) ≈ ∂re_re rtol=1e-5
+            @test ndual_partial(real(r), 2) ≈ ∂re_im rtol=1e-5
+            @test ndual_partial(imag(r), 1) ≈ ∂im_re rtol=1e-5
+            @test ndual_partial(imag(r), 2) ≈ ∂im_im rtol=1e-5
+        end
+
+        zv = complex(a, b)
+
+        _check_cx(sin, z, zv)
+        sz = sin(z)
+        @test ndual_partial(real(sz), 1) ≈ cos(a)*cosh(b) rtol=1e-10
+        @test ndual_partial(real(sz), 2) ≈ sin(a)*sinh(b) rtol=1e-10
+        @test ndual_partial(imag(sz), 1) ≈ -sin(a)*sinh(b) rtol=1e-10
+        @test ndual_partial(imag(sz), 2) ≈ cos(a)*cosh(b) rtol=1e-10
+
+        _check_cx(cos, z, zv)
+        _check_cx(exp, z, zv)
+        ez = exp(z)
+        @test ndual_partial(real(ez), 1) ≈ exp(a)*cos(b) rtol=1e-10
+        @test ndual_partial(real(ez), 2) ≈ -exp(a)*sin(b) rtol=1e-10
+        @test ndual_partial(imag(ez), 1) ≈ exp(a)*sin(b) rtol=1e-10
+        @test ndual_partial(imag(ez), 2) ≈ exp(a)*cos(b) rtol=1e-10
+
+        _check_cx(log, z, zv)
+        _check_cx(sqrt, z, zv)
+        _check_cx(tan, z, zv)
+
+        # Float32 variant
+        re32 = NDual{Float32,2}(3.0f0, (1.0f0, 0.0f0))
+        im32 = NDual{Float32,2}(4.0f0, (0.0f0, 1.0f0))
+        z32 = complex(re32, im32)
+        sz32 = sin(z32)
+        @test sz32 isa Complex{NDual{Float32,2}}
+        @test ndual_value(real(sz32)) ≈ real(sin(complex(3.0f0, 4.0f0))) rtol=1e-5
+    end
+
+    @testset "chunk mode: N=3" begin
+        x = NDual{Float64,3}(2.0, (1.0, 0.0, 0.0))
+        y = NDual{Float64,3}(3.0, (0.0, 1.0, 0.0))
+        c = NDual{Float64,3}(5.0, (0.0, 0.0, 1.0))
+
+        r = c * sin(x) * exp(y)
+        v = 5.0 * sin(2.0) * exp(3.0)
+        @test ndual_value(r) ≈ v
+        @test ndual_partial(r, 1) ≈ 5.0 * cos(2.0) * exp(3.0)
+        @test ndual_partial(r, 2) ≈ 5.0 * sin(2.0) * exp(3.0)
+        @test ndual_partial(r, 3) ≈ sin(2.0) * exp(3.0)
+    end
+
+    @testset "reciprocal trig" begin
+        x = _d(0.8, 1.0)
+        @test ndual_value(sec(x)) ≈ sec(0.8)
+        @test ndual_partial(sec(x), 1) ≈ sec(0.8) * tan(0.8)
+        @test ndual_value(csc(x)) ≈ csc(0.8)
+        @test ndual_partial(csc(x), 1) ≈ -csc(0.8) * cot(0.8)
+        @test ndual_value(cot(x)) ≈ cot(0.8)
+        @test ndual_partial(cot(x), 1) ≈ -(1 + cot(0.8)^2)
+
+        y = _d(1.5, 1.0)
+        @test ndual_value(asec(y)) ≈ asec(1.5)
+        @test ndual_partial(asec(y), 1) ≈ inv(abs(1.5) * sqrt(1.5^2 - 1))
+        @test ndual_value(acsc(y)) ≈ acsc(1.5)
+        @test ndual_partial(acsc(y), 1) ≈ -inv(abs(1.5) * sqrt(1.5^2 - 1))
+        @test ndual_value(acot(x)) ≈ acot(0.8)
+        @test ndual_partial(acot(x), 1) ≈ -inv(1 + 0.8^2)
+    end
+
+    @testset "reciprocal hyperbolic" begin
+        x = _d(0.5, 1.0)
+        @test ndual_value(sech(x)) ≈ sech(0.5)
+        @test ndual_partial(sech(x), 1) ≈ -tanh(0.5) * sech(0.5)
+        @test ndual_value(csch(x)) ≈ csch(0.5)
+        @test ndual_partial(csch(x), 1) ≈ -coth(0.5) * csch(0.5)
+        @test ndual_value(coth(x)) ≈ coth(0.5)
+        @test ndual_partial(coth(x), 1) ≈ -(csch(0.5)^2)
+
+        z = _d(0.4, 1.0)
+        @test ndual_value(asech(z)) ≈ asech(0.4)
+        @test ndual_partial(asech(z), 1) ≈ -inv(0.4 * sqrt(1 - 0.4^2))
+        @test ndual_value(acsch(x)) ≈ acsch(0.5)
+        @test ndual_partial(acsch(x), 1) ≈ -inv(abs(0.5) * sqrt(1 + 0.5^2))
+        @test ndual_value(acoth(_d(2.0, 1.0))) ≈ acoth(2.0)
+        @test ndual_partial(acoth(_d(2.0, 1.0)), 1) ≈ inv(1 - 2.0^2)
+    end
+
+    @testset "degree-based trig" begin
+        x = _d(30.0, 1.0)
+        @test ndual_value(sind(x)) ≈ sind(30.0)
+        @test ndual_partial(sind(x), 1) ≈ deg2rad(cosd(30.0))
+        @test ndual_value(cosd(x)) ≈ cosd(30.0)
+        @test ndual_partial(cosd(x), 1) ≈ -deg2rad(sind(30.0))
+        @test ndual_value(tand(x)) ≈ tand(30.0)
+        @test ndual_partial(tand(x), 1) ≈ deg2rad(1 + tand(30.0)^2)
+
+        y = _d(0.5, 1.0)
+        @test ndual_value(asind(y)) ≈ asind(0.5)
+        @test ndual_partial(asind(y), 1) ≈ inv(deg2rad(sqrt(1 - 0.5^2)))
+        @test ndual_value(acosd(y)) ≈ acosd(0.5)
+        @test ndual_partial(acosd(y), 1) ≈ -inv(deg2rad(sqrt(1 - 0.5^2)))
+        @test ndual_value(atand(y)) ≈ atand(0.5)
+        @test ndual_partial(atand(y), 1) ≈ inv(deg2rad(1 + 0.5^2))
+    end
+
+    @testset "angle conversions" begin
+        x = _d(90.0, 1.0)
+        @test ndual_value(deg2rad(x)) ≈ deg2rad(90.0)
+        @test ndual_partial(deg2rad(x), 1) ≈ deg2rad(1.0)
+        @test ndual_value(rad2deg(x)) ≈ rad2deg(90.0)
+        @test ndual_partial(rad2deg(x), 1) ≈ rad2deg(1.0)
+    end
+
+    @testset "sinc" begin
+        x = _d(0.5, 1.0)
+        @test ndual_value(sinc(x)) ≈ sinc(0.5)
+        @test ndual_partial(sinc(x), 1) ≈ cosc(0.5)
+    end
+
+    @testset "two-arg log and ldexp" begin
+        x = _d(4.0, 1.0)
+        @test ndual_value(log(2, x)) ≈ log(2, 4.0)
+        @test ndual_partial(log(2, x), 1) ≈ inv(4.0 * log(2))
+
+        y = _d(1.5, 1.0)
+        @test ndual_value(ldexp(y, 3)) ≈ ldexp(1.5, 3)
+        @test ndual_partial(ldexp(y, 3), 1) ≈ exp2(3)
+    end
+
+    @testset "scalar-base power" begin
+        a = _d(2.0, 1.0)
+        r = 3.0^a
+        @test ndual_value(r) ≈ 3.0^2.0
+        @test ndual_partial(r, 1) ≈ 3.0^2.0 * log(3.0)
+    end
+
+    @testset "utility: eps, iszero, hash" begin
+        x = _d(1.0, 0.0)
+        @test eps(x) === eps(1.0)
+        @test eps(NDual{Float64,1}) === eps(Float64)
+        @test iszero(NDual{Float64,1}(0.0, (0.0,)))
+        @test !iszero(NDual{Float64,1}(0.0, (1.0,)))
+        @test !iszero(NDual{Float64,1}(1.0, (0.0,)))
+        # -0.0 partials must also be treated as zero (==-based, not ===-based)
+        @test iszero(NDual{Float64,1}(0.0, (-0.0,)))
+        @test hash(_d(3.0, 1.0), UInt(0)) == hash(3.0, UInt(0))
+    end
+end


### PR DESCRIPTION
*Part 2a of #1056.*

## Summary

Introduces `NDual{T,N}`, a new GPU-native dual number type for chunk-mode
forward-mode AD through GPU kernels. Also restructures the extension from a
single file (`ext/MooncakeCUDAExt.jl`) into a directory (`ext/MooncakeCUDAExt/`)
to keep the growing codebase manageable.

This is a prerequisite for PR 2b (#1061), which uses `NDual` to implement
`sum(f, x)` and broadcast AD rules.

## Changes

**`ext/MooncakeCUDAExt/ndual.jl`** *(new file, ~830 lines)*
- `NDual{T,N}`: an N-wide dual number type for tiled GPU forward-mode AD
- Full arithmetic (`+`, `-`, `*`, `/`, `^`, trig, exp/log, abs, complex ops)
- Math ops derived from `DiffRules` to avoid gaps
- `_gpu_broadcast_dual`: launches a single GPU kernel pass computing primal +
  all N tangent components simultaneously using `ForwardDiff.Dual`
- Helper functions: `_gpu_dual_val`, `_gpu_dual_part`, `_gpu_adj_part`,
  `_is_gpu_differentiable`, `_gpu_dual_part_cx`

**`ext/MooncakeCUDAExt/MooncakeCUDAExt.jl`** *(renamed/restructured, ~89 lines changed)*
- Moved from `ext/MooncakeCUDAExt.jl` into new directory structure
- Adds `include("ndual.jl")`
- Adds imports needed for NDual and broadcast: `CuArrayStyle`, `cu`,
  `Base.Broadcast.Broadcasted`, `FData`, `Tangent`, `_fields`, `zero_rdata`, `RData`
- Adds `CuFloatOrComplex` type alias and expands comment blocks
- Adds `has_equal_data_internal` for integer/bool `CuArray`s
- Existing rules (including `sum(CuFloatArray)` and `mul!(C, A, B)` from PR 1)
  are **preserved** to keep this PR self-consistent; they are superseded in PR 2b
  and PR 3 respectively

**`test/ext/cuda/ndual.jl`** *(new file, ~470 lines)*
- NDual arithmetic and math op tests (real and complex)
- `_gpu_broadcast_dual` correctness tests

**`test/ext/cuda/cuda.jl`**
- Adds NDual constant imports (accessed from the CUDA extension at runtime)
- Adds `include("ndual.jl")` to run the new test file

## Design note: why NDual instead of ForwardDiff.Dual?

GPU kernels are compiled device code — `ForwardDiff.Dual` is not a CUDA-native
type. `NDual{T,N}` is a plain `isbitstype` struct that maps directly to GPU
registers, enabling GPU-kernel-compatible chunk-mode forward-mode AD without
scalar indexing or device→host transfers.