### PR TITLE
rule reuse consistency checks

### DIFF
--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -558,6 +558,47 @@ function test_frule_correctness(
     @test any(isapprox_results)
 end
 
+function test_frule_reuse(x_ẋ...; frule)
+    @nospecialize x_ẋ
+    x_ẋ_a = map(_deepcopy, x_ẋ)
+    x_ẋ_b = map(_deepcopy, x_ẋ)
+    y_ẏ_a = frule(x_ẋ_a...)
+    y_ẏ_b = frule(x_ẋ_b...)
+    @test has_equal_data(primal(y_ẏ_a), primal(y_ẏ_b))
+    @test has_equal_data(tangent(y_ẏ_a), tangent(y_ẏ_b))
+    @test all(map(has_equal_data, map(tangent, x_ẋ_a), map(tangent, x_ẋ_b)))
+end
+
+function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
+    @nospecialize rng x_x̄
+    function make_inputs(x_x̄)
+        x_x̄ = map(_deepcopy, x_x̄)
+        x = map(primal, x_x̄)
+        x̄_zero = map(zero_tangent, x)
+        x̄_fwds = map(Mooncake.fdata, x̄_zero)
+        x_x̄_rule = map(
+            (xi, fi) -> fcodual_type(_typeof(xi))(_deepcopy(xi), fi), x, x̄_fwds
+        )
+        return x_x̄_rule, x̄_zero
+    end
+    inputs_a, x̄_zero_a = make_inputs(x_x̄)
+    inputs_b, x̄_zero_b = make_inputs(x_x̄)
+
+    # First forward+backward pass.
+    y_ȳ_a, pb_a!! = rrule(inputs_a...)
+    ŷ = randn_tangent(rng, primal(y_ȳ_a))
+    x̄_rvs_a = pb_a!!(Mooncake.rdata(ŷ))
+
+    # Second forward+backward pass with the same rule.
+    y_ȳ_b, pb_b!! = rrule(inputs_b...)
+    x̄_rvs_b = pb_b!!(Mooncake.rdata(_deepcopy(ŷ)))
+    @test has_equal_data(primal(y_ȳ_a), primal(y_ȳ_b))
+    @test has_equal_data(x̄_rvs_a, x̄_rvs_b)
+    @test all(
+        map(has_equal_data, map(Mooncake.fdata, x̄_zero_a), map(Mooncake.fdata, x̄_zero_b))
+    )
+end
+
 # Assumes that the interface has been tested, and we can simply check for numerical issues.
 function test_rrule_correctness(
     rng::AbstractRNG,
@@ -1034,9 +1075,6 @@ function test_rule(
                 test_rvs && test_rrule_interface(x_x̄...; rrule)
             end
 
-            # Snapshot of RNG so "Reuse" testset uses identical probe tangents to "Correctness" testset.
-            rng_snapshot = deepcopy(rng)
-
             # Test that answers are numerically correct / consistent.
             @testset "Correctness" begin
                 if test_fwd && !interface_only
@@ -1049,23 +1087,13 @@ function test_rule(
                 end
             end
 
-            # Verify rules are not invalidated by a first differentiation call.
+            # Verify rules give identical results on a second call.
             @testset "Reuse" begin
                 if test_fwd && !interface_only
-                    test_frule_correctness(
-                        rng_snapshot, x_ẋ...; frule, unsafe_perturb, atol, rtol
-                    )
+                    test_frule_reuse(x_ẋ...; frule)
                 end
                 if test_rvs && !interface_only
-                    test_rrule_correctness(
-                        rng_snapshot,
-                        x_x̄...;
-                        rrule,
-                        unsafe_perturb,
-                        output_tangent,
-                        atol,
-                        rtol,
-                    )
+                    test_rrule_reuse(rng, x_x̄...; rrule)
                 end
             end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -589,14 +589,18 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
     y_primal_a = _deepcopy(primal(y_ȳ_a))
     # Set output cotangent via fdata (vectors communicate cotangents through fdata, not rdata).
     ŷ_delta = randn_tangent(rng, primal(y_ȳ_a))
-    ȳ_a = increment!!(set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), ŷ_delta)
+    ȳ_a = increment!!(
+        set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), ŷ_delta
+    )
     x̄_rvs_a = pb_a!!(Mooncake.rdata(ȳ_a))
 
     # Second forward pass with the same rule.
     y_ȳ_b, pb_b!! = rrule(inputs_b...)
     y_primal_b = _deepcopy(primal(y_ȳ_b))
     # Same output cotangent as run A.
-    ȳ_b = increment!!(set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ŷ_delta))
+    ȳ_b = increment!!(
+        set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ŷ_delta)
+    )
     x̄_rvs_b = pb_b!!(Mooncake.rdata(ȳ_b))
 
     @test has_equal_data(y_primal_a, y_primal_b)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1034,6 +1034,9 @@ function test_rule(
                 test_rvs && test_rrule_interface(x_x̄...; rrule)
             end
 
+            # Snapshot of RNG so "Reuse" testset uses identical probe tangents to "Correctness" testset.
+            rng_snapshot = deepcopy(rng)
+
             # Test that answers are numerically correct / consistent.
             @testset "Correctness" begin
                 if test_fwd && !interface_only
@@ -1049,11 +1052,19 @@ function test_rule(
             # Verify rules are not invalidated by a first differentiation call.
             @testset "Reuse" begin
                 if test_fwd && !interface_only
-                    test_frule_correctness(rng, x_ẋ...; frule, unsafe_perturb, atol, rtol)
+                    test_frule_correctness(
+                        rng_snapshot, x_ẋ...; frule, unsafe_perturb, atol, rtol
+                    )
                 end
                 if test_rvs && !interface_only
                     test_rrule_correctness(
-                        rng, x_x̄...; rrule, unsafe_perturb, output_tangent, atol, rtol
+                        rng_snapshot,
+                        x_x̄...;
+                        rrule,
+                        unsafe_perturb,
+                        output_tangent,
+                        atol,
+                        rtol,
                     )
                 end
             end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -558,57 +558,6 @@ function test_frule_correctness(
     @test any(isapprox_results)
 end
 
-function test_frule_reuse(x_ẋ...; frule)
-    @nospecialize x_ẋ
-    x_ẋ_a = map(_deepcopy, x_ẋ)
-    x_ẋ_b = map(_deepcopy, x_ẋ)
-    y_ẏ_a = frule(x_ẋ_a...)
-    y_ẏ_b = frule(x_ẋ_b...)
-    @test has_equal_data(primal(y_ẏ_a), primal(y_ẏ_b))
-    @test has_equal_data(tangent(y_ẏ_a), tangent(y_ẏ_b))
-    @test all(map(has_equal_data, map(tangent, x_ẋ_a), map(tangent, x_ẋ_b)))
-end
-
-function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
-    @nospecialize rng x_x̄
-    x = map(primal, x_x̄)
-    x̄_zero_a = map(zero_tangent, x)
-    inputs_a = map(
-        (x, x̄_f) -> fcodual_type(_typeof(x))(_deepcopy(x), x̄_f),
-        x,
-        map(Mooncake.fdata, x̄_zero_a),
-    )
-    x̄_zero_b = map(zero_tangent, x)
-    inputs_b = map(
-        (x, x̄_f) -> fcodual_type(_typeof(x))(_deepcopy(x), x̄_f),
-        x,
-        map(Mooncake.fdata, x̄_zero_b),
-    )
-
-    # Skip the deepcopy when tangent(y_ȳ) is NoFData: such primals (e.g. Float64, or
-    # Module-containing types like Core.TypeName) can't be mutated by the pullback
-    y_ȳ_a, pb_a!! = rrule(inputs_a...)
-    y_primal_a = tangent(y_ȳ_a) isa NoFData ? primal(y_ȳ_a) : _deepcopy(primal(y_ȳ_a))
-    ȳ_delta = randn_tangent(rng, primal(y_ȳ_a))
-    ȳ_a = increment!!(
-        set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), _deepcopy(ȳ_delta)
-    )
-    x̄_rvs_a = pb_a!!(Mooncake.rdata(ȳ_a))
-
-    y_ȳ_b, pb_b!! = rrule(inputs_b...)
-    y_primal_b = tangent(y_ȳ_b) isa NoFData ? primal(y_ȳ_b) : _deepcopy(primal(y_ȳ_b))
-    ȳ_b = increment!!(
-        set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ȳ_delta)
-    )
-    x̄_rvs_b = pb_b!!(Mooncake.rdata(ȳ_b))
-
-    @test has_equal_data(y_primal_a, y_primal_b)
-    @test has_equal_data(x̄_rvs_a, x̄_rvs_b)
-    @test all(
-        map(has_equal_data, map(Mooncake.fdata, x̄_zero_a), map(Mooncake.fdata, x̄_zero_b))
-    )
-end
-
 # Assumes that the interface has been tested, and we can simply check for numerical issues.
 function test_rrule_correctness(
     rng::AbstractRNG,
@@ -716,6 +665,73 @@ _deepcopy(x) = deepcopy(x)
 _deepcopy(x::Module) = x
 
 rrule_output_type(::Type{Ty}) where {Ty} = Tuple{Mooncake.fcodual_type(Ty),Any}
+
+function test_frule_reuse(x_ẋ...; frule)
+    @nospecialize x_ẋ
+    x_ẋ_a = map(_deepcopy, x_ẋ)
+    x_ẋ_b = map(_deepcopy, x_ẋ)
+
+    # Snapshot first-call observables; aliased mutable buffers would otherwise let
+    # call B overwrite call A's data and the comparisons alias-pass.
+    y_ẏ_a = frule(x_ẋ_a...)
+    y_primal_a = _deepcopy(primal(y_ẏ_a))
+    y_tangent_a = _deepcopy(tangent(y_ẏ_a))
+    x_primal_a = map(_deepcopy ∘ primal, x_ẋ_a)
+    x_tangent_a = map(_deepcopy ∘ tangent, x_ẋ_a)
+
+    y_ẏ_b = frule(x_ẋ_b...)
+
+    @test has_equal_data(y_primal_a, primal(y_ẏ_b))
+    @test has_equal_data(y_tangent_a, tangent(y_ẏ_b))
+    @test all(map(has_equal_data, x_primal_a, map(primal, x_ẋ_b)))
+    @test all(map(has_equal_data, x_tangent_a, map(tangent, x_ẋ_b)))
+end
+
+function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule, output_tangent=nothing)
+    @nospecialize rng x_x̄
+    x = map(primal, x_x̄)
+    x̄_zero_a = map(zero_tangent, x)
+    inputs_a = map(
+        (x, x̄_f) -> fcodual_type(_typeof(x))(_deepcopy(x), x̄_f),
+        x,
+        map(Mooncake.fdata, x̄_zero_a),
+    )
+    x̄_zero_b = map(zero_tangent, x)
+    inputs_b = map(
+        (x, x̄_f) -> fcodual_type(_typeof(x))(_deepcopy(x), x̄_f),
+        x,
+        map(Mooncake.fdata, x̄_zero_b),
+    )
+
+    # Snapshot first-call observables; aliased mutable buffers (in either the rule
+    # or its pullback) would otherwise let call B overwrite call A's data.
+    y_ȳ_a, pb_a!! = rrule(inputs_a...)
+    y_primal_a = _deepcopy(primal(y_ȳ_a))
+    y_fdata_a = _deepcopy(tangent(y_ȳ_a))
+    ȳ_delta = if isnothing(output_tangent)
+        randn_tangent(rng, primal(y_ȳ_a))
+    else
+        output_tangent
+    end
+    ȳ_a = increment!!(
+        set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), _deepcopy(ȳ_delta)
+    )
+    x̄_rvs_a = _deepcopy(pb_a!!(Mooncake.rdata(ȳ_a)))
+    x_primal_post_a = map(_deepcopy ∘ primal, inputs_a)
+    fdata_post_a = map(_deepcopy ∘ Mooncake.fdata, x̄_zero_a)
+
+    y_ȳ_b, pb_b!! = rrule(inputs_b...)
+    ȳ_b = increment!!(
+        set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ȳ_delta)
+    )
+    x̄_rvs_b = pb_b!!(Mooncake.rdata(ȳ_b))
+
+    @test has_equal_data(y_primal_a, primal(y_ȳ_b))
+    @test has_equal_data(y_fdata_a, tangent(y_ȳ_b))
+    @test all(map(has_equal_data, x_primal_post_a, map(primal, inputs_b)))
+    @test has_equal_data(x̄_rvs_a, x̄_rvs_b)
+    @test all(map(has_equal_data, fdata_post_a, map(Mooncake.fdata, x̄_zero_b)))
+end
 
 function test_frule_interface(x_ẋ...; frule)
     @nospecialize x_ẋ
