### PR TITLE
[Part 2/3] Add LazyFoRRule/DynamicFoRRule: frule caching for build_derived_rrule

### DIFF
--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -81,6 +81,11 @@ end
     interp_fwd_T = MooncakeInterpreter{C,ForwardMode}
     Tfwd = Core.Compiler.return_type(build_frule, Tuple{interp_fwd_T,fwds_oc_T})
     Trvs = Core.Compiler.return_type(build_frule, Tuple{interp_fwd_T,rvs_oc_T})
+    # Fall back to DynamicFoRRule if inference cannot pin down the dual callable types;
+    # LazyFoRRule{Trule,Any,Any} would defeat its own purpose (typed single-slot cache).
+    if !isconcretetype(Tfwd) || !isconcretetype(Trvs)
+        return :(DynamicFoRRule())
+    end
     return :(LazyFoRRule{$Trule,$Tfwd,$Trvs}())
 end
 
@@ -149,6 +154,16 @@ function _compile_for_rule(
 
     # Build forward-mode dual callables for the fwd and rvs passes.
     # Use a forward-mode interpreter to block inlining of frules during optimisation.
+    #
+    # Aliasing: fwd_oc and rvs_oc share the comms Stack objects from dri.shared_data
+    # (fwd_oc.oc.captures[i] === rvs_oc.oc.captures[i] for shared slots).  Calling
+    # zero_tangent jointly on (fwd_oc.oc.captures, rvs_oc.oc.captures) preserves this
+    # aliasing in the returned captures_tangent, so the tangent Stacks written by the
+    # forward-tangent pass are the same objects read by the reverse-tangent pass.
+    # NOTE: fwd_dc and rvs_dc returned here alias with the tangent embedded in
+    # raw_rule_tangent (fwds_oc / pb_oc_ref fields). Callers that cache (rule, fwd_dc,
+    # rvs_dc) and later call _for_rule_cached_dual must use _copy to get fresh Stacks
+    # and a new independent tangent — do not reuse these objects directly.
     fwd_dc, rvs_dc, raw_rule_tangent = let
         interp_forward = MooncakeInterpreter(C, ForwardMode; world=interp.world)
         optimized_fwd_ir = optimise_ir!(dri.fwd_ir; interp=interp_forward)
@@ -187,7 +202,7 @@ function (cache::LazyFoRRule{Trule,Tfwd,Trvs})(
     # Cache hit: reuse compiled artifacts with fresh empty Stacks. sig is not
     # re-checked because each LazyFoRRule lives at exactly one call site in the
     # compiled IR (inside a fixed-grad_f closure), so the inner signature is
-    # invariant for its lifetime. debug_mode is asserted below because the cached rule
+    # invariant for its lifetime. debug_mode is checked below because the cached rule
     # layout differs between DebugRRule and plain DerivedRule.
     if isdefined(cache, :rule)
         if debug_mode != (cache.rule isa DebugRRule)


### PR DESCRIPTION
Replaces the bare `frule!!` for `build_derived_rrule` with a caching design that compiles the inner `DerivedRule` and its dual callables only once per forward-over-reverse call site:

- `LazyFoRRule{Trule,Tfwd,Trvs}` — single-slot cache for the concrete-type case; zero virtual dispatch on cache hits
- `DynamicFoRRule` — Dict-keyed cache (key: `(sig, debug_mode)`) for the `Any`-typed dispatch case arising from `@nospecialize` in `build_rrule`
- `__build_primitive_frule` (`@generated`) + `build_primitive_frule` — selects between the two based on the inferred return type of `build_derived_rrule` for the given signature
- `_for_rule_cached_dual` / `_compile_for_rule` — shared helpers for the cache-hit and first-call compilation paths, including the Stack aliasing invariant for comms tangents

**Note on tests:** The tests for this caching machinery use the public HVP API introduced in PR 3/3 and live there.

> **Note:** This PR is part of a stack (2/3) that supersedes https://github.com/chalk-lab/Mooncake.jl/pull/1036 and https://github.com/chalk-lab/Mooncake.jl/pull/1082. Depends on #1089.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1090 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1090/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 170.0 ns │     1.59 │        1.65 │   0.706 │        3.47 │   6.66 │
│                  _sum_1000 │ 952.0 ns │     6.86 │        1.03 │  5320.0 │        33.5 │   1.08 │
│               sum_sin_1000 │  6.84 μs │     2.86 │        1.45 │    1.69 │        10.1 │    1.8 │
│              _sum_sin_1000 │  5.62 μs │     3.17 │        2.09 │   264.0 │        12.4 │   2.33 │
│                   kron_sum │ 318.0 μs │     9.78 │        3.73 │    9.86 │       230.0 │   18.5 │
│              kron_view_sum │ 360.0 μs │     9.69 │        4.52 │    12.0 │       210.0 │   11.8 │
│      naive_map_sin_cos_exp │  2.68 μs │     2.33 │         1.3 │ missing │         5.8 │   1.89 │
│            map_sin_cos_exp │  2.58 μs │     2.73 │        1.42 │    2.04 │        5.06 │   2.46 │
│      broadcast_sin_cos_exp │  2.72 μs │     2.52 │        1.32 │    4.23 │        1.22 │   1.84 │
│                 simple_mlp │ 400.0 μs │     5.01 │        2.78 │     1.4 │         8.4 │   2.68 │
│                     gp_lml │ 605.0 μs │     4.71 │        1.57 │    4.14 │     missing │   4.05 │
│ turing_broadcast_benchmark │  2.16 ms │     3.82 │        2.83 │ missing │        23.9 │   1.86 │
│         large_single_block │ 400.0 ns │     5.26 │        1.96 │  4590.0 │        29.5 │   2.15 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->