### PR TITLE
nfwd: canonical slot traversal via `_fold_slots` / `_unfold_slots`

### DIFF
--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1929,7 +1929,7 @@ end
     offsets = Int[]
     for ET in args
         push!(offsets, N)
-        N += Nfwd._nfwd_leaf_dof_type(ET)
+        N += Nfwd._nfwd_type_dof(ET)
     end
     N == 0 && return :(f(args...))
     body = Expr[]
@@ -1959,13 +1959,22 @@ function _gpu_broadcast_dual(f::F, args...) where {F}
     ((args...) -> _gpu_apply_with_duals(f, args...)).(args...)
 end
 
-# Number of Dual slots contributed by a broadcast leaf arg.  Matches the slot
-# assignment in _gpu_apply_with_duals by dispatching on the broadcast element type
-# (scalar, CuArray, or Ref all handled via eltype).
-@inline _gpu_total_slots(flat_pargs) = sum(Nfwd._nfwd_leaf_dof, flat_pargs)
+# Map each broadcast leaf arg to a representative scalar element so that
+# _nfwd_input_dof counts per-broadcast-element DOFs.
+@inline _gpu_rep_element(x::CuFloatOrComplex) = x
+@inline _gpu_rep_element(x::AbstractArray{T}) where {T<:IEEEFloat} = zero(T)
+@inline _gpu_rep_element(x::AbstractArray{Complex{T}}) where {T<:IEEEFloat} = zero(
+    Complex{T}
+)
+@inline _gpu_rep_element(::Any) = ()
+
+@inline _gpu_total_slots(flat_pargs) = Nfwd._nfwd_input_dof(
+    map(_gpu_rep_element, flat_pargs)
+)
 
 @inline function _gpu_leaf_slot_meta(pa, offset)
-    return (; Nfwd._nfwd_slot_meta(pa, offset)..., is_scalar=pa isa CuFloatOrComplex)
+    dof = Nfwd._nfwd_input_dof(_gpu_rep_element(pa))
+    return (; dof, slot1=offset + 1, slot2=offset + 2, is_scalar=pa isa CuFloatOrComplex)
 end
 
 @inline function _gpu_extract_partial_slots(out, n_slots::Int)

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -1950,13 +1950,15 @@ end
 """
     _fold_slots(f, init, x, state) -> (acc, state)
 
-Left-fold over the scalar slots of `x` in canonical order.  Each slot visit calls
-`(acc, state) = f(acc, x_leaf, slot_index_within_leaf, state)` and returns the
-updated accumulator and state.  `slot_index_within_leaf` is 1 for a real scalar,
-1 or 2 for the real/imag parts of a complex scalar, and the linear index for array
-elements (with complex elements expanding to two sub-slots each).
+Left-fold over the scalar slots of `x` in canonical order.  Each slot corresponds
+to one differentiable scalar degree of freedom.  Real IEEE-float values contribute
+one floating-point slot.  Complex IEEE-float values contribute two scalar slots,
+visited as real then imaginary.  Tuples are visited left to right, and arrays are
+visited in `eachindex` order.
 
-The slot cursor should be threaded through `state` by the caller.
+Each slot visit calls `(acc, state) = f(acc, x_leaf, slot_index_within_leaf, state)`
+and returns the updated accumulator and state.  The slot cursor should be threaded
+through `state` by the caller.
 """
 @inline function _fold_slots(f::F, init, x::IEEEFloat, state) where {F}
     return f(init, x, 1, state)
@@ -1967,9 +1969,7 @@ end
     return f(acc, x, 2, state)          # imag part
 end
 
-@inline function _fold_slots(
-    f::F, init, x::AbstractArray{T}, state
-) where {F,T<:IEEEFloat}
+@inline function _fold_slots(f::F, init, x::AbstractArray{T}, state) where {F,T<:IEEEFloat}
     acc = init
     @inbounds for i in eachindex(x)
         acc, state = f(acc, x, i, state)
@@ -1997,18 +1997,19 @@ end
 """
     _unfold_slots(f, x, state) -> (rebuilt, state)
 
-Map-like structural rebuild over the primitive leaves of `x`.  Each leaf visit
-calls `(result, state) = f(x_leaf, state)` and returns the rebuilt value for that
-leaf position.  For tuples, the unfold recurses left to right and collects
-per-leaf results into a new tuple.
+Map-like structural rebuild over the primitive leaves of `x`.  Each slot
+corresponds to one differentiable scalar degree of freedom (same semantics as
+`_fold_slots`).  Each leaf visit calls `(result, state) = f(x_leaf, state)` and
+returns the rebuilt value for that leaf position.  For tuples, the unfold recurses
+left to right and collects per-leaf results into a new tuple.
 
 The returned value at each leaf position may have a different type from the input
 leaf (e.g. seeding produces NTuples from scalar inputs).  The slot cursor should
 be threaded through `state` by the caller.
 
-`_fold_slots` and `_unfold_slots` agree on traversal order: tuples
-left to right, arrays in `eachindex` order, and within each leaf the DOF count
-from `_nfwd_input_dof` determines how far the state cursor should advance.
+`_fold_slots` and `_unfold_slots` agree on traversal order: tuples left to right,
+arrays in `eachindex` order.  Within each leaf, the number of slots consumed equals
+`_nfwd_input_dof(leaf)`.
 """
 @inline function _unfold_slots(f::F, x::IEEEFloat, state) where {F}
     return f(x, state)
@@ -2018,9 +2019,7 @@ end
     return f(x, state)
 end
 
-@inline function _unfold_slots(
-    f::F, x::AbstractArray{<:IEEEFloat}, state
-) where {F}
+@inline function _unfold_slots(f::F, x::AbstractArray{<:IEEEFloat}, state) where {F}
     return f(x, state)
 end
 