@@ -1086,7 +1102,8 @@ function test_rule(
                     test_frule_reuse(x_ẋ...; frule)
                 end
                 if test_rvs && !interface_only
-                    test_rrule_reuse(Xoshiro(123), x_x̄...; rrule)
+                    # Isolated rng so Reuse doesn't perturb Correctness's rng state.
+                    test_rrule_reuse(Xoshiro(123), x_x̄...; rrule, output_tangent)
                 end
             end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -569,41 +569,36 @@ function test_frule_reuse(x_ẋ...; frule)
     @test all(map(has_equal_data, map(tangent, x_ẋ_a), map(tangent, x_ẋ_b)))
 end
 
-function test_rrule_reuse(x_x̄...; rrule)
-    @nospecialize x_x̄
-    rng = Xoshiro(123)
-    x_a = map(_deepcopy, map(primal, x_x̄))
-    x̄_zero_a = map(zero_tangent, x_a)
+function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
+    @nospecialize rng x_x̄
+    x = map(primal, x_x̄)
+    x̄_zero_a = map(zero_tangent, x)
     inputs_a = map(
-        (xi, fi) -> fcodual_type(_typeof(xi))(_deepcopy(xi), fi),
-        x_a,
+        (x, x̄_f) -> fcodual_type(_typeof(x))(_deepcopy(x), x̄_f),
+        x,
         map(Mooncake.fdata, x̄_zero_a),
     )
-    x_b = map(_deepcopy, map(primal, x_x̄))
-    x̄_zero_b = map(zero_tangent, x_b)
+    x̄_zero_b = map(zero_tangent, x)
     inputs_b = map(
-        (xi, fi) -> fcodual_type(_typeof(xi))(_deepcopy(xi), fi),
-        x_b,
+        (x, x̄_f) -> fcodual_type(_typeof(x))(_deepcopy(x), x̄_f),
+        x,
         map(Mooncake.fdata, x̄_zero_b),
     )
 
-    # First forward pass: snapshot primal before pullback can modify it.
-    # Only deepcopy when the output has an fdata component -- if tangent is NoFData,
-    # Mooncake does not track mutations on the primal and the pullback won’t modify it
-    # (and deepcopy may fail for types containing Modules, e.g. Core.TypeName).
+    # Skip the deepcopy when tangent(y_ȳ) is NoFData: such primals (e.g. Float64, or
+    # Module-containing types like Core.TypeName) can't be mutated by the pullback
     y_ȳ_a, pb_a!! = rrule(inputs_a...)
     y_primal_a = tangent(y_ȳ_a) isa NoFData ? primal(y_ȳ_a) : _deepcopy(primal(y_ȳ_a))
-    # Set output cotangent via fdata (vectors communicate cotangents through fdata, not rdata).
-    ŷ_delta = randn_tangent(rng, primal(y_ȳ_a))
+    ȳ_delta = randn_tangent(rng, primal(y_ȳ_a))
     ȳ_a = increment!!(
-        set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), ŷ_delta
+        set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), _deepcopy(ȳ_delta)
     )
     x̄_rvs_a = pb_a!!(Mooncake.rdata(ȳ_a))
 
     y_ȳ_b, pb_b!! = rrule(inputs_b...)
     y_primal_b = tangent(y_ȳ_b) isa NoFData ? primal(y_ȳ_b) : _deepcopy(primal(y_ȳ_b))
     ȳ_b = increment!!(
-        set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ŷ_delta)
+        set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ȳ_delta)
     )
     x̄_rvs_b = pb_b!!(Mooncake.rdata(ȳ_b))
 
