### PR TITLE
Disable Turing benchmarks until DI is removed from Turing.jl hard deps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
           # {test_type: 'integration_testing', label: 'diffeq'},
           {test_type: 'integration_testing', label: 'dispatch_doctor'},
           {test_type: 'integration_testing', label: 'distributions'},
-          {test_type: 'integration_testing', label: 'dynamicppl'},
+          # {test_type: 'integration_testing', label: 'dynamicppl'},
           {test_type: 'integration_testing', label: 'gp'},
           {test_type: 'integration_testing', label: 'logexpfunctions'},
           {test_type: 'integration_testing', label: 'battery_tests'},

--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -136,7 +136,9 @@ run_dynamicppl_problem(f::F, x::X) where {F,X} = f(x)
 function should_run_benchmark(
     # TODO: re-enable when DI is removed from DynamicPPL hard deps. 
     # ::Val{:zygote}, ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)}, x...
-    ::Any, ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)}, x...
+    ::Any,
+    ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)},
+    x...,
 )
     return false
 end

--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -134,11 +134,7 @@ end
 run_dynamicppl_problem(f::F, x::X) where {F,X} = f(x)
 
 function should_run_benchmark(
-    # TODO: re-enable when DI is removed from DynamicPPL hard deps. 
-    # ::Val{:zygote}, ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)}, x...
-    ::Any,
-    ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)},
-    x...,
+    ::Val{:zygote}, ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)}, x...
 )
     return false
 end
@@ -173,7 +169,8 @@ function generate_inter_framework_tests()
             (_simple_mlp, randn(128, 256), randn(256, 128), randn(128, 70), randn(128, 70)),
         ),
         ("gp_lml", (_gp_lml, _generate_gp_inputs()...)),
-        ("turing_broadcast_benchmark", build_dynamicppl_problem()),
+        # TODO: re-enable when DI is removed from DynamicPPL hard deps. 
+        # ("turing_broadcast_benchmark", build_dynamicppl_problem()),
         ("large_single_block", (large_single_block, [0.9, 0.99])),
     ]
 end

--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -134,7 +134,9 @@ end
 run_dynamicppl_problem(f::F, x::X) where {F,X} = f(x)
 
 function should_run_benchmark(
-    ::Val{:zygote}, ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)}, x...
+    # TODO: re-enable when DI is removed from DynamicPPL hard deps. 
+    # ::Val{:zygote}, ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)}, x...
+    ::Any, ::Base.Fix1{<:typeof(DynamicPPL.LogDensityProblems.logdensity)}, x...
 )
     return false
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1155 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1155/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 181.0 ns │      1.6 │         1.6 │   0.663 │        3.32 │    6.2 │
│             _sum_1000 │ 962.0 ns │     7.05 │        1.02 │  1680.0 │        42.3 │   1.07 │
│          sum_sin_1000 │  7.25 μs │     3.47 │        1.36 │    1.49 │        10.8 │   1.71 │
│         _sum_sin_1000 │  6.15 μs │     3.53 │        1.86 │   252.0 │        12.8 │   2.14 │
│              kron_sum │ 304.0 μs │     10.3 │        2.73 │    15.7 │       275.0 │   14.9 │
│         kron_view_sum │ 357.0 μs │     10.1 │        4.89 │    22.2 │       260.0 │   6.08 │
│ naive_map_sin_cos_exp │  2.97 μs │     2.74 │        1.45 │ missing │        5.96 │   1.69 │
│       map_sin_cos_exp │  2.99 μs │     3.19 │        1.53 │    1.24 │        5.13 │   2.04 │
│ broadcast_sin_cos_exp │  2.98 μs │     3.33 │        1.44 │    3.54 │        1.14 │   1.69 │
│            simple_mlp │ 465.0 μs │     4.37 │        2.16 │    2.05 │        7.44 │   2.22 │
│                gp_lml │ 251.0 μs │     8.98 │        2.62 │     6.2 │     missing │   5.12 │
│    large_single_block │ 561.0 ns │     11.0 │        2.37 │  4350.0 │        24.7 │   1.54 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->