### PR TITLE
Add cached value_and_jacobian!! interface.

### DIFF
--- a/docs/src/developer_documentation/ir_representation.md
+++ b/docs/src/developer_documentation/ir_representation.md
@@ -231,7 +231,7 @@ For example, consider
 julia> using Mooncake.BasicBlockCode: ID # to improve printing
 
 julia> bb_ir.blocks[3].insts[1]
-Compiler.NewInstruction(:(Base.add_int(ID(109), 1)), Int64, Compiler.NoCallInfo(), (0, 0, 0), 0x00002478)
+Compiler.NewInstruction(:(Base.add_int(ID(2), 1)), Int64, Compiler.NoCallInfo(), (0, 0, 0), 0x00002478)
 ```
 This is the first instruction of the third basic block.
 The first field is a call to `Base.add_int`, the second field is `Int64` (we promise that the other fields are just copies of the corresponding data from the `Core.Compiler.InstructionStream` in the original `IRCode` representation of this IR).
@@ -249,15 +249,15 @@ The final major difference between `IRCode` and `BBCode` is that all ssa values 
 ```jldoctest my_factorial
 julia> bb_ir.blocks[3].inst_ids
 3-element Vector{ID}:
- ID(112)
- ID(113)
- ID(114)
+ ID(5)
+ ID(6)
+ ID(7)
 ```
 There is exactly one `ID` per instruction, and it is an error to have the same `ID` associated to multiple instructions.
 Similarly, while the number associated to a basic block in `IRCode` is a function of the number of basic blocks which precede it, the `ID` of a basic block in `BBCode` is stored in its `id` field:
 ```jldoctest my_factorial
 julia> bb_ir.blocks[3].id
-ID(118)
+ID(11)
 ```
 As a result of this, all references to ssa values and basic block numbers in `IRCode` are replaced with `ID`s in `BBCode`.
 The purpose of this is to guarantee that the "name" of a basic block and an instruction does not change when you insert new basic blocks and new instructions.
@@ -319,10 +319,10 @@ The same transformation can be performed on `BBCode`:
 julia> bb_ir_copy = copy(bb_ir);
 
 julia> old_inst = bb_ir_copy.blocks[3].insts[2]
-Compiler.NewInstruction(:(Base.mul_int(ID(108), ID(112))), Int64, Compiler.NoCallInfo(), (3, 0, 0), 0x00002478)
+Compiler.NewInstruction(:(Base.mul_int(ID(1), ID(5))), Int64, Compiler.NoCallInfo(), (3, 0, 0), 0x00002478)
 
 julia> new_stmt = Expr(:call, Base.add_int, old_inst.stmt.args[2:end]...)
-:((Core.Intrinsics.add_int)(ID(108), ID(112)))
+:((Core.Intrinsics.add_int)(ID(1), ID(5)))
 
 julia> bb_ir_copy.blocks[3].insts[2] = CC.NewInstruction(old_inst; stmt=new_stmt);
 

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -95,6 +95,26 @@ Separately, the Hessian path exposed by `prepare_hessian_cache` /
 closure. It does not currently use the public `NfwdMooncake` fast path, even though the
 outer layer is forward mode.
 
+## Jacobian example
+
+For a vector-valued function of a single dense vector input, `value_and_jacobian!!`
+returns the primal output together with a dense Jacobian whose columns correspond to
+input coordinates.
+
+```jldoctest
+julia> using Mooncake
+
+julia> f(x) = [x[1]^2 + x[2], x[1] * x[2]]
+f (generic function with 1 method)
+
+julia> x = [2.0, 3.0];
+
+julia> cache = Mooncake.prepare_derivative_cache(f, x);
+
+julia> Mooncake.value_and_jacobian!!(cache, f, x)
+([7.0, 6.0], [4.0 1.0; 3.0 2.0])
+```
+
 ## API Reference
 
 ```@docs; canonical=true

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -102,6 +102,7 @@ Mooncake.Config
 Mooncake.value_and_derivative!!
 Mooncake.value_and_gradient!!(::Mooncake.Cache, f::F, x::Vararg{Any, N}) where {F, N}
 Mooncake.value_and_gradient!!(::Mooncake.ForwardCache, f::F, x::Vararg{Any, N}) where {F, N}