@@ -1091,7 +1086,7 @@ function test_rule(
                     test_frule_reuse(x_ẋ...; frule)
                 end
                 if test_rvs && !interface_only
-                    test_rrule_reuse(x_x̄...; rrule)
+                    test_rrule_reuse(rng, x_x̄...; rrule)
                 end
             end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -584,9 +584,12 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
     inputs_a, x̄_zero_a = make_inputs(x_x̄)
     inputs_b, x̄_zero_b = make_inputs(x_x̄)
 
-    # First forward pass: snapshot primal before pullback can modify it.
+    # First forward pass: snapshot primal before pullback can restore mutations.
+    # Only deepcopy when the output has an fdata component -- if tangent is NoFData,
+    # Mooncake does not track mutations on the primal and the pullback won’t modify it
+    # (and deepcopy may fail for types containing Modules, e.g. Core.TypeName).
     y_ȳ_a, pb_a!! = rrule(inputs_a...)
-    y_primal_a = _deepcopy(primal(y_ȳ_a))
+    y_primal_a = tangent(y_ȳ_a) isa NoFData ? primal(y_ȳ_a) : _deepcopy(primal(y_ȳ_a))
     # Set output cotangent via fdata (vectors communicate cotangents through fdata, not rdata).
     ŷ_delta = randn_tangent(rng, primal(y_ȳ_a))
     ȳ_a = increment!!(
@@ -596,7 +599,7 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
 
     # Second forward pass with the same rule.
     y_ȳ_b, pb_b!! = rrule(inputs_b...)
-    y_primal_b = _deepcopy(primal(y_ȳ_b))
+    y_primal_b = tangent(y_ȳ_b) isa NoFData ? primal(y_ȳ_b) : _deepcopy(primal(y_ȳ_b))
     # Same output cotangent as run A.
     ȳ_b = increment!!(
         set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ŷ_delta)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -678,30 +678,30 @@ function test_frule_reuse(x_ẋ...; frule)
     # types like Core.TypeName) can't safely be deepcopied and can't be mutated either.
     y_ẏ_a = frule(x_ẋ_a...)
     y_primal_a = tangent(y_ẏ_a) isa NoTangent ? primal(y_ẏ_a) : _deepcopy(primal(y_ẏ_a))
-    y_tangent_a = _deepcopy(tangent(y_ẏ_a))
-    x_tangent_a = map(_deepcopy ∘ tangent, x_ẋ_a)
+    ẏ_a = _deepcopy(tangent(y_ẏ_a))
+    ẋ_a = map(_deepcopy ∘ tangent, x_ẋ_a)
 
     y_ẏ_b = frule(x_ẋ_b...)
     y_primal_b = tangent(y_ẏ_b) isa NoTangent ? primal(y_ẏ_b) : _deepcopy(primal(y_ẏ_b))
-    y_tangent_b = _deepcopy(tangent(y_ẏ_b))
-    x_tangent_b = map(_deepcopy ∘ tangent, x_ẋ_b)
+    ẏ_b = _deepcopy(tangent(y_ẏ_b))
+    ẋ_b = map(_deepcopy ∘ tangent, x_ẋ_b)
 
     @test has_equal_data(y_primal_a, y_primal_b)
-    @test has_equal_data(y_tangent_a, y_tangent_b)
-    @test all(map(has_equal_data, x_tangent_a, x_tangent_b))
+    @test has_equal_data(ẏ_a, ẏ_b)
+    @test all(map(has_equal_data, ẋ_a, ẋ_b))
 end
 
 function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule, output_tangent=nothing)
     @nospecialize rng x_x̄
     x = map(primal, x_x̄)
     x̄_zero_a = map(zero_tangent, x)
-    inputs_a = map(
+    x_x̄_a = map(
         (x, x̄_f) -> fcodual_type(_typeof(x))(_deepcopy(x), x̄_f),
         x,
         map(Mooncake.fdata, x̄_zero_a),
     )
     x̄_zero_b = map(zero_tangent, x)
-    inputs_b = map(
+    x_x̄_b = map(
         (x, x̄_f) -> fcodual_type(_typeof(x))(_deepcopy(x), x̄_f),
         x,
         map(Mooncake.fdata, x̄_zero_b),
@@ -715,7 +715,7 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule, output_tangent=noth
     # Skip the deepcopy when tangent (fdata) is NoFData: such primals (e.g. Module-
     # containing types like Core.TypeName) can't safely be deepcopied and the pullback
     # has no fdata path through which it could mutate them.
-    y_ȳ_a, pb_a!! = rrule(inputs_a...)
+    y_ȳ_a, pb_a!! = rrule(x_x̄_a...)
     y_primal_a = tangent(y_ȳ_a) isa NoFData ? primal(y_ȳ_a) : _deepcopy(primal(y_ȳ_a))
     y_fdata_a = _deepcopy(tangent(y_ȳ_a))
     ȳ_delta = if isnothing(output_tangent)
@@ -727,21 +727,21 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule, output_tangent=noth
         set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), _deepcopy(ȳ_delta)
     )
     x̄_rvs_a = _deepcopy(pb_a!!(Mooncake.rdata(ȳ_a)))
-    fdata_post_a = map(_deepcopy ∘ Mooncake.fdata, x̄_zero_a)
+    x̄_fwds_a = map(_deepcopy ∘ Mooncake.fdata, x̄_zero_a)
 
-    y_ȳ_b, pb_b!! = rrule(inputs_b...)
+    y_ȳ_b, pb_b!! = rrule(x_x̄_b...)
     y_primal_b = tangent(y_ȳ_b) isa NoFData ? primal(y_ȳ_b) : _deepcopy(primal(y_ȳ_b))
     y_fdata_b = _deepcopy(tangent(y_ȳ_b))
     ȳ_b = increment!!(
         set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ȳ_delta)
     )
     x̄_rvs_b = _deepcopy(pb_b!!(Mooncake.rdata(ȳ_b)))
-    fdata_post_b = map(_deepcopy ∘ Mooncake.fdata, x̄_zero_b)
+    x̄_fwds_b = map(_deepcopy ∘ Mooncake.fdata, x̄_zero_b)
 
     @test has_equal_data(y_primal_a, y_primal_b)
     @test has_equal_data(y_fdata_a, y_fdata_b)
     @test has_equal_data(x̄_rvs_a, x̄_rvs_b)
-    @test all(map(has_equal_data, fdata_post_a, fdata_post_b))
+    @test all(map(has_equal_data, x̄_fwds_a, x̄_fwds_b))
 end
 
 function test_frule_interface(x_ẋ...; frule)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -671,20 +671,24 @@ function test_frule_reuse(x_ẋ...; frule)
     x_ẋ_a = map(_deepcopy, x_ẋ)
     x_ẋ_b = map(_deepcopy, x_ẋ)
 
-    # Snapshot first-call observables; aliased mutable buffers would otherwise let
-    # call B overwrite call A's data and the comparisons alias-pass.
+    # Snapshot every observable at the same point in each cycle. Without snapshots,
+    # an aliased mutable buffer would let call B overwrite call A's data; snapshotting
+    # only one side would compare different temporal points if a rule mutates inputs.
+    # Skip the deepcopy when tangent is NoTangent: such primals (e.g. Module-containing
+    # types like Core.TypeName) can't safely be deepcopied and can't be mutated either.
     y_ẏ_a = frule(x_ẋ_a...)
-    y_primal_a = _deepcopy(primal(y_ẏ_a))
+    y_primal_a = tangent(y_ẏ_a) isa NoTangent ? primal(y_ẏ_a) : _deepcopy(primal(y_ẏ_a))
     y_tangent_a = _deepcopy(tangent(y_ẏ_a))
-    x_primal_a = map(_deepcopy ∘ primal, x_ẋ_a)
     x_tangent_a = map(_deepcopy ∘ tangent, x_ẋ_a)
 
     y_ẏ_b = frule(x_ẋ_b...)
+    y_primal_b = tangent(y_ẏ_b) isa NoTangent ? primal(y_ẏ_b) : _deepcopy(primal(y_ẏ_b))
+    y_tangent_b = _deepcopy(tangent(y_ẏ_b))
+    x_tangent_b = map(_deepcopy ∘ tangent, x_ẋ_b)
 
-    @test has_equal_data(y_primal_a, primal(y_ẏ_b))
-    @test has_equal_data(y_tangent_a, tangent(y_ẏ_b))
-    @test all(map(has_equal_data, x_primal_a, map(primal, x_ẋ_b)))
-    @test all(map(has_equal_data, x_tangent_a, map(tangent, x_ẋ_b)))
+    @test has_equal_data(y_primal_a, y_primal_b)
+    @test has_equal_data(y_tangent_a, y_tangent_b)
+    @test all(map(has_equal_data, x_tangent_a, x_tangent_b))
 end
 
 function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule, output_tangent=nothing)
