### PR TITLE
Document aliasing invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ The overall target is: correct by construction where possible, aggressively test
 - Only forward-over-reverse nested AD is tested. Do not assume rules compose correctly under reverse-over-reverse or other higher-order combinations unless explicitly verified.
 - Prefer clear Julia error messages, especially around malformed rules, unsupported cases, and rule-construction failures.
 - Mooncake's AD transform should preserve core execution properties: if the primal has zero allocation, the pullback should also have zero allocation; otherwise, pullbacks should allocate only a small constant-factor times the primal allocation (`c *` primal allocation); and type-stable primals should yield type-stable pullbacks.
-- Preserve semantics under mutation and aliasing, not just pure-function cases.
+- Preserve the aliasing invariant (`primal(a) === primal(b)` implies `fdata(a) === fdata(b)`): aliased primals must share fdata. Custom rules that intentionally break this must not allow the shared primal to be mutated in-place while both `CoDual`s are live. See the "Aliasing Invariant" subsection of `docs/src/understanding_mooncake/rule_system.md`.
 - In reverse mode, Mooncake usually restores mutations on the pullback; stateful exceptions need explicit rules and focused tests.
 - Internal helper APIs may change freely, but exported and public behaviour should come with tests, documentation, and clear error messages.
 - Prepared caches are shape/type dependent; when cache construction changes, test reuse semantics and failure modes.

--- a/docs/src/understanding_mooncake/rule_system.md
+++ b/docs/src/understanding_mooncake/rule_system.md
@@ -135,7 +135,7 @@ Observe that ``f`` behaves a little like a transition operator, in that the firs
 
 This model is good enough for the vast majority of functions.
 Unfortunately it isn't sufficient to describe a `function` when arguments alias each other (e.g. consider the way in which this particular model is wrong if `y` aliases `z`).
-Fortunately this is only a problem in a small fraction of all cases of aliasing, so we defer discussion of this until later on.
+Fortunately this is only a problem in a small fraction of all cases of aliasing, so we defer discussion of this until the [Aliasing Invariant](@ref) section below.
 
 Consider now how this approach can be used to model several additional Julia functions, and to obtain their derivatives and adjoints.
 
@@ -312,7 +312,7 @@ _**FData and RData**_
 While tangents are the things used to represent gradients and are what high-level interfaces will return, they are not what gets propagated forwards and backwards by rules during AD.
 
 Rather, during AD, Mooncake.jl makes a fundamental distinction between data which is identified by its address in memory (`Array`s, `mutable struct`s, etc), and data which is identified by its value (is-bits types such as `Float64`, `Int`, and `struct`s thereof).
-In particular, memory which is identified by its address gets assigned a unique location in memory in which its gradient lives (that this "unique gradient address" system is essential will become apparent when we discuss aliasing later on).
+In particular, memory which is identified by its address gets assigned a unique location in memory in which its gradient lives (that this "unique gradient address" system is essential will become apparent in the [Aliasing Invariant](@ref) section below).
 Conversely, the gradient w.r.t. a value type resides in another value type.
 
 The following docstring provides the best in-depth explanation.
@@ -330,6 +330,14 @@ _**CoDuals**_
 
 CoDuals are simply used to bundle together a primal and an associated fdata, depending upon context.
 Occassionally, they are used to pair together a primal and a tangent.
+
+_**Aliasing Invariant**_
+
+The AD transform upholds the _aliasing invariant_: `primal(a) === primal(b)` implies `fdata(a) === fdata(b)`.
+In-place mutations accumulate into fdata buffers; two `CoDual`s with the same primal but different fdata buffers would diverge under mutation, producing wrong gradients.
+
+The invariant holds automatically in generated AD code.
+Custom rules that break it — constructing a `CoDual` with a primal already held by another live `CoDual` but a different fdata — must not allow the shared primal to be mutated in-place while both are live.
 
 _**A quick aside: Non-Differentiable Data**_
 


### PR DESCRIPTION
- Adds an "Aliasing Invariant" subsection to `docs/src/understanding_mooncake/rule_system.md`, fulfilling two deferred references already present in that file ("we defer discussion of this until later on")
- Updates `AGENTS.md` with a concise statement of the invariant and a pointer to the new section

Closes #1081.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

_Pending. No docs preview comment found yet._

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │      1.5 │        1.61 │   0.667 │        3.23 │   6.23 │
│             _sum_1000 │ 952.0 ns │     6.92 │        1.03 │  1780.0 │        37.2 │   1.08 │
│          sum_sin_1000 │  7.74 μs │     3.48 │        1.24 │    2.54 │        10.4 │   1.62 │
│         _sum_sin_1000 │  6.64 μs │      3.4 │        1.73 │   235.0 │        12.0 │   1.99 │
│              kron_sum │ 211.0 μs │     11.9 │        3.21 │    13.3 │       340.0 │   19.0 │
│         kron_view_sum │ 291.0 μs │     10.9 │        5.05 │    25.6 │       312.0 │   6.96 │
│ naive_map_sin_cos_exp │  2.54 μs │     2.92 │        1.49 │ missing │        6.96 │   1.94 │
│       map_sin_cos_exp │  2.64 μs │     3.25 │        1.55 │    1.34 │        5.92 │   2.35 │
│ broadcast_sin_cos_exp │  2.53 μs │     3.05 │        1.62 │    4.37 │        1.42 │   2.03 │
│            simple_mlp │ 363.0 μs │     4.75 │        2.69 │    1.87 │        8.57 │   2.82 │
│                gp_lml │ 422.0 μs │      5.2 │        1.55 │    4.29 │     missing │   2.93 │
│    large_single_block │ 471.0 ns │     5.59 │        1.85 │  4010.0 │        28.3 │   1.83 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->