### PR TITLE
Fix DI second-order test to only run intended variant per CI job

### DIFF
--- a/test/ext/differentiation_interface_second_order/differentiation_interface_second_order.jl
+++ b/test/ext/differentiation_interface_second_order/differentiation_interface_second_order.jl
@@ -10,9 +10,7 @@ using Test
 # https://github.com/chalk-lab/MistyClosures.jl/pull/12#issue-3278662295
 const _broken_on_1_11 = v"1.11-" ≤ VERSION ≤ v"1.12-"
 
-scens = filter(DifferentiationInterfaceTest.default_scenarios()) do s
-    s.f !== DifferentiationInterfaceTest.arr_to_num_no_linalg
-end
+scens = DifferentiationInterfaceTest.default_scenarios()
 
 const _backend = [
     SecondOrder(AutoMooncakeForward(; config=nothing), AutoMooncake(; config=nothing))
@@ -22,9 +20,9 @@ const _DI_TEST = get(ENV, "DI_SECOND_ORDER_TEST", "both")
 # Test second-order differentiation (forward-over-reverse)
 for variant in (:hvp, :second_derivative)
     _DI_TEST in ("both", string(variant)) || continue
-    excluded =
-        _broken_on_1_11 ? [FIRST_ORDER..., :hvp, :second_derivative] : [FIRST_ORDER...]
-    test_differentiation(_backend, scens; excluded, logging=true)
+    _broken_on_1_11 && continue  # broken on 1.11 due to an opaque closure bug
+    other = variant == :hvp ? :second_derivative : :hvp
+    test_differentiation(_backend, scens; excluded=[FIRST_ORDER..., other], logging=true)
 end
 
 # Test for world-age fix when using closures (#916, #632)


### PR DESCRIPTION
## Summary

- Each Buildkite job sets `DI_SECOND_ORDER_TEST` to either `"hvp"` or `"second_derivative"`, causing the loop to skip one iteration via `continue`
- However, the `excluded` list didn't use `variant` to exclude the *other* operation — so whichever iteration ran would test **both** `:hvp` and `:second_derivative`
- Both CI jobs were therefore running the full second-order suite, defeating the purpose of splitting them
- Also drops the `arr_to_num_no_linalg` filter from scenarios, and skips the loop early on Julia 1.11 (broken due to an opaque closure bug) rather than running `test_differentiation` with everything excluded

**Fix:** exclude the other variant in each loop iteration and skip on 1.11:
- `DI_SECOND_ORDER_TEST=hvp` → excludes `:second_derivative`, tests only `:hvp`
- `DI_SECOND_ORDER_TEST=second_derivative` → excludes `:hvp`, tests only `:second_derivative`
- `DI_SECOND_ORDER_TEST=both` (local default) → both iterations run, each testing one variant
- Julia 1.11 → skips both iterations entirely (opaque closure bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)