### PR TITLE
fix: patch AllocCheck to allow jl_get_pgcstack_static on Apple Silicon

### DIFF
--- a/ext/MooncakeAllocCheckExt.jl
+++ b/ext/MooncakeAllocCheckExt.jl
@@ -7,6 +7,7 @@ import Mooncake.TestUtils: check_allocs_internal, Shim
 @check_allocs check_allocs_internal(::Shim, f::F, x, y) where {F} = f(x, y)
 @check_allocs check_allocs_internal(::Shim, f::F, x, y, z) where {F} = f(x, y, z)
 
+# TODO: remove the fix below after https://github.com/JuliaLang/AllocCheck.jl/pull/100 is merged
 function __init__()
     # AllocCheck's allowlist includes "get_pgcstack" but not "get_pgcstack_static",
     # which is the arm64-specific variant used on Apple Silicon. Patch fn_may_allocate


### PR DESCRIPTION
Closes #982

- `AllocCheck.fn_may_allocate` allowlists `"get_pgcstack"` but not `"get_pgcstack_static"`, the arm64-specific variant used on Apple Silicon
- This caused a spurious \"1 allocation\" report for every `@check_allocs`-decorated function on macOS/arm64, making all `check_allocs`-based tests fail with false positives
- Fixes by patching `fn_may_allocate` in `MooncakeAllocCheckExt.__init__` to intercept `"get_pgcstack_static"` before the upstream classifier sees it


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1092 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1092/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 180.0 ns │     1.56 │        1.62 │   0.667 │        3.23 │   6.18 │
│                  _sum_1000 │ 952.0 ns │     6.87 │        1.03 │  5190.0 │        33.5 │   1.08 │
│               sum_sin_1000 │  7.22 μs │     2.86 │        1.45 │    1.58 │         9.8 │   1.78 │
│              _sum_sin_1000 │  6.13 μs │     3.18 │         2.0 │   238.0 │        11.4 │   2.15 │
│                   kron_sum │ 212.0 μs │     11.4 │        3.25 │    11.2 │       308.0 │   21.1 │
│              kron_view_sum │ 290.0 μs │     10.3 │        4.63 │    12.8 │       243.0 │   11.0 │
│      naive_map_sin_cos_exp │  2.54 μs │     2.44 │        1.38 │ missing │        6.17 │   1.98 │
│            map_sin_cos_exp │  2.63 μs │     2.77 │        1.46 │     2.0 │        5.03 │   2.41 │
│      broadcast_sin_cos_exp │  2.64 μs │     2.54 │        1.41 │    4.54 │        1.29 │   1.94 │
│                 simple_mlp │ 326.0 μs │     4.79 │        2.77 │     1.6 │        8.12 │   3.04 │
│                     gp_lml │ 427.0 μs │     5.28 │        1.65 │     2.5 │     missing │   3.47 │
│ turing_broadcast_benchmark │  2.16 ms │      3.8 │        2.83 │ missing │        21.8 │   1.87 │
│         large_single_block │ 401.0 ns │     5.02 │        1.95 │  4330.0 │        30.5 │   2.15 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->