### PR TITLE
Give a clear error for try/catch blocks in reverse-mode AD

### DIFF
--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -9,6 +9,37 @@ While `Mooncake.jl` should now work on a very large subset of the language, ther
 1. Builtins which require rules. The vast majority of them have rules now, but some don't. You should get a sensible error if you encounter a primitive without a rule.
 1. Anything involving tasks / threading -- we have no thread safety guarantees and, at the time of writing, I'm not entirely sure what error you will find if you attempt to AD through code which uses Julia's task / thread system. The same applies to distributed computing. These limitations ought to be possible to resolve.
 
+## `try`/`catch`/`finally` Blocks
+
+Mooncake.jl does not support differentiating through `try`/`catch` or `try`/`finally` blocks
+in **reverse mode**. Attempting to do so will produce an `UnhandledLanguageFeatureException`
+with a message explaining the cause. Forward mode does support these constructs.
+
+**The fix** is to replace `try`/`catch` blocks with explicit conditional checks where possible.
+For example:
+
+```julia
+# Does not work with Mooncake
+function safe_log(x)
+    try
+        return log(x)
+    catch e
+        return -Inf
+    end
+end
+
+# Works with Mooncake
+function safe_log(x)
+    x <= 0 && return -Inf
+    return log(x)
+end
+```
+
+If the `try`/`catch` block cannot be avoided (e.g. it lives inside a third-party library), the
+alternative is to provide a custom `rrule!!` for the function that contains the `try`/`catch`
+block, so that Mooncake never needs to differentiate through the block itself.
+See [Defining Rules](@ref) for guidance on writing custom rules.
+
 ## Mutation of Global Variables
 
 ```@meta

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1299,6 +1299,24 @@ function generate_ir(
     fwd_ret_type = forwards_ret_type(ir)
     rvs_ret_type = pullback_ret_type(ir)
 
+    # Check before normalise! to avoid a cryptic CC.verify_ir failure downstream.
+    for inst in stmt(ir.stmts)
+        is_enter = Meta.isexpr(inst, :enter)
+        @static if isdefined(Core, :EnterNode)
+            is_enter = is_enter || inst isa Core.EnterNode
+        end
+        if is_enter
+            unhandled_feature(
+                "try/catch/finally blocks are not supported by Mooncake.jl in reverse " *
+                "mode. The code being differentiated contains a try/catch or try/finally " *
+                "construct. Strategies for resolving this error include re-writing code " *
+                "to avoid try/catch blocks (e.g. by replacing them with explicit " *
+                "conditional checks), or providing a custom rrule!! for the relevant " *
+                "function. See the known limitations documentation for more context.",
+            )
+        end
+    end
+
     # Normalise the IR, and generated BBCode version of it.
     isva, spnames = is_vararg_and_sparam_names(sig_or_mi)
     ir = normalise!(ir, spnames)

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -356,9 +356,11 @@ rule_type_nonreturning(e::Exception) = throw(e)
         @test_throws(Mooncake.MooncakeRuleCompilationError, Mooncake.build_rrule(sin))
         _trycatch_fn(x::Float64) =
             try
-                ; return log(x);
+                ;
+                return log(x);
             catch
-                ; return 0.0;
+                ;
+                return 0.0;
             end
         @test_throws(
             Mooncake.MooncakeRuleCompilationError, Mooncake.build_rrule(_trycatch_fn, 1.0)

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -354,6 +354,10 @@ rule_type_nonreturning(e::Exception) = throw(e)
     end
     @testset "MooncakeRuleCompilationError" begin
         @test_throws(Mooncake.MooncakeRuleCompilationError, Mooncake.build_rrule(sin))
+        _trycatch_fn(x::Float64) = try; return log(x); catch; return 0.0; end
+        @test_throws(
+            Mooncake.MooncakeRuleCompilationError, Mooncake.build_rrule(_trycatch_fn, 1.0)
+        )
         # showerror should include the originating method's source location (issue #649)
         function _rrule_error_test_llvmcall(x::Int64)
             Base.llvmcall(

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -354,7 +354,12 @@ rule_type_nonreturning(e::Exception) = throw(e)
     end
     @testset "MooncakeRuleCompilationError" begin
         @test_throws(Mooncake.MooncakeRuleCompilationError, Mooncake.build_rrule(sin))
-        _trycatch_fn(x::Float64) = try; return log(x); catch; return 0.0; end
+        _trycatch_fn(x::Float64) =
+            try
+                ; return log(x);
+            catch
+                ; return 0.0;
+            end
         @test_throws(
             Mooncake.MooncakeRuleCompilationError, Mooncake.build_rrule(_trycatch_fn, 1.0)
         )


### PR DESCRIPTION

Closes #1147

- Scans the primal IR for `:enter`/`Core.EnterNode` in `generate_ir` before `normalise!` and throws `UnhandledLanguageFeatureException` with an actionable message
- Without this check, `CC.verify_ir` inside `normalise!` fails first with a cryptic _"IR verification failed"_ that gives no indication that `try`/`catch` is the cause
- Forward mode is unaffected — the check is placed only in the reverse-mode `generate_ir`
- Documents the limitation in `docs/src/known_limitations.md` with workarounds



🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1161 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1161/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.56 │        1.61 │   0.722 │        3.51 │   7.01 │
│             _sum_1000 │  1.07 μs │     6.14 │        1.05 │  3210.0 │        40.8 │   1.08 │
│          sum_sin_1000 │  7.46 μs │     2.49 │        1.11 │    1.65 │        10.9 │   1.78 │
│         _sum_sin_1000 │  4.63 μs │      3.8 │        2.66 │   372.0 │        17.8 │    3.1 │
│              kron_sum │ 198.0 μs │     12.8 │        3.28 │    12.0 │       482.0 │   22.8 │
│         kron_view_sum │ 264.0 μs │     12.7 │        5.31 │    29.3 │       483.0 │   8.17 │
│ naive_map_sin_cos_exp │  2.26 μs │     2.77 │         1.5 │ missing │        8.21 │   2.11 │
│       map_sin_cos_exp │  2.33 μs │     3.25 │        1.56 │    1.49 │        6.71 │   2.52 │
│ broadcast_sin_cos_exp │  2.32 μs │     2.98 │        1.55 │    4.15 │        1.39 │   2.06 │
│            simple_mlp │ 345.0 μs │     5.08 │        2.97 │    2.08 │        9.47 │   3.23 │
│                gp_lml │ 377.0 μs │      6.2 │        1.73 │    5.16 │     missing │   3.38 │
│    large_single_block │ 480.0 ns │     7.43 │        2.05 │  3880.0 │        31.3 │   2.04 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->