@@ -703,10 +707,16 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule, output_tangent=noth
         map(Mooncake.fdata, x̄_zero_b),
     )
 
-    # Snapshot first-call observables; aliased mutable buffers (in either the rule
-    # or its pullback) would otherwise let call B overwrite call A's data.
+    # Snapshot every observable at the same point in each cycle: post-forward for
+    # output primal/fdata, post-pullback for inputs and pullback returns. Without
+    # snapshots, aliased mutable buffers can alias-pass; snapshotting only one side
+    # would compare different temporal points since the pullback restores in-place
+    # mutations on the way back.
+    # Skip the deepcopy when tangent (fdata) is NoFData: such primals (e.g. Module-
+    # containing types like Core.TypeName) can't safely be deepcopied and the pullback
+    # has no fdata path through which it could mutate them.
     y_ȳ_a, pb_a!! = rrule(inputs_a...)
-    y_primal_a = _deepcopy(primal(y_ȳ_a))
+    y_primal_a = tangent(y_ȳ_a) isa NoFData ? primal(y_ȳ_a) : _deepcopy(primal(y_ȳ_a))
     y_fdata_a = _deepcopy(tangent(y_ȳ_a))
     ȳ_delta = if isnothing(output_tangent)
         randn_tangent(rng, primal(y_ȳ_a))
