### PR TITLE
[Part 1/3] fixes and build_primitive_frule infrastructure

### DIFF
--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -59,6 +59,33 @@ Performs AD in forward mode, possibly modifying the inputs, and returns a `Dual`
 function frule!! end
 
 """
+    build_primitive_frule(sig::Type{<:Tuple})
+
+Construct an frule for signature `sig`. For this function to be called in `build_frule`, you
+must also ensure that a method of `_is_primitive(context_type, ForwardMode, sig)` exists,
+preferably by using the [@is_primitive](@ref) macro.
+The callable returned by this must obey the frule interface, but there are no restrictions
+on the type of callable itself. For example, you might return a callable `struct`. By
+default, this function returns `frule!!` so, most of the time, you should just implement a
+method of `frule!!`.
+
+See also [`build_primitive_rrule`](@ref) for the reverse-mode analogue of this function.
+
+# Extended Help
+
+The purpose of this function is to permit computation at rule construction time, which can
+be re-used at runtime. For example, you might wish to derive some information from `sig`
+which you use at runtime (e.g. the fdata type of one of the arguments). While constant
+propagation will often optimise this kind of computation away, it will sometimes fail to do
+so in hard-to-predict circumstances. Consequently, if you need certain computations not to
+happen at runtime in order to guarantee good performance, you might wish to e.g. emit a
+callable `struct` with type parameters which are the result of this computation. In this
+context, the motivation for using this function is the same as that of using staged
+programming (e.g. via `@generated` functions) more generally.
+"""
+build_primitive_frule(::Type{<:Tuple}) = frule!!
+
+"""
     rrule!!(f::CoDual, x::CoDual...)
 
 Performs the forwards-pass of AD. The `tangent` field of `f` and each `x` should contain the

--- a/src/debug_mode.jl
+++ b/src/debug_mode.jl
@@ -47,7 +47,7 @@ Apply pre- and post-condition type checking. See [`DebugFRule`](@ref).
     #
     # See https://github.com/JuliaLang/julia/issues/61368
     @generated function (rule::DebugFRule{Trule})(x::Vararg{Dual,N}) where {Trule,N}
-        # First, check tangent type consistency for all Dual inputs at compile time.
+        # Check tangent type consistency for all Dual inputs at compile time.
         # This prevents the compiler from generating code for rule.rule(x...) with
         # mismatched Dual types (e.g., Dual{Float64,Float32} instead of Dual{Float64,Float64}).
         for dt in x

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -81,7 +81,8 @@ function build_frule(
     # If we have a hand-coded rule, just use that.
     sig = _get_sig(sig_or_mi)
     if is_primitive(C, ForwardMode, sig, interp.world)
-        return (debug_mode ? DebugFRule(frule!!) : frule!!)
+        rule = build_primitive_frule(sig)
+        return debug_mode ? DebugFRule(rule) : rule
     end
 
     # We don't have a hand-coded rule, so derive one.
@@ -408,7 +409,15 @@ function modify_fwd_ad_stmts!(
 
         interp = info.interp
         if is_primitive(context_type(interp), ForwardMode, sig, interp.world)
-            replace_call!(dual_ir, ssa, Expr(:call, frule!!, dual_args...))
+            rule = build_primitive_frule(sig)
+            if safe_for_literal(rule)
+                replace_call!(dual_ir, ssa, Expr(:call, rule, dual_args...))
+            else
+                push!(captures, rule)
+                get_rule = Expr(:call, get_capture, Argument(1), length(captures))
+                rule_ssa = CC.insert_node!(dual_ir, ssa, new_inst(get_rule), ATTACH_BEFORE)
+                replace_call!(dual_ir, ssa, Expr(:call, rule_ssa, dual_args...))
+            end
         else
             dm = info.debug_mode
             push!(captures, isexpr(stmt, :invoke) ? LazyFRule(mi, dm) : DynamicFRule(dm))
@@ -495,8 +504,10 @@ end
 function frule_type(
     interp::MooncakeInterpreter{C}, mi::CC.MethodInstance; debug_mode
 ) where {C}
-    if is_primitive(C, ForwardMode, _get_sig(mi), interp.world)
-        return debug_mode ? DebugFRule{typeof(frule!!)} : typeof(frule!!)
+    sig = _get_sig(mi)
+    if is_primitive(C, ForwardMode, sig, interp.world)
+        rule = build_primitive_frule(sig)
+        return debug_mode ? DebugFRule{typeof(rule)} : typeof(rule)
     end
     ir, _ = lookup_ir(interp, mi)
     nargs = length(ir.argtypes)

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -704,7 +704,7 @@ function make_ad_stmts!(stmt::Expr, line::ID, info::ADInfo)
         sig = Tuple{arg_types...}
         interp = info.interp
         raw_rule = if is_primitive(context_type(interp), ReverseMode, sig, interp.world)
-            rrule!! # intrinsic / builtin / thing we provably have rule for
+            build_primitive_rrule(sig) # intrinsic / builtin / thing we provably have rule for
         elseif is_invoke
             mi = get_mi(stmt.args[1])
             LazyDerivedRule(mi, info.debug_mode) # Static dispatch
@@ -1943,8 +1943,9 @@ important for performance in dynamic dispatch, and to ensure that recursion work
 properly.
 """
 function rule_type(interp::MooncakeInterpreter{C}, sig_or_mi; debug_mode) where {C}