@@ -2037,14 +2036,15 @@ end
     return (head, tail...), state
 end
 
-# ── DOF counting via fold ─────────────────────────────────────────────────────────
+# ── DOF counting ─────────────────────────────────────────────────────────────────
 
-@inline function _nfwd_input_dof(x)
-    acc, _ = _fold_slots((_acc, _leaf, _slot, st) -> (_acc + 1, st), 0, x, nothing)
-    return acc
-end
+@inline _nfwd_input_dof(x::IEEEFloat) = 1
+@inline _nfwd_input_dof(x::Complex{<:IEEEFloat}) = 2
+@inline _nfwd_input_dof(x::AbstractArray{<:IEEEFloat}) = length(x)
+@inline _nfwd_input_dof(x::AbstractArray{<:Complex{<:IEEEFloat}}) = 2 * length(x)
+@inline _nfwd_input_dof(x::Tuple) = sum(_nfwd_input_dof, x; init=0)
 
-# ── Legacy helpers (retained for NfwdMooncake compatibility) ──────────────────────
+# ── Helpers used by the CUDA extension (MooncakeCUDAExt) ─────────────────────────
 
 @inline function _nfwd_leaf_dof_type(T::Type)
     dof = _nfwd_type_dof(T)

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -77,6 +77,7 @@ export NDual,
     _nfwd_check_chunk_size,
     _nfwd_check_primal,
     _nfwd_default_chunk_size,
+    _fold_slots,
     _nfwd_infer_scalar_output,
     _nfwd_input_dof,
     _nfwd_input_error,
@@ -88,6 +89,7 @@ export NDual,
     _nfwd_sig_default_chunk_size,
     _nfwd_sig_dof,
     _nfwd_type_dof,
+    _unfold_slots,
     _nfwd_validate
 
 #
@@ -1931,11 +1933,118 @@ end
 @inline _nfwd_rule_sig(::Rule{sig}) where {sig} = sig
 @inline _nfwd_rule_sig(::RRule{sig}) where {sig} = sig
 
-@inline _nfwd_input_dof(x::IEEEFloat) = 1
-@inline _nfwd_input_dof(x::Complex{<:IEEEFloat}) = 2
-@inline _nfwd_input_dof(x::AbstractArray{<:IEEEFloat}) = length(x)
-@inline _nfwd_input_dof(x::AbstractArray{<:Complex{<:IEEEFloat}}) = 2 * length(x)
-@inline _nfwd_input_dof(x::Tuple) = sum(_nfwd_input_dof, x; init=0)
+#
+# ── Canonical slot traversal ──────────────────────────────────────────────────────
+#
+# Every supported nfwd primal decomposes into a fixed number of scalar "slots" in
+# a canonical order:
+#   • IEEEFloat              → 1 slot  (the value itself)
+#   • Complex{<:IEEEFloat}   → 2 slots (real, imag)
+#   • AbstractArray{<:above} → one slot per scalar component, in eachindex order
+#   • Tuple of the above     → concatenation, left to right
+#
+# `_fold_slots` and `_unfold_slots` define this order exactly once.
+# All DOF counting, basis seeding, and gradient scatter must use these helpers so
+# that the slot order is guaranteed to agree everywhere.
+
+"""
+    _fold_slots(f, init, x, state) -> (acc, state)
+
+Left-fold over the scalar slots of `x` in canonical order.  Each slot visit calls
+`(acc, state) = f(acc, x_leaf, slot_index_within_leaf, state)` and returns the
+updated accumulator and state.  `slot_index_within_leaf` is 1 for a real scalar,
+1 or 2 for the real/imag parts of a complex scalar, and the linear index for array
+elements (with complex elements expanding to two sub-slots each).
+
+The slot cursor should be threaded through `state` by the caller.
+"""
+@inline function _fold_slots(f::F, init, x::IEEEFloat, state) where {F}
+    return f(init, x, 1, state)
+end
+
+@inline function _fold_slots(f::F, init, x::Complex{<:IEEEFloat}, state) where {F}
+    acc, state = f(init, x, 1, state)  # real part
+    return f(acc, x, 2, state)          # imag part
+end
+
+@inline function _fold_slots(
+    f::F, init, x::AbstractArray{T}, state
+) where {F,T<:IEEEFloat}
+    acc = init
+    @inbounds for i in eachindex(x)
+        acc, state = f(acc, x, i, state)
+    end
+    return acc, state
+end
+
+@inline function _fold_slots(
+    f::F, init, x::AbstractArray{Complex{T}}, state
+) where {F,T<:IEEEFloat}
+    acc = init
+    @inbounds for i in eachindex(x)
+        acc, state = f(acc, x, 2i - 1, state)  # real part of element i
+        acc, state = f(acc, x, 2i, state)       # imag part of element i
+    end
+    return acc, state
+end
+
+@inline _fold_slots(f::F, init, x::Tuple{}, state) where {F} = (init, state)
+@inline function _fold_slots(f::F, init, x::Tuple, state) where {F}
+    acc, state = _fold_slots(f, init, first(x), state)
+    return _fold_slots(f, acc, Base.tail(x), state)
+end
+
+"""
+    _unfold_slots(f, x, state) -> (rebuilt, state)
+
+Map-like structural rebuild over the primitive leaves of `x`.  Each leaf visit
+calls `(result, state) = f(x_leaf, state)` and returns the rebuilt value for that
+leaf position.  For tuples, the unfold recurses left to right and collects
+per-leaf results into a new tuple.
+
+The returned value at each leaf position may have a different type from the input
+leaf (e.g. seeding produces NTuples from scalar inputs).  The slot cursor should
+be threaded through `state` by the caller.
+
+`_fold_slots` and `_unfold_slots` agree on traversal order: tuples
+left to right, arrays in `eachindex` order, and within each leaf the DOF count
+from `_nfwd_input_dof` determines how far the state cursor should advance.
+"""
+@inline function _unfold_slots(f::F, x::IEEEFloat, state) where {F}
+    return f(x, state)
+end
+
+@inline function _unfold_slots(f::F, x::Complex{<:IEEEFloat}, state) where {F}
+    return f(x, state)
+end
+
+@inline function _unfold_slots(
+    f::F, x::AbstractArray{<:IEEEFloat}, state
+) where {F}
+    return f(x, state)
+end
+
+@inline function _unfold_slots(
+    f::F, x::AbstractArray{<:Complex{<:IEEEFloat}}, state
+) where {F}
+    return f(x, state)
+end
+
+@inline _unfold_slots(f::F, x::Tuple{}, state) where {F} = ((), state)
+@inline function _unfold_slots(f::F, x::Tuple, state) where {F}
+    head, state = _unfold_slots(f, first(x), state)
+    tail, state = _unfold_slots(f, Base.tail(x), state)
+    return (head, tail...), state
+end
+
+# ── DOF counting via fold ─────────────────────────────────────────────────────────
+
+@inline function _nfwd_input_dof(x)
+    acc, _ = _fold_slots((_acc, _leaf, _slot, st) -> (_acc + 1, st), 0, x, nothing)
+    return acc
+end
+
+# ── Legacy helpers (retained for NfwdMooncake compatibility) ──────────────────────
 
 @inline function _nfwd_leaf_dof_type(T::Type)
     dof = _nfwd_type_dof(T)

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -2039,19 +2039,4 @@ end
 @inline _nfwd_input_dof(x::AbstractArray{<:Complex{<:IEEEFloat}}) = 2 * length(x)
 @inline _nfwd_input_dof(x::Tuple) = sum(_nfwd_input_dof, x; init=0)
 
