### PR TITLE
Fix Type infering for overlayed methods

### DIFF
--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -114,6 +114,36 @@ else
     get_inference_world(interp::CC.AbstractInterpreter) = CC.get_inference_world(interp)
 end
 
+# A NativeInterpreter-like interpreter that uses Mooncake's OverlayMethodTable for method
+# lookup. Unlike MooncakeInterpreter it has no abstract_call_gf_by_type override, so it
+# infers method bodies using standard AbstractInterpreter behaviour — no primitive detection,
+# no MooncakeInterpreter recursion. Used for primitive call sites so we get overlay-aware
+# return types and effects without MooncakeInterpreter ever touching the primitive body,
+# preserving the base-case guarantee from PR #1115.
+struct OverlayNativeInterpreter <: CC.AbstractInterpreter
+    native::CC.NativeInterpreter
+    inf_cache::Vector{CC.InferenceResult}
+end
+
+OverlayNativeInterpreter(world::UInt) = OverlayNativeInterpreter(
+    CC.NativeInterpreter(world), CC.InferenceResult[]
+)
+
+CC.InferenceParams(i::OverlayNativeInterpreter) = CC.InferenceParams(i.native)
+CC.OptimizationParams(i::OverlayNativeInterpreter) = CC.OptimizationParams(i.native)
+CC.get_inference_cache(i::OverlayNativeInterpreter) = i.inf_cache
+CC.code_cache(i::OverlayNativeInterpreter) = CC.code_cache(i.native)
+function CC.method_table(i::OverlayNativeInterpreter)
+    return CC.OverlayMethodTable(get_inference_world(i), mooncake_method_table)
+end
+
+@static if VERSION < v"1.11.0"
+    CC.get_world_counter(i::OverlayNativeInterpreter) = CC.get_world_counter(i.native)
+else
+    CC.get_inference_world(i::OverlayNativeInterpreter) = CC.get_inference_world(i.native)
+    CC.cache_owner(::OverlayNativeInterpreter) = nothing
+end
+
 struct NoInlineCallInfo <: CC.CallInfo
     info::CC.CallInfo # wrapped call
     tt::Any # signature
