### PR TITLE
fix(@zero_derivative): support parametric Vararg{T} and Vararg{T,N}

### DIFF
--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -214,7 +214,7 @@ julia> rrule!!(zero_fcodual(foo), zero_fcodual(3.0))[2](NoRData())
 (NoRData(), 0.0)
 ```
 
-Limited support for `Vararg`s is also available. For example
+`Vararg` signatures are also supported. For example
 ```jldoctest
 julia> using Mooncake: @zero_derivative, DefaultCtx, zero_fcodual, rrule!!, is_primitive, ReverseMode
 
@@ -272,6 +272,8 @@ end
 # caller's scope (parse_signature_expr already escaped the whole arg as one unit).
 function _vararg_wrapped_type(vararg_esc_expr, wrapper)
     inner = vararg_esc_expr.args[1]
+    # Bare `Vararg` maps to `Vararg{wrapper}` without `<:` — any Dual/CoDual matches,
+    # consistent with `Vararg` meaning `Vararg{Any}`.
     inner == :Vararg && return :(Vararg{$wrapper})
     # inner is Expr(:curly, :Vararg, T) or Expr(:curly, :Vararg, T, N)
     T = Expr(:escape, inner.args[2])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -186,7 +186,6 @@ function lookup_method(sig)::Union{Method,Nothing}
     world = Base.get_world_counter()
     min = Base.RefValue{UInt}(typemin(UInt))
     max = Base.RefValue{UInt}(typemax(UInt))
-    # Base._methods_by_ftype is a Julia-internal API.
     ms = Base._methods_by_ftype(sig, nothing, 1, world, true, min, max, Ptr{Int32}(C_NULL))
     return (ms isa Vector && !isempty(ms)) ? first(ms).method : nothing
 end

--- a/test/tools_for_rules.jl
+++ b/test/tools_for_rules.jl
@@ -41,6 +41,12 @@ nested_vararg_zero_tester(x::Vector{Float64}...) = 0
     typeof(nested_vararg_zero_tester),Vararg{Vector{Float64},N}
 } where {N}
 
+mixed_vararg_zero_tester(n::Int, x::Float64...) = 0
+@zero_derivative MinimalCtx Tuple{typeof(mixed_vararg_zero_tester),Int,Vararg{Float64}}
+@zero_derivative MinimalCtx Tuple{
+    typeof(mixed_vararg_zero_tester),Int,Vararg{Float64,N}
+} where {N}
+
 zero_tester_forward_only(x) = 0
 @zero_derivative MinimalCtx Tuple{typeof(zero_tester_forward_only),Float64} ForwardMode
 
@@ -213,9 +219,31 @@ end
         )
         test_rule(
             sr(123),
+            ToolsForRulesResources.counted_vararg_zero_tester;
+            is_primitive=true,
+            perf_flag=:stability_and_allocs,
+        )
+        test_rule(
+            sr(123),
             ToolsForRulesResources.nested_vararg_zero_tester,
             [5.0],
             [4.0];
+            is_primitive=true,
+            perf_flag=:stability_and_allocs,
+        )
+        test_rule(
+            sr(123),
+            ToolsForRulesResources.mixed_vararg_zero_tester,
+            3,
+            5.0,
+            4.0;
+            is_primitive=true,
+            perf_flag=:stability_and_allocs,
+        )
+        test_rule(
+            sr(123),
+            ToolsForRulesResources.mixed_vararg_zero_tester,
+            3;
             is_primitive=true,
             perf_flag=:stability_and_allocs,
         )


### PR DESCRIPTION
## Summary

Fixes #923.

`@zero_derivative` only detected bare `Vararg` as a vararg signature. Signatures using `Vararg{T}` or `Vararg{T,N}` fell through to the non-vararg branch, which generated rules with `CoDual{<:Vararg{T,N}}` as a parameter type — nonsensical and never matching any dispatch, so the rule was silently a no-op.

- Adds `_is_vararg_expr`: detects bare `Vararg`, `Vararg{T}`, and `Vararg{T,N}`
- Adds `_vararg_wrapped_type`: generates `Vararg{Dual{<:T},N}` / `Vararg{CoDual{<:T},N}` correctly, including arbitrarily nested element types (e.g. `Vararg{Vector{Float64},N}`)
- Throws `ArgumentError` with an informative message if `Vararg` appears in a non-last position
- Adds `test_rule` coverage for `Vararg{T}`, `Vararg{T,N}`, nested element types, and the non-last-position error

🤖 Generated with [Claude Code](https://claude.com/claude-code)