### PR TITLE
Fix three minor issues in GPU mutation rules (PR 1064 follow-up)

### DIFF
--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1181,6 +1181,7 @@ function _check_gpu_sum_f(f)
             ),
         )
     end
+    return nothing
 end
 
 @is_primitive(MinimalCtx, Tuple{typeof(sum),Any,CuFloatArray})
@@ -2399,7 +2400,7 @@ function frule!!(
 
     # Non-differentiable output (e.g. Bool arrays): zero the tangent and return.
     if !_is_gpu_differentiable(eltype(dual_out))
-        fill!(dout, 0)
+        fill!(dout, zero(eltype(dout)))
         return dest
     end
 
@@ -2473,10 +2474,10 @@ function rrule!!(
         # (e.g. x .= x .+ y), flat_fdatas contains fd = dout for x's slot.
         # Without a snapshot, _leaf_accum_fdata!(x, dout, contrib) would corrupt
         # dout mid-loop, causing subsequent slots to read a doubled value, and
-        # fill!(dout, 0) at the end would then zero x's gradient entirely.
-        # Zeroing dout first and then accumulating avoids both problems.
+        # zeroing dout at the end would then zero x's gradient entirely.
+        # Snapshot dout into g first, then zero dout before accumulating.
         g = copy(dout)
-        fill!(dout, 0)
+        fill!(dout, zero(eltype(dout)))
         scalar_grads = has_scalars ? Any[] : nothing
         offset = 0
         for (pa, fd) in zip(flat_pargs, flat_fdatas)


### PR DESCRIPTION
## Summary

Three cleanups following review of PR #1064 (GPU mutation rules):

- **`_check_gpu_sum_f` missing `return nothing`**: the function explicitly returns `nothing` on the early-exit path (`fieldcount(F) == 0`) but falls through implicitly on the non-throwing path (`RT === NoRData`). Added `return nothing` for consistency.

- **`fill!(dout, 0)` integer literal**: two `fill!` calls used the integer literal `0` instead of `zero(eltype(dout))`. Every other zero-fill in the file uses `zero(eltype(...))` (e.g. `fill!(da, zero(eltype(da)))` in `fill!_gpu_pb!!`). Updated both to match.

- **Misleading comment in `materialize!_pb!!`**: the comment said *"Zeroing dout first and then accumulating avoids both problems"* but the code does `g = copy(dout)` first, then `fill!(dout, 0)` — i.e. snapshot first, zero second. Reworded to *"Snapshot dout into g first, then zero dout before accumulating."*

## Test plan

- [ ] No behaviour changes — existing `materialize!` tests cover the pullback path
- [ ] `_check_gpu_sum_f` is covered by the `sum(f, CuArray)` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)