-# ── Helpers used by the CUDA extension (MooncakeCUDAExt) ─────────────────────────
-
-@inline function _nfwd_leaf_dof_type(T::Type)
-    dof = _nfwd_type_dof(T)
-    return isnothing(dof) ? 0 : dof
-end
-
-@inline _nfwd_leaf_dof_type(::Type{<:AbstractArray{T}}) where {T} = _nfwd_leaf_dof_type(T)
-@inline _nfwd_leaf_dof(x) = _nfwd_leaf_dof_type(typeof(x))
-
-@inline function _nfwd_slot_meta(x, offset::Int)
-    dof = _nfwd_leaf_dof(x)
-    return (; dof, slot1=offset + 1, slot2=offset + 2)
-end
-
 end

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -77,7 +77,7 @@ export NDual,
     _nfwd_check_chunk_size,
     _nfwd_check_primal,
     _nfwd_default_chunk_size,
-    _fold_slots,
+    _nfwd_fold_slots,
     _nfwd_infer_scalar_output,
     _nfwd_input_dof,
     _nfwd_input_error,
@@ -89,7 +89,7 @@ export NDual,
     _nfwd_sig_default_chunk_size,
     _nfwd_sig_dof,
     _nfwd_type_dof,
-    _unfold_slots,
+    _nfwd_unfold_slots,
     _nfwd_validate
 
 #
@@ -1943,12 +1943,12 @@ end
 #   • AbstractArray{<:above} → one slot per scalar component, in eachindex order
 #   • Tuple of the above     → concatenation, left to right
 #
-# `_fold_slots` and `_unfold_slots` define this order exactly once.
+# `_nfwd_fold_slots` and `_nfwd_unfold_slots` define this order exactly once.
 # All DOF counting, basis seeding, and gradient scatter must use these helpers so
 # that the slot order is guaranteed to agree everywhere.
 
 """
-    _fold_slots(f, init, x, state) -> (acc, state)
+    _nfwd_fold_slots(f, init, x, state) -> (acc, state)
 
 Left-fold over the scalar slots of `x` in canonical order.  Each slot corresponds
 to one differentiable scalar degree of freedom.  Real IEEE-float values contribute
@@ -1960,16 +1960,18 @@ Each slot visit calls `(acc, state) = f(acc, x_leaf, slot_index_within_leaf, sta
 and returns the updated accumulator and state.  The slot cursor should be threaded
 through `state` by the caller.
 """
-@inline function _fold_slots(f::F, init, x::IEEEFloat, state) where {F}
+@inline function _nfwd_fold_slots(f::F, init, x::IEEEFloat, state) where {F}
     return f(init, x, 1, state)
 end
 
-@inline function _fold_slots(f::F, init, x::Complex{<:IEEEFloat}, state) where {F}
+@inline function _nfwd_fold_slots(f::F, init, x::Complex{<:IEEEFloat}, state) where {F}
     acc, state = f(init, x, 1, state)  # real part
     return f(acc, x, 2, state)          # imag part
 end
 
-@inline function _fold_slots(f::F, init, x::AbstractArray{T}, state) where {F,T<:IEEEFloat}
+@inline function _nfwd_fold_slots(
+    f::F, init, x::AbstractArray{T}, state
+) where {F,T<:IEEEFloat}
     acc = init
     @inbounds for i in eachindex(x)
         acc, state = f(acc, x, i, state)
@@ -1977,7 +1979,7 @@ end
     return acc, state
 end
 
