### PR TITLE
Guard friendly_tangent_cache array branch against NoTangent eltypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -85,7 +85,6 @@ Pkg = "1"
 Random = "1"
 Revise = "3.0 - 3.12"
 SLEEFPirates = "0.6.43"
-SparseArrays = "1"
 SpecialFunctions = "2"
 StableRNGs = "1"
 Static = "1.1.1"
@@ -106,7 +105,6 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [targets]
 test = [
     "AllocCheck",
@@ -118,7 +116,6 @@ test = [
     "Logging",
     "Pkg",
     "Revise",
-    "SparseArrays",
     "StableRNGs",
     "Test",
     "LogExpFunctions",

--- a/Project.toml
+++ b/Project.toml
@@ -85,6 +85,7 @@ Pkg = "1"
 Random = "1"
 Revise = "3.0 - 3.12"
 SLEEFPirates = "0.6.43"
+SparseArrays = "1"
 SpecialFunctions = "2"
 StableRNGs = "1"
 Static = "1.1.1"
@@ -105,6 +106,7 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [targets]
 test = [
     "AllocCheck",
@@ -116,6 +118,7 @@ test = [
     "Logging",
     "Pkg",
     "Revise",
+    "SparseArrays",
     "StableRNGs",
     "Test",
     "LogExpFunctions",

--- a/src/tangents/tangents.jl
+++ b/src/tangents/tangents.jl
@@ -1382,7 +1382,7 @@ caches instead.
 |---|---|
 | Immutable struct with fields and standard `Tangent` | `NamedTuple` of per-field caches *(composite)* |
 | `Tuple` | `Tuple` of per-element caches *(composite)* |
-| `AbstractArray` with non-float, non-`NoTangent` eltype | `Array` of per-element caches via `map` *(composite)* |
+| `AbstractArray` with non-float eltype whose `tangent_type` is not `NoTangent` | `Array` of per-element caches via `map` *(composite)* |
 | Mutable struct with fields and standard `MutableTangent` | `FriendlyTangentCache{AsMutableFields}` — per-field `NamedTuple` at runtime *(non-composite, internal mode)* |
 | `AbstractDict` | `FriendlyTangentCache{AsPrimal}` *(non-composite)* |
 | `LinearAlgebra.Symmetric` / `Hermitian` / `SymTridiagonal` | `FriendlyTangentCache{AsCustomised}` *(non-composite)* |
@@ -1450,9 +1450,10 @@ Overloads for `LinearAlgebra.Symmetric`, `LinearAlgebra.Hermitian`, and
         return :(NamedTuple{$names}(($(dest_exprs...),)))
     end
     # Skip non-differentiable eltypes: avoids pointless caches and map on sparse containers.
-    # Calling tangent_type in a generator body risks world-age cycles, but is safe here:
-    # every eltype for which tangent_type == NoTangent (integers, Bool, Symbol, …) has an
-    # explicit non-generated method, so no generated dispatch occurs at generation time.
+    # Calling tangent_type in a generator body would normally risk world-age cycles, since
+    # generators cannot safely trigger runtime dispatch into other generated functions.
+    # This is safe here because tangent_type is @foldable (Base.@assume_effects :foldable),
+    # meaning Julia evaluates it at compile time, avoiding any runtime dispatch.
     if P <: AbstractArray &&
         !(eltype(P) <: Union{IEEEFloat,Complex{<:IEEEFloat}}) &&
         tangent_type(eltype(P)) != NoTangent

--- a/src/tangents/tangents.jl
+++ b/src/tangents/tangents.jl
@@ -1382,11 +1382,11 @@ caches instead.
 |---|---|
 | Immutable struct with fields and standard `Tangent` | `NamedTuple` of per-field caches *(composite)* |
 | `Tuple` | `Tuple` of per-element caches *(composite)* |
-| `AbstractArray` with non-float eltype | `Array` of per-element caches via `map` *(composite)* |
+| `AbstractArray` with non-float, non-`NoTangent` eltype | `Array` of per-element caches via `map` *(composite)* |
 | Mutable struct with fields and standard `MutableTangent` | `FriendlyTangentCache{AsMutableFields}` — per-field `NamedTuple` at runtime *(non-composite, internal mode)* |
 | `AbstractDict` | `FriendlyTangentCache{AsPrimal}` *(non-composite)* |
 | `LinearAlgebra.Symmetric` / `Hermitian` / `SymTridiagonal` | `FriendlyTangentCache{AsCustomised}` *(non-composite)* |
-| Everything else (Julia primitive types, float arrays, custom-tangent types, zero-field types) | `FriendlyTangentCache{AsRaw}` *(non-composite)* |
+| Everything else (Julia primitive types, float arrays, non-differentiable arrays, custom-tangent types, zero-field types) | `FriendlyTangentCache{AsRaw}` *(non-composite)* |
 
 Override to opt a type into a non-composite mode with a custom buffer:
 
@@ -1449,8 +1449,13 @@ Overloads for `LinearAlgebra.Symmetric`, `LinearAlgebra.Hermitian`, and
         end
         return :(NamedTuple{$names}(($(dest_exprs...),)))
     end
-    # Array whose elements are non-primitive structs: recurse element-wise.
-    if P <: AbstractArray && !(eltype(P) <: Union{IEEEFloat,Complex{<:IEEEFloat}})
+    # Skip non-differentiable eltypes: avoids pointless caches and map on sparse containers.
+    # Calling tangent_type in a generator body risks world-age cycles, but is safe here:
+    # every eltype for which tangent_type == NoTangent (integers, Bool, Symbol, …) has an
+    # explicit non-generated method, so no generated dispatch occurs at generation time.
+    if P <: AbstractArray &&
+        !(eltype(P) <: Union{IEEEFloat,Complex{<:IEEEFloat}}) &&
+        tangent_type(eltype(P)) != NoTangent
         return :(map(friendly_tangent_cache, x))
     end
     # Mutable structs with fields: pre-build per-field caches at prepare time and store them

--- a/test/tangents/tangents.jl
+++ b/test/tangents/tangents.jl
@@ -1,4 +1,5 @@
 using DispatchDoctor: allow_unstable
+using SparseArrays
 @testset "tangents" begin
     @testset "$(tangent_type(primal_type))" for (primal_type, expected_tangent_type) in Any[
 
@@ -386,7 +387,6 @@ using DispatchDoctor: allow_unstable
     end
 
     @testset "friendly_tangent_cache SparseMatrixCSC{Int} returns AsRaw" begin
-        using SparseArrays
         A = SparseArrays.sparse([1, 2], [1, 2], [1, 2], 2, 2)
         @test Mooncake.friendly_tangent_cache(A) isa
             Mooncake.FriendlyTangentCache{Mooncake.AsRaw}

--- a/test/tangents/tangents.jl
+++ b/test/tangents/tangents.jl
@@ -384,6 +384,13 @@ using DispatchDoctor: allow_unstable
         d_cache = Mooncake.friendly_tangent_cache(Dict("a" => 1.0))
         @test d_cache isa Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}
     end
+
+    @testset "friendly_tangent_cache SparseMatrixCSC{Int} returns AsRaw" begin
+        using SparseArrays
+        A = SparseArrays.sparse([1, 2], [1, 2], [1, 2], 2, 2)
+        @test Mooncake.friendly_tangent_cache(A) isa
+            Mooncake.FriendlyTangentCache{Mooncake.AsRaw}
+    end
 end
 
 # The goal of these tests is to check that we can indeed generate tangent types for anything

--- a/test/tangents/tangents.jl
+++ b/test/tangents/tangents.jl
@@ -1,5 +1,4 @@
 using DispatchDoctor: allow_unstable
-using SparseArrays
 @testset "tangents" begin
     @testset "$(tangent_type(primal_type))" for (primal_type, expected_tangent_type) in Any[
 
@@ -386,8 +385,14 @@ using SparseArrays
         @test d_cache isa Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}
     end
 
-    @testset "friendly_tangent_cache SparseMatrixCSC{Int} returns AsRaw" begin
-        A = SparseArrays.sparse([1, 2], [1, 2], [1, 2], 2, 2)
+    @testset "friendly_tangent_cache Vector{Int} returns AsRaw" begin
+        A = [1, 2]
+        @test Mooncake.friendly_tangent_cache(A) isa
+            Mooncake.FriendlyTangentCache{Mooncake.AsRaw}
+    end
+
+    @testset "friendly_tangent_cache Transpose{Int} returns AsRaw (#1149)" begin
+        A = transpose([1, 2])
         @test Mooncake.friendly_tangent_cache(A) isa
             Mooncake.FriendlyTangentCache{Mooncake.AsRaw}
     end


### PR DESCRIPTION
  Add `tangent_type(eltype(P)) != NoTangent` to the array-recursion guard in `friendly_tangent_cache`. For integer-element sparse arrays,                
  `tangent_type(Int64) == NoTangent`, so the `map` is skipped and the cache falls through to `FriendlyTangentCache{AsRaw}` — the correct result since the
   elements are non-differentiable.                                                                                                                      
                                                                      
  The call to `tangent_type` in the generator body is safe here: every type for which `tangent_type == NoTangent` has an explicit, non-generated method, 
  so no generated dispatch occurs at generation time.
                                                                                                                                                         
  Fixes #1149 -- note the fix is not specific to SparseArrays and affect Arrays of Integers too.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1150 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1150/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 171.0 ns │     1.64 │         1.7 │    0.76 │        3.87 │   7.38 │
│             _sum_1000 │   1.1 μs │     5.97 │        1.02 │  4430.0 │        40.3 │   1.06 │
│          sum_sin_1000 │  7.42 μs │     2.47 │        1.11 │    1.63 │        10.9 │    1.8 │
│         _sum_sin_1000 │  4.61 μs │     3.86 │        2.65 │   359.0 │        17.7 │   3.08 │
│              kron_sum │ 193.0 μs │     13.0 │        3.32 │    7.13 │       500.0 │   18.2 │
│         kron_view_sum │ 264.0 μs │     12.9 │        5.32 │    29.6 │       375.0 │   6.86 │
│ naive_map_sin_cos_exp │  2.21 μs │     2.82 │        1.53 │ missing │        8.33 │   2.15 │
│       map_sin_cos_exp │  2.21 μs │     3.35 │        1.61 │    1.53 │        7.18 │   2.67 │
│ broadcast_sin_cos_exp │   2.3 μs │     3.15 │        1.56 │     4.2 │        1.42 │   2.11 │
│            simple_mlp │ 345.0 μs │     5.02 │        2.94 │     2.0 │        9.72 │    3.2 │
│                gp_lml │ 371.0 μs │     5.98 │        1.76 │    3.13 │     missing │   3.22 │
│    large_single_block │ 471.0 ns │     8.08 │        1.96 │  4130.0 │        36.0 │   2.06 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->