### PR TITLE
Use _model_name in Lux testset titles (PR 1065 follow-up)

### DIFF
--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -236,7 +236,7 @@ const TEST_MODELS = Any[
 ]
 
 @testset "lux" begin
-    @testset "$(typeof(f))" for (interface_only, gpu_supported, f, x) in TEST_MODELS
+    @testset "$(_model_name(f))" for (interface_only, gpu_supported, f, x) in TEST_MODELS
         @info "[CPU] testing $(_model_name(f))"
         rng = sr(123546)
         cvt = eltype(x) == Float64 ? f64 : f32
@@ -258,7 +258,9 @@ end
 if CUDA.functional()
     dev = gpu_device()
     @testset "lux (GPU)" begin
-        @testset "$(typeof(f))" for (interface_only, gpu_supported, f, x) in TEST_MODELS
+        @testset "$(_model_name(f))" for (interface_only, gpu_supported, f, x) in
+                                         TEST_MODELS
+
             gpu_supported || continue  # GPU support not yet implemented
             eltype(x) == Float64 && continue  # Float64 CuArrays not supported
             @info "[GPU] testing $(_model_name(f))"


### PR DESCRIPTION
## Summary

`_model_name` was introduced in PR #1065 and used in `@info` log lines, but the `@testset` names were left as `$(typeof(f))`. This produces verbose, hard-to-read names in test output:

```
# before
Test Summary: | Pass  Fail  Error  Total
Dense{typeof(identity), Matrix{Float32}, Vector{Float32}} | ...

# after
Test Summary: | Pass  Fail  Error  Total
Dense(2, 4) | ...
```

Updated both the CPU `"lux"` testset and the GPU `"lux (GPU)"` testset to use `$(_model_name(f))`, consistent with the `@info` lines already using it.

Note: the DI second-order test issue from PR #1065 (running both variants regardless of `DI_SECOND_ORDER_TEST`) was already fixed in PR #1070.

## Test plan

- [ ] No logic changes — only testset label strings affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)