### PR TITLE
`friendly_tangent_cache` comment fix

### DIFF
--- a/src/tangents/tangents.jl
+++ b/src/tangents/tangents.jl
@@ -1449,11 +1449,11 @@ Overloads for `LinearAlgebra.Symmetric`, `LinearAlgebra.Hermitian`, and
         end
         return :(NamedTuple{$names}(($(dest_exprs...),)))
     end
-    # Skip non-differentiable eltypes: avoids pointless caches and map on sparse containers.
-    # Calling tangent_type in a generator body would normally risk world-age cycles, since
-    # generators cannot safely trigger runtime dispatch into other generated functions.
-    # This is safe here because tangent_type is @foldable (Base.@assume_effects :foldable),
-    # meaning Julia evaluates it at compile time, avoiding any runtime dispatch.
+    # Skip non-differentiable eltypes: avoids pointless caches and map on sparse containers.                                                                                              
+    # Calling tangent_type in a generator body risks world-age cycles, but is safe here:
+    # every eltype for which tangent_type == NoTangent (integers, Bool, Symbol, …) has an                                                                                                 
+    # explicit non-generated method, and tangent_type for struct eltypes recurses only into
+    # field types, all of which eventually bottom out at such explicit methods. 
     if P <: AbstractArray &&
         !(eltype(P) <: Union{IEEEFloat,Complex{<:IEEEFloat}}) &&
         tangent_type(eltype(P)) != NoTangent

--- a/src/tangents/tangents.jl
+++ b/src/tangents/tangents.jl
@@ -1449,8 +1449,8 @@ Overloads for `LinearAlgebra.Symmetric`, `LinearAlgebra.Hermitian`, and
         end
         return :(NamedTuple{$names}(($(dest_exprs...),)))
     end
-    # Skip non-differentiable eltypes: avoids pointless caches and map on sparse containers.                                                                                              
-    # Calling tangent_type in a generator body risks world-age cycles, but is safe here:
+    # Skip non-differentiable eltypes: avoids pointless caches and maps on sparse containers.                                                                                              
+    # Calling tangent_type in a generator body risks world-age cycles, but is probably sufficient here:
     # every eltype for which tangent_type == NoTangent (integers, Bool, Symbol, …) has an                                                                                                 
     # explicit non-generated method, and tangent_type for struct eltypes recurses only into
     # field types, all of which eventually bottom out at such explicit methods. 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1164 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1164/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 190.0 ns │     1.53 │        1.79 │   0.684 │        3.53 │   6.64 │
│             _sum_1000 │   1.1 μs │     6.04 │        1.05 │  3780.0 │        40.0 │   1.06 │
│          sum_sin_1000 │  7.44 μs │     2.53 │        1.12 │    1.63 │        10.9 │   1.73 │
│         _sum_sin_1000 │  4.75 μs │     3.91 │        2.59 │   355.0 │        17.1 │    3.0 │
│              kron_sum │ 202.0 μs │     12.3 │        3.23 │    7.01 │       481.0 │   22.2 │
│         kron_view_sum │ 265.0 μs │     13.2 │        5.29 │    28.8 │       512.0 │   7.16 │
│ naive_map_sin_cos_exp │  2.27 μs │     2.83 │        1.51 │ missing │        8.38 │   2.14 │
│       map_sin_cos_exp │  2.39 μs │      3.1 │        1.47 │     1.4 │        6.65 │   2.42 │
│ broadcast_sin_cos_exp │  2.29 μs │      3.0 │         1.6 │    4.22 │        1.42 │   2.08 │
│            simple_mlp │ 354.0 μs │      4.9 │        2.87 │    2.19 │        9.79 │   3.11 │
│                gp_lml │ 380.0 μs │     5.76 │        1.68 │    3.41 │     missing │   3.51 │
│    large_single_block │ 481.0 ns │     7.23 │        1.94 │  3970.0 │        37.4 │   2.04 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->