-    if is_primitive(C, ReverseMode, _get_sig(sig_or_mi), interp.world)
-        rule = build_primitive_rrule(_get_sig(sig_or_mi))
+    sig = _get_sig(sig_or_mi)
+    if is_primitive(C, ReverseMode, sig, interp.world)
+        rule = build_primitive_rrule(sig)
         return debug_mode ? DebugRRule{typeof(rule)} : typeof(rule)
     end
 

--- a/src/rules/misc.jl
+++ b/src/rules/misc.jl
@@ -27,6 +27,17 @@
 @zero_derivative DefaultCtx Tuple{typeof(Base.throw_boundserror),Vararg}
 @zero_derivative DefaultCtx Tuple{typeof(Base.Broadcast.eltypes),Vararg}
 @zero_derivative DefaultCtx Tuple{typeof(Base.eltype),Vararg}
+# Debug verification helpers are diagnostic-only. They should execute at primal time, but
+# AD should never propagate derivatives through them in any context.
+@zero_derivative MinimalCtx Tuple{typeof(verify_args),Any,Any}
+@zero_derivative MinimalCtx Tuple{typeof(verify_dual_inputs),Tuple}
+@zero_derivative MinimalCtx Tuple{typeof(verify_dual_output),Any,Any}
+@zero_derivative MinimalCtx Tuple{typeof(verify_dual_value),Dual}
+@zero_derivative MinimalCtx Tuple{typeof(verify_rvs_input),Any,Any}
+@zero_derivative MinimalCtx Tuple{typeof(verify_rvs_output),Any,Any}
+@zero_derivative MinimalCtx Tuple{typeof(verify_fwds_inputs),Any,Tuple}
+@zero_derivative MinimalCtx Tuple{typeof(verify_fwds_output),Any,Any}
+@zero_derivative MinimalCtx Tuple{typeof(verify_fwds),CoDual}
 @zero_derivative MinimalCtx Tuple{typeof(Base.padding),DataType}
 @zero_derivative MinimalCtx Tuple{typeof(Base.padding),DataType,Int}
 @zero_derivative MinimalCtx Tuple{Type,TypeVar,Type}

--- a/src/tangents/dual.jl
+++ b/src/tangents/dual.jl
@@ -28,7 +28,7 @@ extract(x::Dual) = primal(x), tangent(x)
 zero_dual(x) = Dual(x, zero_tangent(x))
 randn_dual(rng::AbstractRNG, x) = Dual(x, randn_tangent(rng, x))
 
-function dual_type(::Type{P}) where {P}
+@unstable function dual_type(::Type{P}) where {P}
     P == Union{} && return Union{}
     P == DataType && return Dual
     P isa Union && return Union{dual_type(P.a),dual_type(P.b)}

--- a/src/tangents/tangents.jl
+++ b/src/tangents/tangents.jl
@@ -43,6 +43,8 @@ struct Tangent{Tfields<:NamedTuple}
     fields::Tfields
 end
 
+_copy(x::T) where {T<:Tangent} = T(_copy(x.fields))
+
 Base.:(==)(x::Tangent, y::Tangent) = x.fields == y.fields
 
 """


### PR DESCRIPTION
- Add `_copy(Tangent)` (needed by FoR caching in PR 2/3)
- Mark `dual_type` `@unstable` for DispatchDoctor compliance
- Add `@zero_derivative` rules for all `verify_*` debug helpers so AD never differentiates through diagnostic checks
- Add `build_primitive_frule(sig)` (default: `frule!!`) with full docstring, analogous to the existing `build_primitive_rrule`; update `build_frule`, `modify_fwd_ad_stmts!`, and `frule_type` in `forward_mode.jl` to use it
- Minor: extract local `sig` before `build_primitive_rrule` call in `reverse_mode.jl`

> **Note:** This PR is part of a stack (1/3) that supersedes https://github.com/chalk-lab/Mooncake.jl/pull/1036 and https://github.com/chalk-lab/Mooncake.jl/pull/1082.