+Mooncake.value_and_jacobian!!
 Mooncake.value_and_pullback!!(::Mooncake.Cache, ȳ, f::F, x::Vararg{Any, N}) where {F, N}
 Mooncake.prepare_derivative_cache
 Mooncake.prepare_gradient_cache

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -245,6 +245,7 @@ end
 # Public, exported
 export prepare_gradient_cache, value_and_gradient!!     # reverse
 export prepare_derivative_cache, value_and_derivative!! # forward
+export value_and_jacobian!!
 export prepare_hvp_cache, value_and_hvp!!
 export prepare_hessian_cache, value_gradient_and_hessian!!
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2396,6 +2396,177 @@ function _validate_hessian_arguments(x::Vararg{Any,N}) where {N}
     return T
 end
 
+function _validate_jacobian_argument(x)
+    x isa AbstractVector || throw(
+        ArgumentError(
+            "value_and_jacobian!! only supports AbstractVector inputs; got $(typeof(x))"
+        ),
+    )
+    T = eltype(x)
+    T <: IEEEFloat || throw(
+        ArgumentError(
+            "value_and_jacobian!! only supports AbstractVector inputs with IEEEFloat element types; got eltype $T",
+        ),
+    )
+    x isa DenseVector || throw(
+        ArgumentError(
+            "value_and_jacobian!! only supports dense vector inputs; got $(typeof(x))"
+        ),
+    )
+    return T
+end
+
+function _validate_jacobian_output(y, Tx)
+    y isa AbstractVector || throw(
+        ArgumentError(
+            "value_and_jacobian!! only supports AbstractVector outputs; got $(typeof(y))",
+        ),
+    )
+    Ty = eltype(y)
+    Ty <: IEEEFloat || throw(
+        ArgumentError(
+            "value_and_jacobian!! only supports AbstractVector outputs with IEEEFloat element types; got eltype $Ty",
+        ),
+    )
+    Ty == Tx || throw(
+        ArgumentError(
+            "value_and_jacobian!! requires input and output AbstractVector element types to match; got input eltype $Tx and output eltype $Ty",
+        ),
+    )
+    return Ty
+end
+
+"""
+    value_and_jacobian!!(cache::ForwardCache, f, x)
+    value_and_jacobian!!(cache::Cache, f, x)
+
+Using a pre-built cache, compute and return `(value, jacobian)` for a vector-valued
+function `f` of a single vector input.
+
+The current implementation supports a single dense vector input and an
+`AbstractVector` output, both with the same `IEEEFloat` element type. The returned
+Jacobian is a dense matrix whose columns correspond to input coordinates.
+
+!!! info
+    `cache` must be the output of [`prepare_derivative_cache`](@ref) or
+    [`prepare_pullback_cache`](@ref), and `f` and `x` must match the types and shapes used
+    to construct the cache.
+"""
+@unstable @inline function value_and_jacobian!!(
+    cache::ForwardCache, f::F, x::AbstractVector{<:IEEEFloat}
+) where {F}
+    _validate_prepared_cache_inputs(getfield(cache, :input_specs), (f, x))
+    Tx = _validate_jacobian_argument(x)
+    total_dof = length(x)
+    total_dof > 0 ||
+        throw(ArgumentError("value_and_jacobian!! requires a non-empty input vector"))
+    chunk_size = min(getfield(cache, :gradient_chunk_size), total_dof)
+    dz = zero_tangent(f)
+    # Without this pre-flight check, a mismatched output eltype surfaces as a
+    # MethodError inside the Nfwd engine rather than a clean ArgumentError.
+    let Y = Core.Compiler.return_type(f, Tuple{typeof(x)})
+        if Y <: AbstractVector
+            Ty = eltype(Y)
+            if Ty <: IEEEFloat && Ty != Tx
+                throw(
+                    ArgumentError(
+                        "value_and_jacobian!! requires input and output AbstractVector element types to match; got input eltype $Tx and output eltype $Ty",
+                    ),
+                )
+            end
+        end
+    end
+    y, chunk_dy = value_and_derivative!!(
+        cache,
+        (f, dz),
+        (x, NTangent(ntuple(lane -> _fcache_gradient_seed_tangent(x, lane), chunk_size))),
+    )
+    Ty = _validate_jacobian_output(y, Tx)
+    J = zeros(Ty, length(y), total_dof)
+    if chunk_dy isa NTangent
+        @inbounds for lane in 1:length(chunk_dy)
+            J[:, lane] .= chunk_dy[lane]
+        end
+    else
+        @inbounds J[:, 1] .= chunk_dy
+    end
+    for start_col in (chunk_size + 1):chunk_size:total_dof
+        _, chunk_dy = value_and_derivative!!(
+            cache,
+            (f, dz),
+            (
+                x,
+                NTangent(
+                    ntuple(
+                        lane -> let slot = start_col + lane - 1
+                            if slot <= total_dof
+                                _fcache_gradient_seed_tangent(x, slot)
+                            else
+                                zero_tangent(x)
+                            end
+                        end, chunk_size
+                    ),
+                ),
+            ),
+        )
+        if chunk_dy isa NTangent
+            @inbounds for lane in 1:length(chunk_dy)
+                col = start_col + lane - 1
+                col <= total_dof || break
+                J[:, col] .= chunk_dy[lane]
+            end
+        else
+            @inbounds J[:, start_col] .= chunk_dy
+        end
+    end
+    return y, J
+end
+
+@unstable @inline function value_and_jacobian!!(
+    cache::Cache, f::F, x::AbstractVector{<:IEEEFloat}
+) where {F}
+    _validate_prepared_cache_inputs(getfield(cache, :input_specs), (f, x))
+    Tx = _validate_jacobian_argument(x)
+    total_dof = length(x)
+    total_dof > 0 ||
+        throw(ArgumentError("value_and_jacobian!! requires a non-empty input vector"))
+    y_cache = getfield(cache, :y_cache)
+    Ty = _validate_jacobian_output(y_cache, Tx)
+    ȳ = zeros(Ty, length(y_cache))
+    J = zeros(Ty, length(ȳ), total_dof)
+    if isempty(ȳ)
+        y, _ = value_and_pullback!!(cache, ȳ, f, x)
+        return y, J
+    end
+
+    ȳ[1] = one(Ty)
+    y, pb = value_and_pullback!!(cache, ȳ, f, x)
+    @inbounds J[1, :] .= pb[2]
+    ȳ[1] = zero(Ty)
+
+    @inbounds for row in 2:length(ȳ)
+        ȳ[row] = one(Ty)
+        _, pb = value_and_pullback!!(cache, ȳ, f, x)
+        J[row, :] .= pb[2]
+        ȳ[row] = zero(Ty)
+    end
+
+    return y, J
+end
+
+@unstable function value_and_jacobian!!(cache::Union{Cache,ForwardCache}, f::F, x) where {F}
+    _validate_prepared_cache_inputs(getfield(cache, :input_specs), (f, x))
+    _validate_jacobian_argument(x)
+end
+
+@unstable function value_and_jacobian!!(cache, f::F, x) where {F}
+    throw(
+        ArgumentError(
+            "value_and_jacobian!! only supports cache types Cache and ForwardCache"
+        ),
+    )
+end
+
 """
     value_gradient_and_hessian!!(cache::HVPCache, f, x...)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2416,23 +2416,31 @@ function _validate_jacobian_argument(x)
     return T
 end
 
-function _validate_jacobian_output(y, Tx)
-    y isa AbstractVector || throw(
+function _throw_jacobian_eltype_mismatch(Tx, Ty)
+    throw(
         ArgumentError(
-            "value_and_jacobian!! only supports AbstractVector outputs; got $(typeof(y))",
+            "value_and_jacobian!! requires input and output AbstractVector element types to match; got input eltype $Tx and output eltype $Ty",
         ),
     )
+end
+
+function _throw_jacobian_output_type_error(y)
+    throw(
+        ArgumentError(
+            "value_and_jacobian!! only supports AbstractVector outputs; got $(typeof(y))"
+        ),
+    )
+end
+
+function _validate_jacobian_output(y, Tx)
+    y isa AbstractVector || _throw_jacobian_output_type_error(y)
     Ty = eltype(y)
     Ty <: IEEEFloat || throw(
         ArgumentError(
             "value_and_jacobian!! only supports AbstractVector outputs with IEEEFloat element types; got eltype $Ty",
         ),
     )
-    Ty == Tx || throw(
-        ArgumentError(
-            "value_and_jacobian!! requires input and output AbstractVector element types to match; got input eltype $Tx and output eltype $Ty",
-        ),
-    )
+    Ty == Tx || _throw_jacobian_eltype_mismatch(Tx, Ty)
     return Ty
 end
 
@@ -2455,33 +2463,19 @@ Jacobian is a dense matrix whose columns correspond to input coordinates.
 @unstable @inline function value_and_jacobian!!(
     cache::ForwardCache, f::F, x::AbstractVector{<:IEEEFloat}
 ) where {F}
+    _validate_jacobian_argument(x)
     _validate_prepared_cache_inputs(getfield(cache, :input_specs), (f, x))
-    Tx = _validate_jacobian_argument(x)
     total_dof = length(x)
     total_dof > 0 ||
         throw(ArgumentError("value_and_jacobian!! requires a non-empty input vector"))
-    chunk_size = min(getfield(cache, :gradient_chunk_size), total_dof)
+    chunk_size = min(cache.gradient_chunk_size, total_dof)
     dz = zero_tangent(f)
-    # Without this pre-flight check, a mismatched output eltype surfaces as a
-    # MethodError inside the Nfwd engine rather than a clean ArgumentError.
-    let Y = Core.Compiler.return_type(f, Tuple{typeof(x)})
-        if Y <: AbstractVector
-            Ty = eltype(Y)
-            if Ty <: IEEEFloat && Ty != Tx
-                throw(
-                    ArgumentError(
-                        "value_and_jacobian!! requires input and output AbstractVector element types to match; got input eltype $Tx and output eltype $Ty",
-                    ),
-                )
-            end
-        end
-    end
     y, chunk_dy = value_and_derivative!!(
         cache,
         (f, dz),
         (x, NTangent(ntuple(lane -> _fcache_gradient_seed_tangent(x, lane), chunk_size))),
     )
-    Ty = _validate_jacobian_output(y, Tx)
+    Ty = _validate_jacobian_output(y, eltype(x))
     J = zeros(Ty, length(y), total_dof)
     if chunk_dy isa NTangent
         @inbounds for lane in 1:length(chunk_dy)
@@ -2525,13 +2519,13 @@ end
 @unstable @inline function value_and_jacobian!!(
     cache::Cache, f::F, x::AbstractVector{<:IEEEFloat}
 ) where {F}
+    _validate_jacobian_argument(x)
     _validate_prepared_cache_inputs(getfield(cache, :input_specs), (f, x))
-    Tx = _validate_jacobian_argument(x)
     total_dof = length(x)
     total_dof > 0 ||
         throw(ArgumentError("value_and_jacobian!! requires a non-empty input vector"))
-    y_cache = getfield(cache, :y_cache)
-    Ty = _validate_jacobian_output(y_cache, Tx)
+    y_cache = cache.y_cache
+    Ty = _validate_jacobian_output(y_cache, eltype(x))
     ȳ = zeros(Ty, length(y_cache))
     J = zeros(Ty, length(ȳ), total_dof)
     if isempty(ȳ)
@@ -2555,8 +2549,8 @@ end
 end
 
 @unstable function value_and_jacobian!!(cache::Union{Cache,ForwardCache}, f::F, x) where {F}
-    _validate_prepared_cache_inputs(getfield(cache, :input_specs), (f, x))
     _validate_jacobian_argument(x)
+    _validate_prepared_cache_inputs(getfield(cache, :input_specs), (f, x))
 end
 
 @unstable function value_and_jacobian!!(cache, f::F, x) where {F}

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,4 +1,3 @@
-using Mooncake: TestUtils
 using Mooncake:
     prepare_gradient_cache,
     prepare_hvp_cache,
@@ -6,8 +5,13 @@ using Mooncake:
     prepare_pullback_cache,
     value_and_gradient!!,
     value_and_hvp!!,
+    value_and_jacobian!!,
     value_gradient_and_hessian!!,
-    value_and_pullback!!
+    value_and_pullback!!,
+    CoDual,
+    TestUtils,
+    build_rrule,
+    tangent_type
 
 struct SimplePair
     x1::Float64
@@ -1170,6 +1174,141 @@ end
                     _ndual_width_sensitive_sum(x, y), (Mooncake.NoTangent(), one(x), one(y))
                 )
             end
+        end
+
+        @testset "value_and_jacobian!!" begin
+            f_jac = x -> [x[1]^2 + x[2], x[1] * x[2], sin(x[2])]
+            x_jac = [x, y]
+            expected_jac = [2x 1.0; y x; 0.0 cos(y)]
+
+            fwd_cache_jac = Mooncake.prepare_derivative_cache(
+                f_jac,
+                x_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            val_jac_fwd, jac_fwd = Mooncake.value_and_jacobian!!(
+                fwd_cache_jac, f_jac, x_jac
+            )
+            @test val_jac_fwd == f_jac(x_jac)
+            @test jac_fwd ≈ expected_jac
+
+            rev_cache_jac = Mooncake.prepare_pullback_cache(
+                f_jac,
+                x_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            val_jac_rev, jac_rev = Mooncake.value_and_jacobian!!(
+                rev_cache_jac, f_jac, x_jac
+            )
+            @test val_jac_rev == f_jac(x_jac)
+            @test jac_rev ≈ expected_jac
+
+            x_jac2 = [x + 1, y - 1]
+            expected_jac2 = [2x_jac2[1] 1.0; x_jac2[2] x_jac2[1]; 0.0 cos(x_jac2[2])]
+            @test Mooncake.value_and_jacobian!!(fwd_cache_jac, f_jac, x_jac2) ==
+                (f_jac(x_jac2), expected_jac2)
+            @test Mooncake.value_and_jacobian!!(rev_cache_jac, f_jac, x_jac2) ==
+                (f_jac(x_jac2), expected_jac2)
+
+            scalar_out_fwd_cache = Mooncake.prepare_derivative_cache(
+                sum,
+                x_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+                scalar_out_fwd_cache, sum, x_jac
+            )
+            scalar_out_rev_cache = Mooncake.prepare_pullback_cache(
+                sum,
+                x_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+                scalar_out_rev_cache, sum, x_jac
+            )
+
+            fwd_cache_jac_chunk1 = Mooncake.prepare_derivative_cache(
+                f_jac, x_jac; config=Mooncake.Config(; chunk_size=1)
+            )
+            @test Mooncake.value_and_jacobian!!(fwd_cache_jac_chunk1, f_jac, x_jac) ==
+                (f_jac(x_jac), expected_jac)
+
+            hvp_cache = Mooncake.prepare_hvp_cache(sin, 1.0)
+            @test_throws "value_and_jacobian!! only supports cache types Cache and ForwardCache" Mooncake.value_and_jacobian!!(
+                hvp_cache, sin, 1.0
+            )
+
+            f_mut_jac = x -> (x .*= 2; x .^ 2)
+            x_mut_jac = [1.5, -2.0]
+            rev_cache_mut_jac = Mooncake.prepare_pullback_cache(
+                f_mut_jac,
+                copy(x_mut_jac);
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            x_mut_jac_work = copy(x_mut_jac)
+            val_mut_jac, jac_mut_jac = Mooncake.value_and_jacobian!!(
+                rev_cache_mut_jac, f_mut_jac, x_mut_jac_work
+            )
+            @test x_mut_jac_work == x_mut_jac
+            @test val_mut_jac == 4 .* x_mut_jac .^ 2
+            @test jac_mut_jac ≈ [8 * x_mut_jac[1] 0.0; 0.0 8 * x_mut_jac[2]]
+
+            x_mut_jac_chunked = [1.0, 2.0, 3.0]
+            fwd_cache_mut_jac = Mooncake.prepare_derivative_cache(
+                f_mut_jac,
+                copy(x_mut_jac_chunked);
+                config=Mooncake.Config(;
+                    chunk_size=2, debug_mode=false, friendly_tangents=false
+                ),
+            )
+            x_mut_jac_chunked_work = copy(x_mut_jac_chunked)
+            val_mut_jac_chunked, jac_mut_jac_chunked = Mooncake.value_and_jacobian!!(
+                fwd_cache_mut_jac, f_mut_jac, x_mut_jac_chunked_work
+            )
+            @test x_mut_jac_chunked_work == x_mut_jac_chunked
+            @test val_mut_jac_chunked == 4 .* x_mut_jac_chunked .^ 2
+            @test jac_mut_jac_chunked ≈ Diagonal(8 .* x_mut_jac_chunked)
+
+            x_jac_parent = [x, y, 0.0]
+            x_jac_view = @view x_jac_parent[1:2]
+            f_view_jac = x -> [x[1]^2, x[1] + x[2]]
+            fwd_cache_view_jac = Mooncake.prepare_derivative_cache(
+                f_view_jac,
+                x_jac_view;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+                fwd_cache_view_jac, f_view_jac, x_jac_view
+            )
+
+            rev_cache_view_jac = Mooncake.prepare_pullback_cache(
+                f_view_jac,
+                x_jac_view;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+                rev_cache_view_jac, f_view_jac, x_jac_view
+            )
+
+            f_mismatched_jac = x -> Float32[x[1] + x[2], x[1] - x[2]]
+            x_mismatched_jac = [x, y]
+            fwd_cache_mismatched_jac = Mooncake.prepare_derivative_cache(
+                f_mismatched_jac,
+                x_mismatched_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+                fwd_cache_mismatched_jac, f_mismatched_jac, x_mismatched_jac
+            )
+
+            rev_cache_mismatched_jac = Mooncake.prepare_pullback_cache(
+                f_mismatched_jac,
+                x_mismatched_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+                rev_cache_mismatched_jac, f_mismatched_jac, x_mismatched_jac
+            )
         end
 
         @testset "prepare_derivative_cache does not execute nfwd-eligible functions" begin

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1181,50 +1181,79 @@ end
             x_jac = [x, y]
             expected_jac = [2x 1.0; y x; 0.0 cos(y)]
 
-            fwd_cache_jac = Mooncake.prepare_derivative_cache(
-                f_jac,
-                x_jac;
-                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
-            )
-            val_jac_fwd, jac_fwd = Mooncake.value_and_jacobian!!(
-                fwd_cache_jac, f_jac, x_jac
-            )
-            @test val_jac_fwd == f_jac(x_jac)
-            @test jac_fwd ≈ expected_jac
+            for prepare_cache in
+                (Mooncake.prepare_derivative_cache, Mooncake.prepare_pullback_cache)
+                cache_jac = prepare_cache(
+                    f_jac,
+                    x_jac;
+                    config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+                )
+                val_jac, jac = Mooncake.value_and_jacobian!!(cache_jac, f_jac, x_jac)
+                @test val_jac == f_jac(x_jac)
+                @test jac ≈ expected_jac
 
-            rev_cache_jac = Mooncake.prepare_pullback_cache(
-                f_jac,
-                x_jac;
-                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
-            )
-            val_jac_rev, jac_rev = Mooncake.value_and_jacobian!!(
-                rev_cache_jac, f_jac, x_jac
-            )
-            @test val_jac_rev == f_jac(x_jac)
-            @test jac_rev ≈ expected_jac
-
-            x_jac2 = [x + 1, y - 1]
-            expected_jac2 = [2x_jac2[1] 1.0; x_jac2[2] x_jac2[1]; 0.0 cos(x_jac2[2])]
-            @test Mooncake.value_and_jacobian!!(fwd_cache_jac, f_jac, x_jac2) ==
-                (f_jac(x_jac2), expected_jac2)
-            @test Mooncake.value_and_jacobian!!(rev_cache_jac, f_jac, x_jac2) ==
-                (f_jac(x_jac2), expected_jac2)
+                x_jac2 = [x + 1, y - 1]
+                expected_jac2 = [2x_jac2[1] 1.0; x_jac2[2] x_jac2[1]; 0.0 cos(x_jac2[2])]
+                @test Mooncake.value_and_jacobian!!(cache_jac, f_jac, x_jac2) ==
+                    (f_jac(x_jac2), expected_jac2)
+            end
 
             scalar_out_fwd_cache = Mooncake.prepare_derivative_cache(
                 sum,
                 x_jac;
                 config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
             )
-            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+            @test_throws "value_and_jacobian!! only supports AbstractVector outputs" Mooncake.value_and_jacobian!!(
                 scalar_out_fwd_cache, sum, x_jac
             )
+
             scalar_out_rev_cache = Mooncake.prepare_pullback_cache(
                 sum,
                 x_jac;
                 config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
             )
-            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+            @test_throws "value_and_jacobian!! only supports AbstractVector outputs" Mooncake.value_and_jacobian!!(
                 scalar_out_rev_cache, sum, x_jac
+            )
+
+            f_empty_jac = x -> Float64[]
+            expected_empty = (Float64[], zeros(Float64, 0, length(x_jac)))
+            fwd_empty_cache = Mooncake.prepare_derivative_cache(
+                f_empty_jac,
+                x_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test Mooncake.value_and_jacobian!!(fwd_empty_cache, f_empty_jac, x_jac) ==
+                expected_empty
+
+            rev_empty_cache = Mooncake.prepare_pullback_cache(
+                f_empty_jac,
+                x_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test Mooncake.value_and_jacobian!!(rev_empty_cache, f_empty_jac, x_jac) ==
+                expected_empty
+            @test Mooncake.value_and_jacobian!!(
+                rev_empty_cache, f_empty_jac, [x + 1, y - 1]
+            ) == expected_empty
+
+            f_mismatched_jac = x -> Float32[x[1] + x[2], x[1] - x[2]]
+            fwd_cache_mismatched_jac = Mooncake.prepare_derivative_cache(
+                f_mismatched_jac,
+                x_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test_throws "value_and_jacobian!! requires input and output AbstractVector element types to match" Mooncake.value_and_jacobian!!(
+                fwd_cache_mismatched_jac, f_mismatched_jac, x_jac
+            )
+
+            rev_cache_mismatched_jac = Mooncake.prepare_pullback_cache(
+                f_mismatched_jac,
+                x_jac;
+                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+            )
+            @test_throws "value_and_jacobian!! requires input and output AbstractVector element types to match" Mooncake.value_and_jacobian!!(
+                rev_cache_mismatched_jac, f_mismatched_jac, x_jac
             )
 
             fwd_cache_jac_chunk1 = Mooncake.prepare_derivative_cache(
@@ -1272,43 +1301,17 @@ end
             x_jac_parent = [x, y, 0.0]
             x_jac_view = @view x_jac_parent[1:2]
             f_view_jac = x -> [x[1]^2, x[1] + x[2]]
-            fwd_cache_view_jac = Mooncake.prepare_derivative_cache(
-                f_view_jac,
-                x_jac_view;
-                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
-            )
-            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
-                fwd_cache_view_jac, f_view_jac, x_jac_view
-            )
-
-            rev_cache_view_jac = Mooncake.prepare_pullback_cache(
-                f_view_jac,
-                x_jac_view;
-                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
-            )
-            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
-                rev_cache_view_jac, f_view_jac, x_jac_view
-            )
-
-            f_mismatched_jac = x -> Float32[x[1] + x[2], x[1] - x[2]]
-            x_mismatched_jac = [x, y]
-            fwd_cache_mismatched_jac = Mooncake.prepare_derivative_cache(
-                f_mismatched_jac,
-                x_mismatched_jac;
-                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
-            )
-            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
-                fwd_cache_mismatched_jac, f_mismatched_jac, x_mismatched_jac
-            )
-
-            rev_cache_mismatched_jac = Mooncake.prepare_pullback_cache(
-                f_mismatched_jac,
-                x_mismatched_jac;
-                config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
-            )
-            @test_throws ArgumentError Mooncake.value_and_jacobian!!(
-                rev_cache_mismatched_jac, f_mismatched_jac, x_mismatched_jac
-            )
+            for prepare_cache in
+                (Mooncake.prepare_derivative_cache, Mooncake.prepare_pullback_cache)
+                view_cache_jac = prepare_cache(
+                    f_view_jac,
+                    x_jac_view;
+                    config=Mooncake.Config(; debug_mode=false, friendly_tangents=false),
+                )
+                @test_throws ArgumentError Mooncake.value_and_jacobian!!(
+                    view_cache_jac, f_view_jac, x_jac_view
+                )
+            end
         end
 
         @testset "prepare_derivative_cache does not execute nfwd-eligible functions" begin


### PR DESCRIPTION
Fix https://github.com/chalk-lab/Mooncake.jl/issues/1145

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1153 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1153/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.56 │        1.62 │   0.667 │        3.23 │   6.23 │
│             _sum_1000 │ 962.0 ns │     6.84 │        1.03 │  1800.0 │        43.5 │   1.07 │
│          sum_sin_1000 │  7.19 μs │     3.52 │        1.35 │    1.48 │        11.2 │   1.78 │
│         _sum_sin_1000 │  6.02 μs │     3.61 │        1.89 │   248.0 │        13.9 │   2.17 │
│              kron_sum │ 214.0 μs │     12.9 │        3.27 │    16.6 │       348.0 │   18.8 │
│         kron_view_sum │ 295.0 μs │     10.8 │        5.05 │    25.5 │       278.0 │   7.07 │
│ naive_map_sin_cos_exp │  2.51 μs │     2.87 │         1.5 │ missing │        7.17 │   1.97 │
│       map_sin_cos_exp │  2.56 μs │     3.37 │        1.53 │    1.59 │        5.99 │   2.42 │
│ broadcast_sin_cos_exp │  2.49 μs │     3.02 │        1.52 │    4.44 │        1.38 │   2.01 │
│            simple_mlp │ 379.0 μs │     4.49 │        2.75 │    1.94 │        9.02 │   2.71 │
│                gp_lml │ 223.0 μs │     9.06 │        2.17 │    5.56 │     missing │   4.73 │
│    large_single_block │ 421.0 ns │     7.09 │        2.16 │  4560.0 │        40.0 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->