### PR TITLE
Import ChainRules SVD rule

### DIFF
--- a/ext/MooncakeChainRulesExt.jl
+++ b/ext/MooncakeChainRulesExt.jl
@@ -4,7 +4,17 @@ using ChainRules, LinearAlgebra, Mooncake
 using Base: IEEEFloat
 
 import Mooncake:
-    @is_primitive, CoDual, Dual, MinimalCtx, NoRData, frule!!, primal, rrule!!, tangent
+    @from_rrule,
+    @is_primitive,
+    CoDual,
+    DefaultCtx,
+    Dual,
+    MinimalCtx,
+    NoRData,
+    frule!!,
+    primal,
+    rrule!!,
+    tangent
 
 @is_primitive MinimalCtx Tuple{typeof(exp),Matrix{<:IEEEFloat}}
 
@@ -31,5 +41,7 @@ function rrule!!(::CoDual{typeof(exp)}, X::CoDual{Matrix{P}}) where {P<:IEEEFloa
     Ybar = zero(Y)
     return CoDual(Y, Ybar), ExpPullback{P}(pb, Ybar, X.dx)
 end
+
+@from_rrule DefaultCtx Tuple{typeof(svd),AbstractMatrix{<:IEEEFloat}}
 
 end

--- a/test/rules/linear_algebra.jl
+++ b/test/rules/linear_algebra.jl
@@ -1,3 +1,10 @@
 @testset "linear_algebra" begin
     TestUtils.run_rule_test_cases(StableRNG, Val(:linear_algebra))
 end
+
+if Base.get_extension(Mooncake, :MooncakeChainRulesExt) !== nothing
+    rng = StableRNG(123)
+    @testset "svd, $P, $m×$n" for P in [Float64, Float32], (m, n) in [(3, 3), (5, 3)]
+        TestUtils.test_rule(rng, svd, randn(rng, P, m, n); mode=ReverseMode)
+    end
+end


### PR DESCRIPTION
- Adds `@from_rrule DefaultCtx Tuple{typeof(svd),AbstractMatrix{<:IEEEFloat}}` to `MooncakeChainRulesExt`, importing ChainRules' `svd` reverse-mode rule for real matrices
- Tests reverse-mode correctness for Float64/Float32 and square/rectangular inputs in `test/rules/linear_algebra.jl`

Fixes #670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

_Pending. No docs preview comment found yet._

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 161.0 ns │     1.74 │         1.8 │   0.745 │        3.55 │   6.97 │
│             _sum_1000 │ 972.0 ns │     6.82 │        1.01 │  3770.0 │        39.3 │   1.06 │
│          sum_sin_1000 │  7.29 μs │     3.39 │        1.39 │    1.46 │        10.8 │   1.74 │
│         _sum_sin_1000 │  6.83 μs │     3.23 │        1.68 │   241.0 │        11.6 │   1.92 │
│              kron_sum │ 231.0 μs │     13.4 │        3.32 │    8.38 │       323.0 │   15.6 │
│         kron_view_sum │ 323.0 μs │     10.2 │        4.97 │    23.0 │       269.0 │   6.15 │
│ naive_map_sin_cos_exp │  2.64 μs │     2.82 │        1.46 │ missing │         6.7 │   1.89 │
│       map_sin_cos_exp │  2.41 μs │     3.52 │        1.55 │    1.41 │        6.32 │   2.58 │
│ broadcast_sin_cos_exp │  2.51 μs │     3.07 │        1.51 │    3.67 │        1.36 │   1.99 │
│            simple_mlp │ 397.0 μs │     4.56 │        2.45 │    2.01 │        8.82 │   2.61 │
│                gp_lml │ 398.0 μs │     5.65 │        1.74 │    3.16 │     missing │    3.1 │
│    large_single_block │ 421.0 ns │     7.59 │        1.95 │  4710.0 │        32.6 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->