@@ -717,20 +727,21 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule, output_tangent=noth
         set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), _deepcopy(ȳ_delta)
     )
     x̄_rvs_a = _deepcopy(pb_a!!(Mooncake.rdata(ȳ_a)))
-    x_primal_post_a = map(_deepcopy ∘ primal, inputs_a)
     fdata_post_a = map(_deepcopy ∘ Mooncake.fdata, x̄_zero_a)
 
     y_ȳ_b, pb_b!! = rrule(inputs_b...)
+    y_primal_b = tangent(y_ȳ_b) isa NoFData ? primal(y_ȳ_b) : _deepcopy(primal(y_ȳ_b))
+    y_fdata_b = _deepcopy(tangent(y_ȳ_b))
     ȳ_b = increment!!(
         set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ȳ_delta)
     )
-    x̄_rvs_b = pb_b!!(Mooncake.rdata(ȳ_b))
+    x̄_rvs_b = _deepcopy(pb_b!!(Mooncake.rdata(ȳ_b)))
+    fdata_post_b = map(_deepcopy ∘ Mooncake.fdata, x̄_zero_b)
 
-    @test has_equal_data(y_primal_a, primal(y_ȳ_b))
-    @test has_equal_data(y_fdata_a, tangent(y_ȳ_b))
-    @test all(map(has_equal_data, x_primal_post_a, map(primal, inputs_b)))
+    @test has_equal_data(y_primal_a, y_primal_b)
+    @test has_equal_data(y_fdata_a, y_fdata_b)
     @test has_equal_data(x̄_rvs_a, x̄_rvs_b)
-    @test all(map(has_equal_data, fdata_post_a, map(Mooncake.fdata, x̄_zero_b)))
+    @test all(map(has_equal_data, fdata_post_a, fdata_post_b))
 end
 
 function test_frule_interface(x_ẋ...; frule)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -597,10 +597,8 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
     )
     x̄_rvs_a = pb_a!!(Mooncake.rdata(ȳ_a))
 
-    # Second forward pass with the same rule.
     y_ȳ_b, pb_b!! = rrule(inputs_b...)
     y_primal_b = tangent(y_ȳ_b) isa NoFData ? primal(y_ȳ_b) : _deepcopy(primal(y_ȳ_b))
-    # Same output cotangent as run A.
     ȳ_b = increment!!(
         set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ŷ_delta)
     )

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -584,7 +584,7 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
     inputs_a, x̄_zero_a = make_inputs(x_x̄)
     inputs_b, x̄_zero_b = make_inputs(x_x̄)
 
-    # First forward pass: snapshot primal before pullback can restore mutations.
+    # First forward pass: snapshot primal before pullback can modify it.
     # Only deepcopy when the output has an fdata component -- if tangent is NoFData,
     # Mooncake does not track mutations on the primal and the pullback won’t modify it
     # (and deepcopy may fail for types containing Modules, e.g. Core.TypeName).
