### PR TITLE
cleanup for codecov

### DIFF
--- a/src/tangents/fwds_rvs_data.jl
+++ b/src/tangents/fwds_rvs_data.jl
@@ -889,13 +889,6 @@ Given the type of the fdata and rdata, `F` and `R` resp., for some primal type, 
 tangent type. This method must be equivalent to `tangent_type(_typeof(primal))`.
 """
 
-# All methods below are marked @foldable (Base.@assume_effects :foldable), which tells
-# Julia to evaluate them at compile time. Their bodies never execute at runtime, so the
-# coverage instrumenter sees them as uninstrumented ("-") rather than hit or missed lines.
-# COV_EXCL_START/STOP excludes them from the Codecov patch-coverage calculation to avoid
-# a misleading drop. Correctness is verified by the direct tangent_type(F, R) tests in
-# test/tangents/fwds_rvs_data.jl.
-# COV_EXCL_START
 @foldable tangent_type(::Type{NoFData}, ::Type{NoRData}) = NoTangent
 @foldable tangent_type(::Type{NoFData}, ::Type{R}) where {R<:IEEEFloat} = R
 @foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
@@ -948,7 +941,6 @@ end
     @assert F isa Union
     Union{tangent_type(F.a, NoRData),tangent_type(F.b, NoRData)}
 end
-# COV_EXCL_STOP
 
 function _validate_union(::Type{F}) where {F<:Union{NoFData,T} where {T}}
     _T = F isa Union ? (F.a == NoFData ? F.b : F.a) : F
@@ -961,7 +953,6 @@ function _validate_union(::Type{F}) where {F<:Union{NoFData,T} where {T}}
     return nothing
 end
 
-# COV_EXCL_START  (same reason as above: all @foldable, never instrumented at runtime)
 # Tuples
 @foldable @generated function tangent_type(::Type{F}, ::Type{R}) where {F<:Tuple,R<:Tuple}
     tt_exprs = map((f, r) -> :(tangent_type($f, $r)), fieldtypes(F), fieldtypes(R))
@@ -1017,7 +1008,6 @@ end
 
 # Abstract types.
 @foldable tangent_type(::Type{Any}, ::Type{Any}) = Any
-# COV_EXCL_STOP
 
 """
     tangent(f, r)


### PR DESCRIPTION
Closes #1157 
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1158 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1158/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.56 │        1.62 │   0.722 │        3.62 │   7.01 │
│             _sum_1000 │  1.09 μs │      6.0 │        1.04 │  3670.0 │        40.0 │   1.06 │
│          sum_sin_1000 │  7.44 μs │      2.5 │        1.13 │     3.1 │        12.1 │   1.76 │
│         _sum_sin_1000 │  4.58 μs │     3.79 │        2.68 │   398.0 │        17.7 │    3.1 │
│              kron_sum │ 195.0 μs │     12.8 │         3.3 │    7.95 │       537.0 │   13.9 │
│         kron_view_sum │ 260.0 μs │     12.8 │        5.35 │    29.8 │       510.0 │   7.27 │
│ naive_map_sin_cos_exp │  2.25 μs │     2.84 │        1.53 │ missing │        8.37 │   2.13 │
│       map_sin_cos_exp │  2.24 μs │     3.24 │        1.62 │    1.55 │        7.11 │   2.67 │
│ broadcast_sin_cos_exp │   2.3 μs │     2.99 │        1.57 │    4.27 │        1.42 │    2.1 │
│            simple_mlp │ 353.0 μs │      5.0 │        2.88 │     2.0 │        9.36 │   3.11 │
│                gp_lml │ 375.0 μs │     5.94 │        1.74 │    4.91 │     missing │   3.37 │
│    large_single_block │ 481.0 ns │     6.95 │        1.97 │  4010.0 │        36.5 │   2.04 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->