-@inline function _fold_slots(
+@inline function _nfwd_fold_slots(
     f::F, init, x::AbstractArray{Complex{T}}, state
 ) where {F,T<:IEEEFloat}
     acc = init
@@ -1988,18 +1990,18 @@ end
     return acc, state
 end
 
-@inline _fold_slots(f::F, init, x::Tuple{}, state) where {F} = (init, state)
-@inline function _fold_slots(f::F, init, x::Tuple, state) where {F}
-    acc, state = _fold_slots(f, init, first(x), state)
-    return _fold_slots(f, acc, Base.tail(x), state)
+@inline _nfwd_fold_slots(f::F, init, x::Tuple{}, state) where {F} = (init, state)
+@inline function _nfwd_fold_slots(f::F, init, x::Tuple, state) where {F}
+    acc, state = _nfwd_fold_slots(f, init, first(x), state)
+    return _nfwd_fold_slots(f, acc, Base.tail(x), state)
 end
 
 """
-    _unfold_slots(f, x, state) -> (rebuilt, state)
+    _nfwd_unfold_slots(f, x, state) -> (rebuilt, state)
 
 Map-like structural rebuild over the primitive leaves of `x`.  Each slot
 corresponds to one differentiable scalar degree of freedom (same semantics as
-`_fold_slots`).  Each leaf visit calls `(result, state) = f(x_leaf, state)` and
+`_nfwd_fold_slots`).  Each leaf visit calls `(result, state) = f(x_leaf, state)` and
 returns the rebuilt value for that leaf position.  For tuples, the unfold recurses
 left to right and collects per-leaf results into a new tuple.
 
@@ -2007,11 +2009,11 @@ The returned value at each leaf position may have a different type from the inpu
 leaf (e.g. seeding produces NTuples from scalar inputs).  The slot cursor should
 be threaded through `state` by the caller.
 
-`_fold_slots` and `_unfold_slots` agree on traversal order: tuples left to right,
+`_nfwd_fold_slots` and `_nfwd_unfold_slots` agree on traversal order: tuples left to right,
 arrays in `eachindex` order.  Within each leaf, the number of slots consumed equals
 `_nfwd_input_dof(leaf)`.
 """
-@inline function _unfold_slots(
+@inline function _nfwd_unfold_slots(
     f::F,
     x::Union{
         IEEEFloat,
@@ -2024,10 +2026,10 @@ arrays in `eachindex` order.  Within each leaf, the number of slots consumed equ
     return f(x, state)
 end
 
-@inline _unfold_slots(f::F, x::Tuple{}, state) where {F} = ((), state)
-@inline function _unfold_slots(f::F, x::Tuple, state) where {F}
-    head, state = _unfold_slots(f, first(x), state)
-    tail, state = _unfold_slots(f, Base.tail(x), state)
+@inline _nfwd_unfold_slots(f::F, x::Tuple{}, state) where {F} = ((), state)
+@inline function _nfwd_unfold_slots(f::F, x::Tuple, state) where {F}
+    head, state = _nfwd_unfold_slots(f, first(x), state)
+    tail, state = _nfwd_unfold_slots(f, Base.tail(x), state)
     return (head, tail...), state
 end
 

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -2011,20 +2011,15 @@ be threaded through `state` by the caller.
 arrays in `eachindex` order.  Within each leaf, the number of slots consumed equals
 `_nfwd_input_dof(leaf)`.
 """
-@inline function _unfold_slots(f::F, x::IEEEFloat, state) where {F}
-    return f(x, state)
-end
-
-@inline function _unfold_slots(f::F, x::Complex{<:IEEEFloat}, state) where {F}
-    return f(x, state)
-end
-
-@inline function _unfold_slots(f::F, x::AbstractArray{<:IEEEFloat}, state) where {F}
-    return f(x, state)
-end
-
 @inline function _unfold_slots(
-    f::F, x::AbstractArray{<:Complex{<:IEEEFloat}}, state
+    f::F,
+    x::Union{
+        IEEEFloat,
+        Complex{<:IEEEFloat},
+        AbstractArray{<:IEEEFloat},
+        AbstractArray{<:Complex{<:IEEEFloat}},
+    },
+    state,
 ) where {F}
     return f(x, state)
 end

--- a/src/nfwd/NfwdMooncake.jl
+++ b/src/nfwd/NfwdMooncake.jl
@@ -787,20 +787,18 @@ end
 end
 
 function _nfwd_scatter_chunk!(grads::Tuple, inputs::Tuple, dy::Tuple, start_slot::Int)
-    global_slot = start_slot
-    for lane_val in dy
-        offset = 0
-        for (i, x) in enumerate(inputs)
-            dof = _nfwd_input_dof(x)
-            if offset < global_slot <= offset + dof
-                local_slot = global_slot - offset
-                _nfwd_add_slot!(grads[i], local_slot, lane_val)
-                break
+    function scatter_leaf!(x, (offset, remaining_grads))
+        g = first(remaining_grads)
+        dof = _nfwd_input_dof(x)
+        for k in 1:dof
+            lane = offset + k - start_slot + 1
+            if 1 <= lane <= length(dy)
+                _nfwd_add_slot!(g, k, dy[lane])
             end
-            offset += dof
         end
-        global_slot += 1
+        return nothing, (offset + dof, Base.tail(remaining_grads))
     end
+    _unfold_slots(scatter_leaf!, inputs, (0, grads))
     return nothing
 end
 
@@ -847,35 +845,22 @@ end
     )
 end
 
-@inline function _nfwd_update_scalar_grad(
-    grads::Tuple, primals::Tuple, global_slot::Int, lane_val, offset::Int=0
-)
-    x = first(primals)
-    dof = _nfwd_input_dof(x)
-    if offset < global_slot <= offset + dof
-        local_slot = global_slot - offset
-        return (
-            _nfwd_accumulate_scalar_gradient(first(grads), local_slot, lane_val),
-            Base.tail(grads)...,
-        )
-    end
-    return (
-        first(grads),
-        _nfwd_update_scalar_grad(
-            Base.tail(grads), Base.tail(primals), global_slot, lane_val, offset + dof
-        )...,
-    )
-end
-
 @inline function _nfwd_scatter_scalar_chunk(
     grads::Tuple, primals::Tuple, dy::Tuple, start_slot::Int
 )
-    global_slot = start_slot
-    for lane_val in dy
-        grads = _nfwd_update_scalar_grad(grads, primals, global_slot, lane_val)
-        global_slot += 1
+    function scatter_leaf(x, (offset, remaining_grads))
+        g = first(remaining_grads)
+        dof = _nfwd_input_dof(x)
+        for k in 1:dof
+            lane = offset + k - start_slot + 1
+            if 1 <= lane <= length(dy)
+                g = _nfwd_accumulate_scalar_gradient(g, k, dy[lane])
+            end
+        end
+        return g, (offset + dof, Base.tail(remaining_grads))
     end
-    return grads
+    new_grads, _ = _unfold_slots(scatter_leaf, primals, (0, grads))
+    return new_grads
 end
 
 # `slot` is the 1-based DOF index within the scalar/complex input: 1 for the real
@@ -1056,17 +1041,14 @@ function _nfwd_pullback(f, primals::Tuple, tangents::Tuple, y_fdata, ::Val{N}) w
     )
 end
 
-@inline _nfwd_seed_tangents(::Tuple{}, ::Val{N}, start_slot::Int, offset::Int=0) where {N} = ()
 @inline function _nfwd_seed_tangents(
     primals::Tuple, ::Val{N}, start_slot::Int, offset::Int=0
 ) where {N}
-    x = first(primals)
-    return (
-        _nfwd_seed_tangent(x, N, start_slot, offset),
-        _nfwd_seed_tangents(
-            Base.tail(primals), Val(N), start_slot, offset + _nfwd_input_dof(x)
-        )...,
-    )
+    function seed_leaf(x, off)
+        return _nfwd_seed_tangent(x, N, start_slot, off), off + _nfwd_input_dof(x)
+    end
+    tangents, _ = _unfold_slots(seed_leaf, primals, offset)
+    return tangents
 end
 """
     _nfwd_scalar_gradient_rdata(pb, y_rdata)

--- a/src/nfwd/NfwdMooncake.jl
+++ b/src/nfwd/NfwdMooncake.jl
@@ -798,7 +798,7 @@ function _nfwd_scatter_chunk!(grads::Tuple, inputs::Tuple, dy::Tuple, start_slot
         end
         return nothing, (offset + dof, Base.tail(remaining_grads))
     end
-    _unfold_slots(scatter_leaf!, inputs, (0, grads))
+    _nfwd_unfold_slots(scatter_leaf!, inputs, (0, grads))
     return nothing
 end
 
@@ -859,7 +859,7 @@ end
         end
         return g, (offset + dof, Base.tail(remaining_grads))
     end
-    new_grads, _ = _unfold_slots(scatter_leaf, primals, (0, grads))
+    new_grads, _ = _nfwd_unfold_slots(scatter_leaf, primals, (0, grads))
     return new_grads
 end
 
@@ -1047,7 +1047,7 @@ end
     function seed_leaf(x, off)
         return _nfwd_seed_tangent(x, N, start_slot, off), off + _nfwd_input_dof(x)
     end
-    tangents, _ = _unfold_slots(seed_leaf, primals, offset)
+    tangents, _ = _nfwd_unfold_slots(seed_leaf, primals, offset)
     return tangents
 end
 """

--- a/test/nfwd/nfwd.jl
+++ b/test/nfwd/nfwd.jl
@@ -948,32 +948,20 @@ end
     end
 
     @testset "fold accumulates correctly" begin
-        # Sum all slot values (real parts for complex)
-        function sum_slots(acc, leaf, slot, st)
-            if leaf isa Complex
-                val = slot == 1 ? real(leaf) : imag(leaf)
-            elseif leaf isa AbstractArray && eltype(leaf) <: Complex
-                elem = cld(slot, 2)
-                val = isodd(slot) ? real(leaf[elem]) : imag(leaf[elem])
-            elseif leaf isa AbstractArray
-                val = leaf[slot]
-            else
-                val = leaf
-            end
-            return (acc + val, st)
-        end
+        # Sum within-leaf slot indices to verify fold visits the expected indices.
+        sum_slot_idx(acc, _leaf, slot, st) = (acc + slot, st)
 
-        total, _ = _fold_slots(sum_slots, 0.0, 3.0, nothing)
-        @test total ≈ 3.0
-
-        total, _ = _fold_slots(sum_slots, 0.0, 1.0 + 2.0im, nothing)
-        @test total ≈ 3.0  # 1.0 + 2.0
-
-        total, _ = _fold_slots(sum_slots, 0.0, [1.0, 2.0, 3.0], nothing)
-        @test total ≈ 6.0
-
-        total, _ = _fold_slots(sum_slots, 0.0, (1.0, [2.0, 3.0]), nothing)
-        @test total ≈ 6.0
+        # real scalar: one slot at index 1
+        @test _fold_slots(sum_slot_idx, 0, 3.0, nothing) == (1, nothing)
+        # complex: slots 1 and 2
+        @test _fold_slots(sum_slot_idx, 0, 1.0 + 2.0im, nothing) == (3, nothing)
+        # real array of length 3: slots 1, 2, 3
+        @test _fold_slots(sum_slot_idx, 0, [1.0, 2.0, 3.0], nothing) == (6, nothing)
+        # complex array of length 2: slots 1, 2, 3, 4
+        @test _fold_slots(sum_slot_idx, 0, [1.0+0im, 2.0+3.0im], nothing) == (10, nothing)
+        # tuple: slot indices from each leaf are independent
+        total, _ = _fold_slots(sum_slot_idx, 0, (1.0, [2.0, 3.0]), nothing)
+        @test total == 1 + 1 + 2  # scalar(1) + array-slot1(1) + array-slot2(2)
     end
 
     @testset "Float32 support" begin

--- a/test/nfwd/nfwd.jl
+++ b/test/nfwd/nfwd.jl
@@ -832,17 +832,17 @@ using Mooncake.Nfwd
     end
 end
 
-# Slot traversal contract tests — verify _fold_slots and _unfold_slots
+# Slot traversal contract tests — verify _nfwd_fold_slots and _nfwd_unfold_slots
 # agree on canonical order and produce correct results for all supported types.
 @testset "slot traversal" begin
-    using Mooncake.Nfwd: _fold_slots, _unfold_slots, _nfwd_input_dof
+    using Mooncake.Nfwd: _nfwd_fold_slots, _nfwd_unfold_slots, _nfwd_input_dof
 
     count_slot(acc, _leaf, _slot, st) = (acc + 1, st)
 
     # helper: collect global slot indices via fold
     function fold_order(x)
         collect_order(acc, _leaf, _slot, st) = (push!(acc, st), st + 1)
-        order, _ = _fold_slots(collect_order, Int[], x, 1)
+        order, _ = _nfwd_fold_slots(collect_order, Int[], x, 1)
         return order
     end
 
@@ -853,12 +853,12 @@ end
             append!(order, cursor:(cursor + dof - 1))
             return nothing, (order, cursor + dof)
         end
-        _, (order, _) = _unfold_slots(collect_leaf, x, (Int[], 1))
+        _, (order, _) = _nfwd_unfold_slots(collect_leaf, x, (Int[], 1))
         return order
     end
 
     @testset "real scalar" begin
-        @test _fold_slots(count_slot, 0, 1.0, nothing) == (1, nothing)
+        @test _nfwd_fold_slots(count_slot, 0, 1.0, nothing) == (1, nothing)
         @test _nfwd_input_dof(1.0) == 1
         @test fold_order(1.0) == [1]
         @test unfold_order(1.0) == [1]
@@ -866,7 +866,7 @@ end
 
     @testset "complex scalar" begin
         z = 1.0 + 2.0im
-        @test _fold_slots(count_slot, 0, z, nothing) == (2, nothing)
+        @test _nfwd_fold_slots(count_slot, 0, z, nothing) == (2, nothing)
         @test _nfwd_input_dof(z) == 2
         @test fold_order(z) == [1, 2]
         @test unfold_order(z) == [1, 2]
@@ -874,7 +874,7 @@ end
 
     @testset "dense real array" begin
         a = [1.0, 2.0, 3.0]
-        @test _fold_slots(count_slot, 0, a, nothing) == (3, nothing)
+        @test _nfwd_fold_slots(count_slot, 0, a, nothing) == (3, nothing)
         @test _nfwd_input_dof(a) == 3
         @test fold_order(a) == [1, 2, 3]
         @test unfold_order(a) == [1, 2, 3]
@@ -882,7 +882,7 @@ end
 
     @testset "dense complex array" begin
         a = [1.0+0im, 2.0+3.0im]
-        @test _fold_slots(count_slot, 0, a, nothing) == (4, nothing)
+        @test _nfwd_fold_slots(count_slot, 0, a, nothing) == (4, nothing)
         @test _nfwd_input_dof(a) == 4
         @test fold_order(a) == [1, 2, 3, 4]
         @test unfold_order(a) == [1, 2, 3, 4]
@@ -890,7 +890,7 @@ end
 
     @testset "tuple mixtures" begin
         t = (1.0, [2.0, 3.0], 4.0 + 5.0im)
-        @test _fold_slots(count_slot, 0, t, nothing) == (5, nothing)
+        @test _nfwd_fold_slots(count_slot, 0, t, nothing) == (5, nothing)
         @test _nfwd_input_dof(t) == 5
         @test fold_order(t) == [1, 2, 3, 4, 5]
         @test unfold_order(t) == [1, 2, 3, 4, 5]
@@ -902,7 +902,7 @@ end
         @test unfold_order(t2) == [1, 2, 3, 4]
 
         # empty tuple
-        @test _fold_slots(count_slot, 0, (), nothing) == (0, nothing)
+        @test _nfwd_fold_slots(count_slot, 0, (), nothing) == (0, nothing)
         @test _nfwd_input_dof(()) == 0
         @test fold_order(()) == Int[]
         @test unfold_order(()) == Int[]
@@ -929,18 +929,18 @@ end
             return x, st + _nfwd_input_dof(x)
         end
 
-        val, st = _unfold_slots(id_leaf, 3.14, 0)
+        val, st = _nfwd_unfold_slots(id_leaf, 3.14, 0)
         @test val === 3.14
 
-        val, st = _unfold_slots(id_leaf, 1.0+2.0im, 0)
+        val, st = _nfwd_unfold_slots(id_leaf, 1.0+2.0im, 0)
         @test val === 1.0+2.0im
 
         a = [1.0, 2.0, 3.0]
-        val, st = _unfold_slots(id_leaf, a, 0)
+        val, st = _nfwd_unfold_slots(id_leaf, a, 0)
         @test val == a
 
         t = (1.0, [2.0, 3.0], 4.0+5.0im)
-        val, st = _unfold_slots(id_leaf, t, 0)
+        val, st = _nfwd_unfold_slots(id_leaf, t, 0)
         @test val[1] === 1.0
         @test val[2] == [2.0, 3.0]
         @test val[3] === 4.0+5.0im
@@ -952,15 +952,16 @@ end
         sum_slot_idx(acc, _leaf, slot, st) = (acc + slot, st)
 
         # real scalar: one slot at index 1
-        @test _fold_slots(sum_slot_idx, 0, 3.0, nothing) == (1, nothing)
+        @test _nfwd_fold_slots(sum_slot_idx, 0, 3.0, nothing) == (1, nothing)
         # complex: slots 1 and 2
-        @test _fold_slots(sum_slot_idx, 0, 1.0 + 2.0im, nothing) == (3, nothing)
+        @test _nfwd_fold_slots(sum_slot_idx, 0, 1.0 + 2.0im, nothing) == (3, nothing)
         # real array of length 3: slots 1, 2, 3
-        @test _fold_slots(sum_slot_idx, 0, [1.0, 2.0, 3.0], nothing) == (6, nothing)
+        @test _nfwd_fold_slots(sum_slot_idx, 0, [1.0, 2.0, 3.0], nothing) == (6, nothing)
         # complex array of length 2: slots 1, 2, 3, 4
-        @test _fold_slots(sum_slot_idx, 0, [1.0+0im, 2.0+3.0im], nothing) == (10, nothing)
+        @test _nfwd_fold_slots(sum_slot_idx, 0, [1.0+0im, 2.0+3.0im], nothing) ==
+            (10, nothing)
         # tuple: slot indices from each leaf are independent
-        total, _ = _fold_slots(sum_slot_idx, 0, (1.0, [2.0, 3.0]), nothing)
+        total, _ = _nfwd_fold_slots(sum_slot_idx, 0, (1.0, [2.0, 3.0]), nothing)
         @test total == 1 + 1 + 2  # scalar(1) + array-slot1(1) + array-slot2(2)
     end
 

--- a/test/nfwd/nfwd.jl
+++ b/test/nfwd/nfwd.jl
@@ -831,3 +831,156 @@ using Mooncake.Nfwd
         @test Nfwd.ndual_partial(Cp[2, 2], 3) ≈ 1.0   # ∂A₂₂
     end
 end
+
+# Slot traversal contract tests — verify _fold_slots and _unfold_slots
+# agree on canonical order and produce correct results for all supported types.
+@testset "slot traversal" begin
+    using Mooncake.Nfwd: _fold_slots, _unfold_slots, _nfwd_input_dof
+
+    count_slot(acc, _leaf, _slot, st) = (acc + 1, st)
+
+    # helper: collect global slot indices via fold
+    function fold_order(x)
+        collect_order(acc, _leaf, _slot, st) = (push!(acc, st), st + 1)
+        order, _ = _fold_slots(collect_order, Int[], x, 1)
+        return order
+    end
+
+    # helper: collect global slot indices via unfold
+    function unfold_order(x)
+        function collect_leaf(leaf, (order, cursor))
+            dof = _nfwd_input_dof(leaf)
+            append!(order, cursor:(cursor + dof - 1))
+            return nothing, (order, cursor + dof)
+        end
+        _, (order, _) = _unfold_slots(collect_leaf, x, (Int[], 1))
+        return order
+    end
+
+    @testset "real scalar" begin
+        @test _fold_slots(count_slot, 0, 1.0, nothing) == (1, nothing)
+        @test _nfwd_input_dof(1.0) == 1
+        @test fold_order(1.0) == [1]
+        @test unfold_order(1.0) == [1]
+    end
+
+    @testset "complex scalar" begin
+        z = 1.0 + 2.0im
+        @test _fold_slots(count_slot, 0, z, nothing) == (2, nothing)
+        @test _nfwd_input_dof(z) == 2
+        @test fold_order(z) == [1, 2]
+        @test unfold_order(z) == [1, 2]
+    end
+
+    @testset "dense real array" begin
+        a = [1.0, 2.0, 3.0]
+        @test _fold_slots(count_slot, 0, a, nothing) == (3, nothing)
+        @test _nfwd_input_dof(a) == 3
+        @test fold_order(a) == [1, 2, 3]
+        @test unfold_order(a) == [1, 2, 3]
+    end
+
+    @testset "dense complex array" begin
+        a = [1.0+0im, 2.0+3.0im]
+        @test _fold_slots(count_slot, 0, a, nothing) == (4, nothing)
+        @test _nfwd_input_dof(a) == 4
+        @test fold_order(a) == [1, 2, 3, 4]
+        @test unfold_order(a) == [1, 2, 3, 4]
+    end
+
+    @testset "tuple mixtures" begin
+        t = (1.0, [2.0, 3.0], 4.0 + 5.0im)
+        @test _fold_slots(count_slot, 0, t, nothing) == (5, nothing)
+        @test _nfwd_input_dof(t) == 5
+        @test fold_order(t) == [1, 2, 3, 4, 5]
+        @test unfold_order(t) == [1, 2, 3, 4, 5]
+
+        # nested tuple
+        t2 = ((1.0, 2.0), [3.0 + 0im])
+        @test _nfwd_input_dof(t2) == 4
+        @test fold_order(t2) == [1, 2, 3, 4]
+        @test unfold_order(t2) == [1, 2, 3, 4]
+
+        # empty tuple
+        @test _fold_slots(count_slot, 0, (), nothing) == (0, nothing)
+        @test _nfwd_input_dof(()) == 0
+        @test fold_order(()) == Int[]
+        @test unfold_order(()) == Int[]
+    end
+
+    @testset "fold and unfold order agree" begin
+        inputs = [
+            1.0,
+            1.0 + 2.0im,
+            [1.0, 2.0, 3.0],
+            [1.0+0im, 2.0+0im],
+            (1.0, [2.0, 3.0], 4.0+5.0im),
+            ((1.0, 2.0), [3.0+0im]),
+            (),
+        ]
+        for x in inputs
+            @test fold_order(x) == unfold_order(x)
+        end
+    end
+
+    @testset "unfold structural rebuild" begin
+        # unfold with identity preserves values
+        function id_leaf(x, st)
+            return x, st + _nfwd_input_dof(x)
+        end
+
+        val, st = _unfold_slots(id_leaf, 3.14, 0)
+        @test val === 3.14
+
+        val, st = _unfold_slots(id_leaf, 1.0+2.0im, 0)
+        @test val === 1.0+2.0im
+
+        a = [1.0, 2.0, 3.0]
+        val, st = _unfold_slots(id_leaf, a, 0)
+        @test val == a
+
+        t = (1.0, [2.0, 3.0], 4.0+5.0im)
+        val, st = _unfold_slots(id_leaf, t, 0)
+        @test val[1] === 1.0
+        @test val[2] == [2.0, 3.0]
+        @test val[3] === 4.0+5.0im
+        @test st == 5
+    end
+
+    @testset "fold accumulates correctly" begin
+        # Sum all slot values (real parts for complex)
+        function sum_slots(acc, leaf, slot, st)
+            if leaf isa Complex
+                val = slot == 1 ? real(leaf) : imag(leaf)
+            elseif leaf isa AbstractArray && eltype(leaf) <: Complex
+                elem = cld(slot, 2)
+                val = isodd(slot) ? real(leaf[elem]) : imag(leaf[elem])
+            elseif leaf isa AbstractArray
+                val = leaf[slot]
+            else
+                val = leaf
+            end
+            return (acc + val, st)
+        end
+
+        total, _ = _fold_slots(sum_slots, 0.0, 3.0, nothing)
+        @test total ≈ 3.0
+
+        total, _ = _fold_slots(sum_slots, 0.0, 1.0 + 2.0im, nothing)
+        @test total ≈ 3.0  # 1.0 + 2.0
+
+        total, _ = _fold_slots(sum_slots, 0.0, [1.0, 2.0, 3.0], nothing)
+        @test total ≈ 6.0
+
+        total, _ = _fold_slots(sum_slots, 0.0, (1.0, [2.0, 3.0]), nothing)
+        @test total ≈ 6.0
+    end
+
+    @testset "Float32 support" begin
+        @test _nfwd_input_dof(1.0f0) == 1
+        @test _nfwd_input_dof(Float32[1, 2, 3]) == 3
+        @test _nfwd_input_dof(1.0f0 + 2.0f0im) == 2
+        @test fold_order((1.0f0, Float32[2, 3])) == [1, 2, 3]
+        @test unfold_order((1.0f0, Float32[2, 3])) == [1, 2, 3]
+    end
+end


### PR DESCRIPTION
Previously, the slot ordering used by DOF counting (`_nfwd_input_dof`),                                                                                                                                                                                      
  tangent seeding (`_nfwd_seed_tangents`), and gradient scatter                                                                                                                                                                                                
  (`_nfwd_scatter_chunk!`, `_nfwd_scatter_scalar_chunk`) was defined                                                                                                                                                                                           
  implicitly and independently in each function. A mismatch between any two                                                                                                                                                                                    
  of them would produce silently wrong gradients with no local indication of                                                                                                                                                                                   
  where the disagreement was.                                                                                                                                                                                                                                  
                                                                  
  This PR introduces two traversal helpers that define the canonical slot
  order exactly once:

  - `_fold_slots(f, init, x, state)` — left-fold over every scalar slot of                                                                                                                                                                                     
    `x`. Each slot is one differentiable scalar DOF: one per `IEEEFloat`,
    two (real then imaginary) per `Complex{<:IEEEFloat}`, one per element                                                                                                                                                                                      
    for real arrays, two per element for complex arrays, left to right for                                                                                                                                                                                     
    tuples.                                                                                                                                                                                                                                                    
  - `_unfold_slots(f, x, state)` — structural map over the primitive leaves                                                                                                                                                                                    
    of `x`, threading state left to right through each leaf.                                                                                                                                                                                                   
                                                                                                                                                                                                                                                               
  `_nfwd_seed_tangents` and both scatter functions are rewritten in terms of
  `_unfold_slots`, eliminating the `_nfwd_update_scalar_grad` recursive                                                                                                                                                                                        
  helper. `_nfwd_input_dof` retains its O(1) per-type specialisations;
  agreement with `_fold_slots` is enforced by 50 new tests covering all                                                                                                                                                                                        
  supported types individually and cross-checked that fold and unfold
  produce identical traversal orders.    

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1136 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1136/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 315.0 ns │      1.5 │        1.68 │   0.359 │        1.46 │   2.71 │
│                  _sum_1000 │   1.2 μs │     8.03 │        1.11 │  1390.0 │        23.1 │   1.43 │
│               sum_sin_1000 │  5.33 μs │     7.09 │        2.36 │     2.6 │        12.8 │    2.4 │
│              _sum_sin_1000 │  5.75 μs │     3.62 │        1.99 │   272.0 │        11.4 │   2.03 │
│                   kron_sum │ 503.0 μs │      7.5 │        2.83 │    12.8 │       171.0 │   9.75 │
│              kron_view_sum │ 537.0 μs │     7.28 │        3.24 │    14.4 │       191.0 │   6.22 │
│      naive_map_sin_cos_exp │  2.93 μs │     2.69 │        1.48 │ missing │        5.06 │   1.74 │
│            map_sin_cos_exp │  2.88 μs │      3.4 │        3.02 │     1.9 │        4.27 │   2.18 │
│      broadcast_sin_cos_exp │  3.13 μs │      2.9 │        1.92 │    2.85 │        1.03 │   1.59 │
│                 simple_mlp │ 585.0 μs │     4.06 │        2.24 │    1.22 │        6.26 │   2.22 │
│                     gp_lml │ 331.0 μs │     8.52 │        2.41 │    4.93 │     missing │   3.85 │
│ turing_broadcast_benchmark │  1.91 ms │     5.03 │        3.01 │ missing │        27.3 │    1.9 │
│         large_single_block │ 506.0 ns │     11.8 │         2.2 │  3580.0 │        21.4 │   1.78 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->