### PR TITLE
Add frule!!/rrule!! for :jl_get_world_counter and :jl_matching_methods

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.5.27
+
+- Add forward- and reverse-mode rules for `:jl_get_world_counter` and `:jl_matching_methods` foreigncalls (`high_order_derivative_patches.jl`). These are needed when forward-over-reverse descends into Mooncake's own `lookup_method` / `is_vararg_and_sparam_names` via `LazyDerivedRule._build_rule!` (e.g. when an inner rule is built lazily inside the outer forward pass, as happens with neural-ODE Hessians through `SciMLSensitivity` + `OrdinaryDiffEq`). Without these rules, `prepare_hvp_cache` raises `MissingForeigncallRuleError`.
+
 # 0.5.26
 
 - Add `Config(empty_cache=true)` to free internal caches before rebuilding rules.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.26"
+version = "0.5.27"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -309,6 +309,34 @@ end
     end
 end
 
+# Forward-over-reverse can descend into Mooncake's own method-lookup utilities
+# (`lookup_method`, `is_vararg_and_sparam_names`) when an inner `LazyDerivedRule`
+# is built lazily inside the outer forward pass. Their bodies eventually call
+# `Base.get_world_counter()` and `Base._methods_by_ftype`, which lower to
+# `:jl_get_world_counter` and `:jl_matching_methods` foreigncalls. The plain
+# reverse path never sees them (rule construction happens once at
+# `prepare_*_cache` time, outside AD), so these rules are only needed for the
+# forward-over-reverse path. Both ccall results carry no differentiable
+# information, so an `uninit` tangent is the correct lifted result (and avoids
+# `zero_tangent` failures on pointer-bearing return types like `Method[]`).
+for name in (:jl_get_world_counter, :jl_matching_methods)
+    @eval function frule!!(
+        ::Dual{typeof(_foreigncall_)}, ::Dual{Val{$(QuoteNode(name))}}, args::Vararg{Dual,N}
+    ) where {N}
+        return uninit_dual(_foreigncall_(Val($(QuoteNode(name))), tuple_map(primal, args)...))
+    end
+    @eval function rrule!!(
+        ::CoDual{typeof(_foreigncall_)},
+        ::CoDual{Val{$(QuoteNode(name))}},
+        args::Vararg{CoDual,N},
+    ) where {N}
+        y = uninit_fcodual(
+            _foreigncall_(Val($(QuoteNode(name))), tuple_map(primal, args)...)
+        )
+        return y, NoPullback((NoRData(), NoRData(), tuple_map(_ -> NoRData(), args)...))
+    end
+end
+
 # This rule is potentially unnecessary if fixes are made elsewhere,
 # but currently fixes differentiating through zero_tangent_internal for Arrays.
 @zero_derivative MinimalCtx Tuple{typeof(zero_tangent),Any}

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -155,6 +155,37 @@ end
     end
 end
 
+@testset "ccall workarounds in build path" begin
+    # Forward-over-reverse can descend into Mooncake's `lookup_method` /
+    # `is_vararg_and_sparam_names` via `LazyDerivedRule._build_rule!`. Their bodies
+    # call `Base.get_world_counter()` (→ `:jl_get_world_counter`) and
+    # `Base._methods_by_ftype` (→ `:jl_matching_methods`), neither of which had a
+    # forward rule until the patches in `high_order_derivative_patches.jl`.
+    # The MWE below differentiates a function that calls `Base.get_world_counter()`
+    # directly: without the rule, both `prepare_gradient_cache` (rrule) and
+    # `prepare_hvp_cache` (frule-of-rrule) raise `MissingForeigncallRuleError`.
+    function f_with_world_counter(x)
+        w = Base.get_world_counter()
+        # Use `w` to keep the call live; the conditional always evaluates to 0.
+        return sum(abs2, x) + (w > 0 ? 0.0 : 0.0)
+    end
+
+    @testset "rrule!! survives reverse build" begin
+        cache = prepare_gradient_cache(f_with_world_counter, [1.0, 2.0])
+        fval, grads = value_and_gradient!!(cache, f_with_world_counter, [1.0, 2.0])
+        @test fval ≈ 5.0
+        @test grads[2] ≈ [2.0, 4.0]
+    end
+
+    @testset "frule!! survives forward-over-reverse build" begin
+        cache = prepare_hvp_cache(f_with_world_counter, [1.0, 2.0])
+        fval, grad, hvp = value_and_hvp!!(cache, f_with_world_counter, [1.0, 0.0], [1.0, 2.0])
+        @test fval ≈ 5.0
+        @test grad ≈ [2.0, 4.0]
+        @test hvp ≈ [2.0, 0.0]
+    end
+end
+
 @testset "reverse over reverse fails" begin
     rosen(z) = (1.0 - z[1])^2 + 100.0 * (z[2] - z[1]^2)^2
     z = [1.2, 1.2]


### PR DESCRIPTION
## Summary

Forward-over-reverse can descend into Mooncake's own method-lookup utilities (`lookup_method`, `is_vararg_and_sparam_names`) when an inner `LazyDerivedRule` is built lazily inside the outer forward pass. Their bodies eventually call `Base.get_world_counter()` and `Base._methods_by_ftype`, which lower to `:jl_get_world_counter` and `:jl_matching_methods` foreigncalls. The plain reverse path never sees them (rule construction happens once at `prepare_*_cache` time, outside AD), so these rules are only needed for the forward-over-reverse path.

Without these, `prepare_hvp_cache` raises `MissingForeigncallRuleError` on workloads that lazily build inner rules at runtime — e.g. the SciMLSensitivity neural-ODE Hessian path through OrdinaryDiffEq's solver stack, where many of the inner rules aren't materialised at cache prep time.

Both ccall results carry no differentiable information, so an `uninit` tangent is the correct lifted result and avoids `zero_tangent` failures on pointer-bearing return types like `Method[]`.

The new rules follow the same pattern as the existing `:jl_genericmemory_owner` workaround in `high_order_derivative_patches.jl`.

## Test plan

- [x] New testset `ccall workarounds in build path` in `test/rules/high_order_derivative_patches.jl` with two subtests:
  - `rrule!! survives reverse build`: differentiates a function that calls `Base.get_world_counter()` directly via `prepare_gradient_cache` + `value_and_gradient!!`. Without this rule the call raises `MissingForeigncallRuleError` for `rrule!!`.
  - `frule!! survives forward-over-reverse build`: same function, via `prepare_hvp_cache` + `value_and_hvp!!`. Without this rule the call raises `MissingForeigncallRuleError` for `frule!!`.
- [x] All other tests in `test/rules/high_order_derivative_patches.jl` continue to pass (`hessian_scalar_functions`, `hessian_multivariate`, `forward over reverse (public interface)`, `reverse over reverse fails`, `native HVP interface`).
- [x] End-to-end smoke test: with this patch, `Mooncake.prepare_hvp_cache` on a SciMLSensitivity neural ODE loss (`Vector{Float32}` parameters) gets past both foreigncall errors and now hits a downstream `UndefRefError` in `_build_output_tangent_cartesian` for `IdDict` tangent construction. That is a separate Mooncake bug and will be filed as its own issue.

## Notes

- Bumps version to 0.5.27.
- The `:jl_matching_methods` rule isn't independently exercised by the new MWE — finding a self-contained user-level repro for it is awkward because it tends to come up only once `is_vararg_and_sparam_names` is forced into a runtime build path. It is, however, exercised by the SciMLSensitivity neural ODE smoke test above and follows the same pattern as the world-counter rule, so they are added together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)