@@ -160,20 +190,21 @@ function Core.Compiler.abstract_call_gf_by_type(
         if any_prim
             # A primitive already has a hand-written `rrule!!`, so Mooncake does not need
             # to inspect its body when differentiating. The only thing we need here is the
-            # ordinary `CallMeta` for the call site, especially the inferred return type.
+            # ordinary `CallMeta` for the call site (return type, effects, exct).
             #
-            # We therefore ask `NativeInterpreter` for the `CallMeta`. This avoids recursing
-            # through the callee IR using Mooncake's primitive-search logic:
-            # `MooncakeInterpreter` would walk nested calls in that body, check them for
-            # primitives, and continue that search down the callee tree. That extra work is
-            # unnecessary for a primitive with a hand-written rule.
+            # We use OverlayNativeInterpreter: it has Mooncake's OverlayMethodTable (so it
+            # finds @mooncake_overlay methods and infers their bodies, giving the correct
+            # return type and effects when an overlay changes the return type) but has no
+            # abstract_call_gf_by_type override (so it never recurses into primitive bodies
+            # with MooncakeInterpreter machinery). This preserves the base-case property
+            # from PR #1115 while being fully overlay-aware for both rt and effects.
             #
             # `noinline_callmeta` below then blocks inlining/const-folding so the primitive
             # call stays in the caller IR and Mooncake can dispatch its `rrule!!` at runtime.
             # See PR #1115 for more discussion.
-            native_interp = CC.NativeInterpreter(interp.world)
+            overlay_native_interp = OverlayNativeInterpreter(interp.world)
             ret = CC.abstract_call_gf_by_type(
-                native_interp, f, arginfo, si, atype, sv, max_methods
+                overlay_native_interp, f, arginfo, si, atype, sv, max_methods
             )
             @static if VERSION < v"1.12-"
                 call = ret::CC.CallMeta

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -116,32 +116,34 @@ end
 
 # A NativeInterpreter-like interpreter that uses Mooncake's OverlayMethodTable for method
 # lookup. Unlike MooncakeInterpreter it has no abstract_call_gf_by_type override, so it
-# infers method bodies using standard AbstractInterpreter behaviour — no primitive detection,
+# infers method bodies using standard AbstractInterpreter behaviour - no primitive detection,
 # no MooncakeInterpreter recursion. Used for primitive call sites so we get overlay-aware
 # return types and effects without MooncakeInterpreter ever touching the primitive body,
 # preserving the base-case guarantee from PR #1115.
-struct OverlayNativeInterpreter <: CC.AbstractInterpreter
+struct OverlayAwareNativeInterpreter <: CC.AbstractInterpreter
     native::CC.NativeInterpreter
     inf_cache::Vector{CC.InferenceResult}
 end
 
-OverlayNativeInterpreter(world::UInt) = OverlayNativeInterpreter(
-    CC.NativeInterpreter(world), CC.InferenceResult[]
-)
+function OverlayAwareNativeInterpreter(world::UInt)
+    OverlayAwareNativeInterpreter(CC.NativeInterpreter(world), CC.InferenceResult[])
+end
 
-CC.InferenceParams(i::OverlayNativeInterpreter) = CC.InferenceParams(i.native)
-CC.OptimizationParams(i::OverlayNativeInterpreter) = CC.OptimizationParams(i.native)
-CC.get_inference_cache(i::OverlayNativeInterpreter) = i.inf_cache
-CC.code_cache(i::OverlayNativeInterpreter) = CC.code_cache(i.native)
-function CC.method_table(i::OverlayNativeInterpreter)
+CC.InferenceParams(i::OverlayAwareNativeInterpreter) = CC.InferenceParams(i.native)
+CC.OptimizationParams(i::OverlayAwareNativeInterpreter) = CC.OptimizationParams(i.native)
+CC.get_inference_cache(i::OverlayAwareNativeInterpreter) = i.inf_cache
+CC.code_cache(i::OverlayAwareNativeInterpreter) = CC.code_cache(i.native)
+function CC.method_table(i::OverlayAwareNativeInterpreter)
     return CC.OverlayMethodTable(get_inference_world(i), mooncake_method_table)
 end
 
 @static if VERSION < v"1.11.0"
-    CC.get_world_counter(i::OverlayNativeInterpreter) = CC.get_world_counter(i.native)
+    CC.get_world_counter(i::OverlayAwareNativeInterpreter) = CC.get_world_counter(i.native)
 else
-    CC.get_inference_world(i::OverlayNativeInterpreter) = CC.get_inference_world(i.native)
-    CC.cache_owner(::OverlayNativeInterpreter) = nothing
+    CC.get_inference_world(i::OverlayAwareNativeInterpreter) = CC.get_inference_world(
+        i.native
+    )
+    CC.cache_owner(::OverlayAwareNativeInterpreter) = nothing
 end
 
 struct NoInlineCallInfo <: CC.CallInfo
@@ -192,17 +194,19 @@ function Core.Compiler.abstract_call_gf_by_type(
             # to inspect its body when differentiating. The only thing we need here is the
             # ordinary `CallMeta` for the call site (return type, effects, exct).
             #
-            # We use OverlayNativeInterpreter: it has Mooncake's OverlayMethodTable (so it
-            # finds @mooncake_overlay methods and infers their bodies, giving the correct
-            # return type and effects when an overlay changes the return type) but has no
-            # abstract_call_gf_by_type override (so it never recurses into primitive bodies
-            # with MooncakeInterpreter machinery). This preserves the base-case property
-            # from PR #1115 while being fully overlay-aware for both rt and effects.
+            # We therefore ask `OverlayAwareNativeInterpreter` for the `CallMeta`. This avoids recursing
+            # through the callee IR using Mooncake's primitive-search logic:
+            # `MooncakeInterpreter` would walk nested calls in that body, check them for
+            # primitives, and continue that search down the callee tree. That extra work is
+            # unnecessary for a primitive with a hand-written rule. 
+            # `OverlayAwareNativeInterpreter` also has access to the Mooncake method table, so it can find @mooncake_overlay methods and 
+            # infer their bodies, giving the correct return type and effects when an overlay changes the  return type. 
+            # (it has no abstract_call_gf_by_type override - so it never recurses into primitive bodies with MooncakeInterpreter machinery)
             #
             # `noinline_callmeta` below then blocks inlining/const-folding so the primitive
             # call stays in the caller IR and Mooncake can dispatch its `rrule!!` at runtime.
             # See PR #1115 for more discussion.
-            overlay_native_interp = OverlayNativeInterpreter(interp.world)
+            overlay_native_interp = OverlayAwareNativeInterpreter(interp.world)
             ret = CC.abstract_call_gf_by_type(
                 overlay_native_interp, f, arginfo, si, atype, sv, max_methods
             )

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -199,8 +199,8 @@ function Core.Compiler.abstract_call_gf_by_type(
             # `MooncakeInterpreter` would walk nested calls in that body, check them for
             # primitives, and continue that search down the callee tree. That extra work is
             # unnecessary for a primitive with a hand-written rule. 
-            # `OverlayAwareNativeInterpreter` also has access to the Mooncake method table, so it can find @mooncake_overlay methods and 
-            # infer their bodies, giving the correct return type and effects when an overlay changes the  return type. 
+            # `OverlayAwareNativeInterpreter` also has access to the Mooncake method table, so it can find @mooncake_overlay methods 
+            # and infer their bodies, giving the correct return type and effects when an overlay changes the return type. 
             # (it has no abstract_call_gf_by_type override - so it never recurses into primitive bodies with MooncakeInterpreter machinery)
             #
             # `noinline_callmeta` below then blocks inlining/const-folding so the primitive

--- a/test/interpreter/abstract_interpretation.jl
+++ b/test/interpreter/abstract_interpretation.jl
@@ -194,7 +194,8 @@ end
         # separate rrule!!s for each type (gradient 1x vs 2x). The correct gradient is
         # 2.0 iff Mooncake inferred the overlaid return type and dispatched to the TypeB
         # rrule!!. A wrong gradient of 1.0 indicates the overlay was ignored.
-        val, (_, grad) = Mooncake.value_and_gradient!!(_overlay_outer, 3.0)
+        cache = Mooncake.prepare_gradient_cache(_overlay_outer, 3.0)
+        val, (_, grad) = Mooncake.value_and_gradient!!(cache, _overlay_outer, 3.0)
         @test val == 6.0
         @test grad == 2.0
     end

--- a/test/interpreter/abstract_interpretation.jl
+++ b/test/interpreter/abstract_interpretation.jl
@@ -3,6 +3,47 @@ non_primitive(x) = sin(x)
 
 Mooncake.@is_primitive DefaultCtx ReverseMode Tuple{typeof(a_primitive),Float64}
 
+# Regression test: primitive with a @mooncake_overlay that changes the return type.
+# Before the fix, NativeInterpreter (overlay-blind) was used for type inference of
+# primitive calls, so downstream dispatch compiled against the non-overlaid type and
+# produced wrong gradients.
+struct _OverlayTypeA end
+struct _OverlayTypeB end
+
+_overlay_switch(::_OverlayTypeA) = _OverlayTypeA()
+Mooncake.@mooncake_overlay _overlay_switch(::_OverlayTypeA) = _OverlayTypeB()
+
+Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{typeof(_overlay_switch), _OverlayTypeA}
+function Mooncake.rrule!!(
+    f::CoDual{typeof(_overlay_switch)}, x::CoDual{_OverlayTypeA}
+)
+    return zero_fcodual(_OverlayTypeB()), NoPullback(f, x)
+end
+
+_overlay_use(::_OverlayTypeA, x::Float64) = x
+_overlay_use(::_OverlayTypeB, x::Float64) = 2x
+
+Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{typeof(_overlay_use), _OverlayTypeA, Float64}
+function Mooncake.rrule!!(
+    f::CoDual{typeof(_overlay_use)}, ::CoDual{_OverlayTypeA}, x::CoDual{Float64}
+)
+    pb(dy) = NoRData(), NoRData(), dy
+    return zero_fcodual(Mooncake.primal(x)), pb
+end
+
+Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{typeof(_overlay_use), _OverlayTypeB, Float64}
+function Mooncake.rrule!!(
+    f::CoDual{typeof(_overlay_use)}, ::CoDual{_OverlayTypeB}, x::CoDual{Float64}
+)
+    pb(dy) = NoRData(), NoRData(), 2dy
+    return zero_fcodual(2.0 * Mooncake.primal(x)), pb
+end
+
+function _overlay_outer(x::Float64)
+    b = _overlay_switch(_OverlayTypeA())
+    return _overlay_use(b, x)
+end
+
 contains_primitive(x) = @inline a_primitive(x)
 contains_non_primitive(x) = @inline non_primitive(x)
 contains_primitive_behind_call(x) = @inline contains_primitive(x)
@@ -145,5 +186,16 @@ end
         val, grad = Mooncake.value_and_gradient!!(cache, f, x)
         @test val ≈ sin(x[1]) + x[2]^2
         @test grad[2] ≈ [cos(x[1]), 2x[2]]
+    end
+
+    @testset "overlay with type-changing return is inferred correctly" begin
+        # _overlay_switch has a @mooncake_overlay that returns _OverlayTypeB instead of
+        # _OverlayTypeA. _overlay_outer passes the result to _overlay_use, which has
+        # separate rrule!!s for each type (gradient 1x vs 2x). The correct gradient is
+        # 2.0 iff Mooncake inferred the overlaid return type and dispatched to the TypeB
+        # rrule!!. A wrong gradient of 1.0 indicates the overlay was ignored.
+        val, (_, grad) = Mooncake.value_and_gradient!!(_overlay_outer, 3.0)
+        @test val == 6.0
+        @test grad == 2.0
     end
 end

--- a/test/interpreter/abstract_interpretation.jl
+++ b/test/interpreter/abstract_interpretation.jl
@@ -13,17 +13,17 @@ struct _OverlayTypeB end
 _overlay_switch(::_OverlayTypeA) = _OverlayTypeA()
 Mooncake.@mooncake_overlay _overlay_switch(::_OverlayTypeA) = _OverlayTypeB()
 
-Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{typeof(_overlay_switch), _OverlayTypeA}
-function Mooncake.rrule!!(
-    f::CoDual{typeof(_overlay_switch)}, x::CoDual{_OverlayTypeA}
-)
+Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{typeof(_overlay_switch),_OverlayTypeA}
+function Mooncake.rrule!!(f::CoDual{typeof(_overlay_switch)}, x::CoDual{_OverlayTypeA})
     return zero_fcodual(_OverlayTypeB()), NoPullback(f, x)
 end
 
 _overlay_use(::_OverlayTypeA, x::Float64) = x
 _overlay_use(::_OverlayTypeB, x::Float64) = 2x
 
-Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{typeof(_overlay_use), _OverlayTypeA, Float64}
+Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{
+    typeof(_overlay_use),_OverlayTypeA,Float64
+}
 function Mooncake.rrule!!(
     f::CoDual{typeof(_overlay_use)}, ::CoDual{_OverlayTypeA}, x::CoDual{Float64}
 )
@@ -31,7 +31,9 @@ function Mooncake.rrule!!(
     return zero_fcodual(Mooncake.primal(x)), pb
 end
 
-Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{typeof(_overlay_use), _OverlayTypeB, Float64}
+Mooncake.@is_primitive MinimalCtx ReverseMode Tuple{
+    typeof(_overlay_use),_OverlayTypeB,Float64
+}
 function Mooncake.rrule!!(
     f::CoDual{typeof(_overlay_use)}, ::CoDual{_OverlayTypeB}, x::CoDual{Float64}
 )


### PR DESCRIPTION
This PR Fixes incorrect gradients when `@mooncake_overlay` changes a primitive's return type :      

When a primitive has a `@mooncake_overlay` that changes its return type, downstream call sites in the same function were getting the wrong type inferred. The root cause was that the primitive inference path used `NativeInterpreter` directly, which doesn't know about Mooncake's overlay method table. 
So even though the overlay exists and runs at runtime, the type inference step would see the original method body and infer the original return type. Anything that dispatched on that return type downstream would then compile against the wrong specialisation.   

The fix introduces `OverlayAwareNativeInterpreter`, which infers every primitive using `NativeInterpreter` (with the standard julia method table) and also redirects it to `Mooncake`'s overlay table when we see a overlayed method. Using this in the primitive path means inference sees the overlay body and gets the correct return type.
The `OverlayAwareNativeInterpreter` wrapper has no `abstract_call_gf_by_type` override, so calls  inside primitive bodies still go through the default path and we don't recurse back into `MooncakeInterpreter` machinery - the base-case guarantee from PR #1115 is preserved. 

Also added a regression test: a primitive overlay switches `_OverlayTypeA` to `_OverlayTypeB`, and a downstream function has separate `rrule!!`s for each type giving gradients of `1x` vs `2x`. Without the fix the gradient is `1.0`; with it, `2.0`.   

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1168 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1168/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 181.0 ns │     1.55 │        1.61 │   0.718 │         3.6 │   7.02 │
│             _sum_1000 │  1.07 μs │     6.41 │        1.05 │  4290.0 │        43.0 │   1.08 │
│          sum_sin_1000 │  7.43 μs │     2.46 │        1.11 │    1.63 │        10.9 │   1.75 │
│         _sum_sin_1000 │  4.79 μs │     3.75 │        2.55 │   347.0 │        16.9 │   2.99 │
│              kron_sum │ 189.0 μs │     13.2 │        3.33 │    7.33 │       468.0 │   22.8 │
│         kron_view_sum │ 261.0 μs │     12.8 │        5.31 │    28.3 │       454.0 │   14.0 │
│ naive_map_sin_cos_exp │  2.26 μs │     2.79 │        1.53 │ missing │        8.32 │   2.14 │
│       map_sin_cos_exp │  2.16 μs │     3.37 │        1.67 │    1.59 │        7.32 │   2.72 │
│ broadcast_sin_cos_exp │   2.3 μs │     2.93 │        1.57 │     4.2 │        1.39 │   2.07 │
│            simple_mlp │ 457.0 μs │      3.8 │         2.2 │    1.64 │        7.13 │   2.41 │
│                gp_lml │ 165.0 μs │     11.6 │        2.61 │    4.79 │     missing │   5.55 │
│    large_single_block │ 471.0 ns │     5.27 │        1.93 │  4220.0 │        31.4 │   2.06 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->