@@ -1083,6 +1083,17 @@ function test_rule(
     redirector = print_results ? ((f, x) -> f()) : redirect_stdout
     ts = redirector(devnull) do
         @testset "$(typeof(x))" begin
+            # Verify rules give identical results on a second call,
+            # i.e. the rule does not corrupt its internal state across calls.
+            @testset "Reuse" begin
+                if test_fwd && !interface_only
+                    test_frule_reuse(x_ẋ...; frule)
+                end
+                if test_rvs && !interface_only
+                    test_rrule_reuse(rng, x_x̄...; rrule)
+                end
+            end
+
             # Test that the interface is basically satisfied (checks types / memory addresses).
             @testset "Interface (1)" begin
                 test_fwd && test_frule_interface(x_ẋ...; frule)
@@ -1098,16 +1109,6 @@ function test_rule(
                     test_rrule_correctness(
                         rng, x_x̄...; rrule, unsafe_perturb, output_tangent, atol, rtol
                     )
-                end
-            end
-
-            # Verify rules give identical results on a second call.
-            @testset "Reuse" begin
-                if test_fwd && !interface_only
-                    test_frule_reuse(x_ẋ...; frule)
-                end
-                if test_rvs && !interface_only
-                    test_rrule_reuse(rng, x_x̄...; rrule)
                 end
             end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -572,18 +572,20 @@ end
 function test_rrule_reuse(x_x̄...; rrule)
     @nospecialize x_x̄
     rng = Xoshiro(123)
-    function make_inputs(x_x̄)
-        x_x̄ = map(_deepcopy, x_x̄)
-        x = map(primal, x_x̄)
-        x̄_zero = map(zero_tangent, x)
-        x̄_fwds = map(Mooncake.fdata, x̄_zero)
-        x_x̄_rule = map(
-            (xi, fi) -> fcodual_type(_typeof(xi))(_deepcopy(xi), fi), x, x̄_fwds
-        )
-        return x_x̄_rule, x̄_zero
-    end
-    inputs_a, x̄_zero_a = make_inputs(x_x̄)
-    inputs_b, x̄_zero_b = make_inputs(x_x̄)
+    x_a = map(_deepcopy, map(primal, x_x̄))
+    x̄_zero_a = map(zero_tangent, x_a)
+    inputs_a = map(
+        (xi, fi) -> fcodual_type(_typeof(xi))(_deepcopy(xi), fi),
+        x_a,
+        map(Mooncake.fdata, x̄_zero_a),
+    )
+    x_b = map(_deepcopy, map(primal, x_x̄))
+    x̄_zero_b = map(zero_tangent, x_b)
+    inputs_b = map(
+        (xi, fi) -> fcodual_type(_typeof(xi))(_deepcopy(xi), fi),
+        x_b,
+        map(Mooncake.fdata, x̄_zero_b),
+    )
 
     # First forward pass: snapshot primal before pullback can modify it.
     # Only deepcopy when the output has an fdata component -- if tangent is NoFData,

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1081,6 +1081,9 @@ function test_rule(
     redirector = print_results ? ((f, x) -> f()) : redirect_stdout
     ts = redirector(devnull) do
         @testset "$(typeof(x))" begin
+            rng_reuse = deepcopy(rng)
+            rng_correctness = deepcopy(rng)
+
             # Verify rules give identical results on a second call,
             # i.e. the rule does not corrupt its internal state across calls.
             @testset "Reuse" begin
@@ -1088,7 +1091,7 @@ function test_rule(
                     test_frule_reuse(x_ẋ...; frule)
                 end
                 if test_rvs && !interface_only
-                    test_rrule_reuse(rng, x_x̄...; rrule)
+                    test_rrule_reuse(rng_reuse, x_x̄...; rrule)
                 end
             end
 
@@ -1101,11 +1104,19 @@ function test_rule(
             # Test that answers are numerically correct / consistent.
             @testset "Correctness" begin
                 if test_fwd && !interface_only
-                    test_frule_correctness(rng, x_ẋ...; frule, unsafe_perturb, atol, rtol)
+                    test_frule_correctness(
+                        rng_correctness, x_ẋ...; frule, unsafe_perturb, atol, rtol
+                    )
                 end
                 if test_rvs && !interface_only
                     test_rrule_correctness(
-                        rng, x_x̄...; rrule, unsafe_perturb, output_tangent, atol, rtol
+                        rng_correctness,
+                        x_x̄...;
+                        rrule,
+                        unsafe_perturb,
+                        output_tangent,
+                        atol,
+                        rtol,
                     )
                 end
             end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -569,8 +569,9 @@ function test_frule_reuse(x_ẋ...; frule)
     @test all(map(has_equal_data, map(tangent, x_ẋ_a), map(tangent, x_ẋ_b)))
 end
 
-function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
-    @nospecialize rng x_x̄
+function test_rrule_reuse(x_x̄...; rrule)
+    @nospecialize x_x̄
+    rng = Xoshiro(123)
     function make_inputs(x_x̄)
         x_x̄ = map(_deepcopy, x_x̄)
         x = map(primal, x_x̄)
@@ -1081,9 +1082,6 @@ function test_rule(
     redirector = print_results ? ((f, x) -> f()) : redirect_stdout
     ts = redirector(devnull) do
         @testset "$(typeof(x))" begin
-            rng_reuse = deepcopy(rng)
-            rng_correctness = deepcopy(rng)
-
             # Verify rules give identical results on a second call,
             # i.e. the rule does not corrupt its internal state across calls.
             @testset "Reuse" begin
@@ -1091,7 +1089,7 @@ function test_rule(
                     test_frule_reuse(x_ẋ...; frule)
                 end
                 if test_rvs && !interface_only
-                    test_rrule_reuse(rng_reuse, x_x̄...; rrule)
+                    test_rrule_reuse(x_x̄...; rrule)
                 end
             end
 
@@ -1104,19 +1102,11 @@ function test_rule(
             # Test that answers are numerically correct / consistent.
             @testset "Correctness" begin
                 if test_fwd && !interface_only
-                    test_frule_correctness(
-                        rng_correctness, x_ẋ...; frule, unsafe_perturb, atol, rtol
-                    )
+                    test_frule_correctness(rng, x_ẋ...; frule, unsafe_perturb, atol, rtol)
                 end
                 if test_rvs && !interface_only
                     test_rrule_correctness(
-                        rng_correctness,
-                        x_x̄...;
-                        rrule,
-                        unsafe_perturb,
-                        output_tangent,
-                        atol,
-                        rtol,
+                        rng, x_x̄...; rrule, unsafe_perturb, output_tangent, atol, rtol
                     )
                 end
             end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -584,15 +584,22 @@ function test_rrule_reuse(rng::AbstractRNG, x_x̄...; rrule)
     inputs_a, x̄_zero_a = make_inputs(x_x̄)
     inputs_b, x̄_zero_b = make_inputs(x_x̄)
 
-    # First forward+backward pass.
+    # First forward pass: snapshot primal before pullback can modify it.
     y_ȳ_a, pb_a!! = rrule(inputs_a...)
-    ŷ = randn_tangent(rng, primal(y_ȳ_a))
-    x̄_rvs_a = pb_a!!(Mooncake.rdata(ŷ))
+    y_primal_a = _deepcopy(primal(y_ȳ_a))
+    # Set output cotangent via fdata (vectors communicate cotangents through fdata, not rdata).
+    ŷ_delta = randn_tangent(rng, primal(y_ȳ_a))
+    ȳ_a = increment!!(set_to_zero!!(zero_tangent(primal(y_ȳ_a), tangent(y_ȳ_a))), ŷ_delta)
+    x̄_rvs_a = pb_a!!(Mooncake.rdata(ȳ_a))
 
-    # Second forward+backward pass with the same rule.
+    # Second forward pass with the same rule.
     y_ȳ_b, pb_b!! = rrule(inputs_b...)
-    x̄_rvs_b = pb_b!!(Mooncake.rdata(_deepcopy(ŷ)))
-    @test has_equal_data(primal(y_ȳ_a), primal(y_ȳ_b))
+    y_primal_b = _deepcopy(primal(y_ȳ_b))
+    # Same output cotangent as run A.
+    ȳ_b = increment!!(set_to_zero!!(zero_tangent(primal(y_ȳ_b), tangent(y_ȳ_b))), _deepcopy(ŷ_delta))
+    x̄_rvs_b = pb_b!!(Mooncake.rdata(ȳ_b))
+
+    @test has_equal_data(y_primal_a, y_primal_b)
     @test has_equal_data(x̄_rvs_a, x̄_rvs_b)
     @test all(
         map(has_equal_data, map(Mooncake.fdata, x̄_zero_a), map(Mooncake.fdata, x̄_zero_b))

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1086,7 +1086,7 @@ function test_rule(
                     test_frule_reuse(x_ẋ...; frule)
                 end
                 if test_rvs && !interface_only
-                    test_rrule_reuse(rng, x_x̄...; rrule)
+                    test_rrule_reuse(Xoshiro(123), x_x̄...; rrule)
                 end
             end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1046,6 +1046,18 @@ function test_rule(
                 end
             end
 
+            # Verify rules are not invalidated by a first differentiation call.
+            @testset "Reuse" begin
+                if test_fwd && !interface_only
+                    test_frule_correctness(rng, x_ẋ...; frule, unsafe_perturb, atol, rtol)
+                end
+                if test_rvs && !interface_only
+                    test_rrule_correctness(
+                        rng, x_x̄...; rrule, unsafe_perturb, output_tangent, atol, rtol
+                    )
+                end
+            end
+
             # Test the performance of the rule.
             @testset "Performance" begin
                 test_fwd && test_frule_performance(perf_flag, frule, x_ẋ...)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -195,7 +195,7 @@ end
         inner_ts = Test.DefaultTestSet("inner"; verbose=false)
         Test.push_testset(inner_ts)
         TestUtils.test_rrule_reuse(
-            StableRNG(1), zero_codual(_broken_rvs_f), zero_codual(1.5); rrule=broken_rrule
+            zero_codual(_broken_rvs_f), zero_codual(1.5); rrule=broken_rrule
         )
         Test.pop_testset()
         @test any(r -> r isa Test.Fail, inner_ts.results)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -195,7 +195,7 @@ end
         inner_ts = Test.DefaultTestSet("inner"; verbose=false)
         Test.push_testset(inner_ts)
         TestUtils.test_rrule_reuse(
-            zero_codual(_broken_rvs_f), zero_codual(1.5); rrule=broken_rrule
+            Xoshiro(123), zero_codual(_broken_rvs_f), zero_codual(1.5); rrule=broken_rrule
         )
         Test.pop_testset()
         @test any(r -> r isa Test.Fail, inner_ts.results)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,6 +1,6 @@
 # Test Mooncake primitives with broken rules to test test_frule_reuse
 # and test_rrule_reuse. Each broken rule corrupts a counter on the first call so
-# the second call returns a different primal output (for the same inputs)
+# the second call returns a different primal output (for the same inputs).
 _fwd_counter = Ref(0)
 _rvs_counter = Ref(0)
 _broken_fwd_f(x::Float64) = x^2

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,3 +1,30 @@
+# Test Mooncake primitives with deliberately broken rules to test test_frule_reuse
+# and test_rrule_reuse. Each broken rule corrupts a counter on the first call so
+# the second call returns a different primal output (for the same inputs)
+_fwd_counter = Ref(0)
+_rvs_counter = Ref(0)
+_broken_fwd_f(x::Float64) = x^2
+_broken_rvs_f(x::Float64) = x^2
+Mooncake.@is_primitive Mooncake.DefaultCtx Tuple{typeof(_broken_fwd_f),Float64}
+Mooncake.@is_primitive Mooncake.DefaultCtx Tuple{typeof(_broken_rvs_f),Float64}
+function Mooncake.frule!!(::Dual{typeof(_broken_fwd_f),NoTangent}, x::Dual{Float64,Float64})
+    xp = primal(x)
+    y = xp^2 + float(_fwd_counter[])
+    _fwd_counter[] += 1
+    return Dual(y, 2 * xp * tangent(x))
+end
+function Mooncake.rrule!!(
+    ::CoDual{typeof(_broken_rvs_f),NoFData}, x::CoDual{Float64,NoFData}
+)
+    xp = primal(x)
+    y = xp^2 + float(_rvs_counter[])
+    pb!! = function (ŷ::Float64)
+        _rvs_counter[] += 1
+        return NoRData(), 2 * xp * ŷ
+    end
+    return CoDual(y, NoFData()), pb!!
+end
+
 @testset "test_utils" begin
     @testset "has_equal_data" begin
         @test !has_equal_data(5.0, 4.0)
@@ -146,5 +173,31 @@
         @test TestUtils.count_allocs(isbitstype, Float64) == 0
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Float64}) == 0
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Vector{Float64}}) == 0
+    end
+    @testset "test_frule_reuse catches state-corrupting Mooncake rules" begin
+        _fwd_counter[] = 0
+        broken_frule = build_frule(
+            get_interpreter(ForwardMode), Tuple{typeof(_broken_fwd_f),Float64}
+        )
+        inner_ts = Test.DefaultTestSet("inner"; verbose=false)
+        Test.push_testset(inner_ts)
+        TestUtils.test_frule_reuse(
+            zero_dual(_broken_fwd_f), zero_dual(1.5); frule=broken_frule
+        )
+        Test.pop_testset()
+        @test any(r -> r isa Test.Fail, inner_ts.results)
+    end
+    @testset "test_rrule_reuse catches state-corrupting Mooncake rules" begin
+        _rvs_counter[] = 0
+        broken_rrule = build_rrule(
+            get_interpreter(ReverseMode), Tuple{typeof(_broken_rvs_f),Float64}
+        )
+        inner_ts = Test.DefaultTestSet("inner"; verbose=false)
+        Test.push_testset(inner_ts)
+        TestUtils.test_rrule_reuse(
+            StableRNG(1), zero_codual(_broken_rvs_f), zero_codual(1.5); rrule=broken_rrule
+        )
+        Test.pop_testset()
+        @test any(r -> r isa Test.Fail, inner_ts.results)
     end
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,4 +1,4 @@
-# Test Mooncake primitives with deliberately broken rules to test test_frule_reuse
+# Test Mooncake primitives with broken rules to test test_frule_reuse
 # and test_rrule_reuse. Each broken rule corrupts a counter on the first call so
 # the second call returns a different primal output (for the same inputs)
 _fwd_counter = Ref(0)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,30 +1,3 @@
-# Test Mooncake primitives with broken rules to test test_frule_reuse
-# and test_rrule_reuse. Each broken rule corrupts a counter on the first call so
-# the second call returns a different primal output (for the same inputs).
-_fwd_counter = Ref(0)
-_rvs_counter = Ref(0)
-_broken_fwd_f(x::Float64) = x^2
-_broken_rvs_f(x::Float64) = x^2
-Mooncake.@is_primitive Mooncake.DefaultCtx Tuple{typeof(_broken_fwd_f),Float64}
-Mooncake.@is_primitive Mooncake.DefaultCtx Tuple{typeof(_broken_rvs_f),Float64}
-function Mooncake.frule!!(::Dual{typeof(_broken_fwd_f),NoTangent}, x::Dual{Float64,Float64})
-    xp = primal(x)
-    y = xp^2 + float(_fwd_counter[])
-    _fwd_counter[] += 1
-    return Dual(y, 2 * xp * tangent(x))
-end
-function Mooncake.rrule!!(
-    ::CoDual{typeof(_broken_rvs_f),NoFData}, x::CoDual{Float64,NoFData}
-)
-    xp = primal(x)
-    y = xp^2 + float(_rvs_counter[])
-    pb!! = function (ŷ::Float64)
-        _rvs_counter[] += 1
-        return NoRData(), 2 * xp * ŷ
-    end
-    return CoDual(y, NoFData()), pb!!
-end
-
 @testset "test_utils" begin
     @testset "has_equal_data" begin
         @test !has_equal_data(5.0, 4.0)
@@ -173,31 +146,5 @@ end
         @test TestUtils.count_allocs(isbitstype, Float64) == 0
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Float64}) == 0
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Vector{Float64}}) == 0
-    end
-    @testset "test_frule_reuse catches state-corrupting Mooncake rules" begin
-        _fwd_counter[] = 0
-        broken_frule = build_frule(
-            get_interpreter(ForwardMode), Tuple{typeof(_broken_fwd_f),Float64}
-        )
-        inner_ts = Test.DefaultTestSet("inner"; verbose=false)
-        Test.push_testset(inner_ts)
-        TestUtils.test_frule_reuse(
-            zero_dual(_broken_fwd_f), zero_dual(1.5); frule=broken_frule
-        )
-        Test.pop_testset()
-        @test any(r -> r isa Test.Fail, inner_ts.results)
-    end
-    @testset "test_rrule_reuse catches state-corrupting Mooncake rules" begin
-        _rvs_counter[] = 0
-        broken_rrule = build_rrule(
-            get_interpreter(ReverseMode), Tuple{typeof(_broken_rvs_f),Float64}
-        )
-        inner_ts = Test.DefaultTestSet("inner"; verbose=false)
-        Test.push_testset(inner_ts)
-        TestUtils.test_rrule_reuse(
-            Xoshiro(123), zero_codual(_broken_rvs_f), zero_codual(1.5); rrule=broken_rrule
-        )
-        Test.pop_testset()
-        @test any(r -> r isa Test.Fail, inner_ts.results)
     end
 end


### PR DESCRIPTION
closes #681.

When a rule is compiled via `build_frule`/`build_rrule`, the resulting closure is intended to be reusable: compile once, call many times. However, there was no test enforcing this. A rule whose closure captures mutable state that gets corrupted on a first call would pass all existing tests but silently return wrong results on any subsequent use, which is exactly the  class of bug described in #681.

This PR adds a "Reuse" testset inside `Mooncake.TestUtils.test_rule` that runs two complete forward+backward cycles with the same compiled rule and asserts the results are identical. Crucially, "Reuse" runs before "Interface (1)" and "Correctness"  testsets so it exercises the true first and second calls on a fresh compiled rule. If a rule corrupts its internal state on the first call, the second call will produce a different primal output or different cotangents and "Reuse" will fail.

The check is implemented via two dedicated functions `test_frule_reuse` and `test_rrule_reuse`. Both functions construct two independent sets of inputs from deepcopies and run the same rule twice. `test_frule_reuse` compares primal outputs and output/input tangents. `test_rrule_reuse` compares primal outputs, `rdata` from the pullback, and `fdata` accumulated in the input buffer. No finite differences are involved, so the check is fast and has no step-size or domain-constraint sensitivity.

`test/test_utils.jl` adds two negative tests using real `@is_primitive` + `frule!!`/`rrule!!` registrations with a deliberately broken rule (a counter is incremented during each call, causing a different primal on the second call) to demonstrate that the reuse check catches this class of bug.


<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1172 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1172/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 210.0 ns │     1.29 │        1.48 │   0.619 │         3.2 │   6.06 │
│             _sum_1000 │   1.1 μs │     6.04 │        1.02 │  3520.0 │        35.2 │   1.06 │
│          sum_sin_1000 │  7.43 μs │     2.56 │        1.12 │    1.67 │        11.2 │   1.71 │
│         _sum_sin_1000 │  4.58 μs │     3.85 │        2.66 │   402.0 │        18.0 │   3.09 │
│              kron_sum │ 197.0 μs │     12.9 │        3.26 │    7.02 │       488.0 │   23.8 │
│         kron_view_sum │ 273.0 μs │     12.6 │        5.26 │    28.1 │       441.0 │   13.8 │
│ naive_map_sin_cos_exp │  2.33 μs │     2.78 │        1.51 │ missing │        8.08 │   2.06 │
│       map_sin_cos_exp │  2.34 μs │     3.23 │        1.53 │    1.48 │        6.88 │   2.51 │
│ broadcast_sin_cos_exp │  2.26 μs │     3.05 │        1.57 │    4.34 │        1.41 │    2.1 │
│            simple_mlp │ 346.0 μs │     4.98 │        2.99 │    1.95 │        11.3 │   3.21 │
│                gp_lml │ 164.0 μs │     12.9 │        2.69 │    5.23 │     missing │   5.88 │
│    large_single_block │ 471.0 ns │     6.55 │        1.96 │  3910.0 │        36.7 │   2.06 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->