### PR TITLE
max_norm_perturbation kwarg

### DIFF
--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -475,6 +475,16 @@ function _diff(p::P, q::P) where {P}
     return increment!!(_scale(-1.0, t2), t1)
 end
 
+function _check_ε_list(ε_list, max_norm_perturbation)
+    isempty(ε_list) && throw(
+        ArgumentError(
+            "max_norm_perturbation=$max_norm_perturbation filters out all finite-difference " *
+            "step sizes; the smallest available is 1e-8, below which floating-point rounding " *
+            "errors dominate the estimate.",
+        ),
+    )
+end
+
 # Assumes that the interface has been tested, and we can simply check for numerical issues.
 function test_frule_correctness(
     rng::AbstractRNG,
@@ -491,7 +501,7 @@ function test_frule_correctness(
 
     # Run original function on deep-copies of inputs.
     x = map(primal, x_ẋ)
-    ẋ = map(x -> normalize_tangent(tangent(x)), x_ẋ)
+    ẋ = map(normalize_tangent ∘ tangent, x_ẋ)
     x_primal = _deepcopy(x)
     y_primal = x_primal[1](x_primal[2:end]...)
 
@@ -502,6 +512,7 @@ function test_frule_correctness(
         ε -> isnothing(max_norm_perturbation) || ε <= max_norm_perturbation,
         [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8],
     )
+    _check_ε_list(ε_list, max_norm_perturbation)
     fd_results = Vector{Any}(undef, length(ε_list))
     for (n, ε) in enumerate(ε_list)
         x′_l = _add_to_primal(x, _scale(ε, ẋ), unsafe_perturb)
@@ -600,6 +611,7 @@ function test_rrule_correctness(
         ε -> isnothing(max_norm_perturbation) || ε <= max_norm_perturbation,
         [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8],
     )
+    _check_ε_list(ε_list, max_norm_perturbation)
     fd_results = Vector{Any}(undef, length(ε_list))
     for (n, ε) in enumerate(ε_list)
         x′_l = _add_to_primal(x, _scale(ε, ẋ), unsafe_perturb)
@@ -921,7 +933,10 @@ __get_primals(xs) = map(x -> x isa Union{Dual,CoDual} ? primal(x) : x, xs)
         print_results=true,
         output_tangent=nothing,
         atol=1e-3,
-        rtol=1e-3
+        rtol=1e-3,
+        frule=nothing,
+        rrule=nothing,
+        max_norm_perturbation::Union{Nothing,Float64}=nothing,
     )
 
 Run standardised tests on the `rule` for `x`.

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -491,7 +491,7 @@ function test_frule_correctness(
 
     # Run original function on deep-copies of inputs.
     x = map(primal, x_ẋ)
-    ẋ = map(normalize_tangent ∘ tangent, x_ẋ)
+    ẋ = map(x -> normalize_tangent(tangent(x)), x_ẋ)
     x_primal = _deepcopy(x)
     y_primal = x_primal[1](x_primal[2:end]...)
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -483,7 +483,7 @@ function test_frule_correctness(
     unsafe_perturb::Bool,
     rtol=1e-3,
     atol=1e-3,
-    max_norm_perturbation::Union{Nothing,Float64}=nothing,
+    max_fd_step::Union{Nothing,Float64}=nothing,
 )
     @nospecialize rng x_ẋ
 
@@ -498,17 +498,13 @@ function test_frule_correctness(
     # Use finite differences to estimate Frechet derivative. Compute the estimate at a range
     # of different step sizes. We'll just require that one of them ends up being close to
     # what AD gives.
-    !isnothing(max_norm_perturbation) &&
-        max_norm_perturbation < 1e-8 &&
-        throw(
-            ArgumentError(
-                "max_norm_perturbation=$max_norm_perturbation < 1e-8; the smallest available step size is 1e-8.",
-            ),
+    ε_list = [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8]
+    if max_fd_step !== nothing
+        ε_list = filter(≤(max_fd_step), ε_list)
+        length(ε_list) ≥ 2 || throw(
+            ArgumentError("max_fd_step=$max_fd_step is too small (leaves <2 FD steps)")
         )
-    ε_list = filter(
-        ε -> isnothing(max_norm_perturbation) || ε <= max_norm_perturbation,
-        [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8],
-    )
+    end
     fd_results = Vector{Any}(undef, length(ε_list))
     for (n, ε) in enumerate(ε_list)
         x′_l = _add_to_primal(x, _scale(ε, ẋ), unsafe_perturb)
@@ -583,7 +579,7 @@ function test_rrule_correctness(
     output_tangent=nothing,
     rtol=1e-3,
     atol=1e-3,
-    max_norm_perturbation::Union{Nothing,Float64}=nothing,
+    max_fd_step::Union{Nothing,Float64}=nothing,
 )
     @nospecialize rng x_x̄
 
@@ -603,17 +599,13 @@ function test_rrule_correctness(
 
     # Use finite differences to estimate vjps. Compute the estimate at a range of different
     # step sizes. We'll just require that one of them ends up being close to what AD gives.
-    !isnothing(max_norm_perturbation) &&
-        max_norm_perturbation < 1e-8 &&
-        throw(
-            ArgumentError(
-                "max_norm_perturbation=$max_norm_perturbation < 1e-8; the smallest available step size is 1e-8.",
-            ),
+    ε_list = [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8]
+    if max_fd_step !== nothing
+        ε_list = filter(≤(max_fd_step), ε_list)
+        length(ε_list) ≥ 2 || throw(
+            ArgumentError("max_fd_step=$max_fd_step is too small (leaves <2 FD steps)")
         )
-    ε_list = filter(
-        ε -> isnothing(max_norm_perturbation) || ε <= max_norm_perturbation,
-        [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8],
-    )
+    end
     fd_results = Vector{Any}(undef, length(ε_list))
     for (n, ε) in enumerate(ε_list)
         x′_l = _add_to_primal(x, _scale(ε, ẋ), unsafe_perturb)
@@ -938,7 +930,7 @@ __get_primals(xs) = map(x -> x isa Union{Dual,CoDual} ? primal(x) : x, xs)
         rtol=1e-3,
         frule=nothing,
         rrule=nothing,
-        max_norm_perturbation::Union{Nothing,Float64}=nothing,
+        max_fd_step::Union{Nothing,Float64}=nothing,
     )
 
 Run standardised tests on the `rule` for `x`.
@@ -992,8 +984,12 @@ signature associated to `x` corresponds to a primitive, a hand-written rule will
     the correctness of reverse rules.
 - `atol=1e-3`: absolute tolerance for correctness check of the Frechet derivatives.
 - `rtol=1e-3`: relative tolerance for correctness check of the Frechet derivatives.
-- `max_norm_perturbation::Union{Nothing,Float64}=nothing`: if provided, only finite-difference
-    step sizes `ε ≤ max_norm_perturbation` are used. Set this when the function is only
+- `frule=nothing`: if provided, use this callable as the forward rule instead of building one
+    from the interpreter. Useful for testing a hand-written `frule!!` directly.
+- `rrule=nothing`: if provided, use this callable as the reverse rule instead of building one
+    from the interpreter. Useful for testing a hand-written `rrule!!` directly.
+- `max_fd_step::Union{Nothing,Float64}=nothing`: if provided, only finite-difference
+    step sizes `ε ≤ max_fd_step` are used. Set this when the function is only
     defined on a restricted domain (e.g. `log`, `sqrt`, `cholesky`) and large perturbations
     would step outside it. The tangent direction `ẋ` is normalised to unit length before
     finite differences are computed, so this bound directly controls the size of the step
@@ -1014,7 +1010,7 @@ function test_rule(
     rtol=1e-3,
     frule=nothing,
     rrule=nothing,
-    max_norm_perturbation::Union{Nothing,Float64}=nothing,
+    max_fd_step::Union{Nothing,Float64}=nothing,
 )
     # Take a copy of `x` to ensure that we do not mutate the original.
     x = deepcopy(x)
@@ -1075,13 +1071,7 @@ function test_rule(
             @testset "Correctness" begin
                 if test_fwd && !interface_only
                     test_frule_correctness(
-                        rng,
-                        x_ẋ...;
-                        frule,
-                        unsafe_perturb,
-                        atol,
-                        rtol,
-                        max_norm_perturbation,
+                        rng, x_ẋ...; frule, unsafe_perturb, atol, rtol, max_fd_step
                     )
                 end
                 if test_rvs && !interface_only
@@ -1093,7 +1083,7 @@ function test_rule(
                         output_tangent,
                         atol,
                         rtol,
-                        max_norm_perturbation,
+                        max_fd_step,
                     )
                 end
             end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -483,7 +483,7 @@ function test_frule_correctness(
     unsafe_perturb::Bool,
     rtol=1e-3,
     atol=1e-3,
-    max_fd_step::Union{Nothing,Float64}=nothing,
+    max_fd_step::Union{Nothing,Real}=nothing,
 )
     @nospecialize rng x_ẋ
 
@@ -502,7 +502,10 @@ function test_frule_correctness(
     if max_fd_step !== nothing
         ε_list = filter(≤(max_fd_step), ε_list)
         length(ε_list) ≥ 2 || throw(
-            ArgumentError("max_fd_step=$max_fd_step is too small (leaves <2 FD steps)")
+            ArgumentError(
+                "max_fd_step=$max_fd_step leaves fewer than two FD steps; the fixed " *
+                "grid ends at 1e-7, so the smallest usable cap is 1e-6.",
+            ),
         )
     end
     fd_results = Vector{Any}(undef, length(ε_list))
@@ -579,7 +582,7 @@ function test_rrule_correctness(
     output_tangent=nothing,
     rtol=1e-3,
     atol=1e-3,
-    max_fd_step::Union{Nothing,Float64}=nothing,
+    max_fd_step::Union{Nothing,Real}=nothing,
 )
     @nospecialize rng x_x̄
 
@@ -603,7 +606,10 @@ function test_rrule_correctness(
     if max_fd_step !== nothing
         ε_list = filter(≤(max_fd_step), ε_list)
         length(ε_list) ≥ 2 || throw(
-            ArgumentError("max_fd_step=$max_fd_step is too small (leaves <2 FD steps)")
+            ArgumentError(
+                "max_fd_step=$max_fd_step leaves fewer than two FD steps; the fixed " *
+                "grid ends at 1e-7, so the smallest usable cap is 1e-6.",
+            ),
         )
     end
     fd_results = Vector{Any}(undef, length(ε_list))
@@ -930,7 +936,7 @@ __get_primals(xs) = map(x -> x isa Union{Dual,CoDual} ? primal(x) : x, xs)
         rtol=1e-3,
         frule=nothing,
         rrule=nothing,
-        max_fd_step::Union{Nothing,Float64}=nothing,
+        max_fd_step::Union{Nothing,Real}=nothing,
     )
 
 Run standardised tests on the `rule` for `x`.
@@ -988,12 +994,11 @@ signature associated to `x` corresponds to a primitive, a hand-written rule will
     from the interpreter. Useful for testing a hand-written `frule!!` directly.
 - `rrule=nothing`: if provided, use this callable as the reverse rule instead of building one
     from the interpreter. Useful for testing a hand-written `rrule!!` directly.
-- `max_fd_step::Union{Nothing,Float64}=nothing`: if provided, only finite-difference
-    step sizes `ε ≤ max_fd_step` are used. Set this when the function is only
-    defined on a restricted domain (e.g. `log`, `sqrt`, `cholesky`) and large perturbations
-    would step outside it. The tangent direction `ẋ` is normalised to unit length before
-    finite differences are computed, so this bound directly controls the size of the step
-    in input space.
+- `max_fd_step::Union{Nothing,Real}=nothing`: cap on finite-difference step sizes; only
+    `ε ≤ max_fd_step` are used. Each argument's tangent is unit-normalised independently,
+    so each argument is perturbed by at most `max_fd_step` in L2 norm. Set this for
+    domain-restricted functions (`log`, `sqrt`, `cholesky`) to keep perturbations inside
+    the domain. The FD grid ends at `1e-7`; the smallest usable cap is `1e-6`.
 """
 function test_rule(
     rng::AbstractRNG,
@@ -1010,7 +1015,7 @@ function test_rule(
     rtol=1e-3,
     frule=nothing,
     rrule=nothing,
-    max_fd_step::Union{Nothing,Float64}=nothing,
+    max_fd_step::Union{Nothing,Real}=nothing,
 )
     # Take a copy of `x` to ensure that we do not mutate the original.
     x = deepcopy(x)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -475,16 +475,6 @@ function _diff(p::P, q::P) where {P}
     return increment!!(_scale(-1.0, t2), t1)
 end
 
-function _check_ε_list(ε_list, max_norm_perturbation)
-    isempty(ε_list) && throw(
-        ArgumentError(
-            "max_norm_perturbation=$max_norm_perturbation filters out all finite-difference " *
-            "step sizes; the smallest available is 1e-8, below which floating-point rounding " *
-            "errors dominate the estimate.",
-        ),
-    )
-end
-
 # Assumes that the interface has been tested, and we can simply check for numerical issues.
 function test_frule_correctness(
     rng::AbstractRNG,
@@ -508,11 +498,17 @@ function test_frule_correctness(
     # Use finite differences to estimate Frechet derivative. Compute the estimate at a range
     # of different step sizes. We'll just require that one of them ends up being close to
     # what AD gives.
+    !isnothing(max_norm_perturbation) &&
+        max_norm_perturbation < 1e-8 &&
+        throw(
+            ArgumentError(
+                "max_norm_perturbation=$max_norm_perturbation < 1e-8; the smallest available step size is 1e-8.",
+            ),
+        )
     ε_list = filter(
         ε -> isnothing(max_norm_perturbation) || ε <= max_norm_perturbation,
         [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8],
     )
-    _check_ε_list(ε_list, max_norm_perturbation)
     fd_results = Vector{Any}(undef, length(ε_list))
     for (n, ε) in enumerate(ε_list)
         x′_l = _add_to_primal(x, _scale(ε, ẋ), unsafe_perturb)
@@ -607,11 +603,17 @@ function test_rrule_correctness(
 
     # Use finite differences to estimate vjps. Compute the estimate at a range of different
     # step sizes. We'll just require that one of them ends up being close to what AD gives.
+    !isnothing(max_norm_perturbation) &&
+        max_norm_perturbation < 1e-8 &&
+        throw(
+            ArgumentError(
+                "max_norm_perturbation=$max_norm_perturbation < 1e-8; the smallest available step size is 1e-8.",
+            ),
+        )
     ε_list = filter(
         ε -> isnothing(max_norm_perturbation) || ε <= max_norm_perturbation,
         [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8],
     )
-    _check_ε_list(ε_list, max_norm_perturbation)
     fd_results = Vector{Any}(undef, length(ε_list))
     for (n, ε) in enumerate(ε_list)
         x′_l = _add_to_primal(x, _scale(ε, ẋ), unsafe_perturb)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -477,22 +477,31 @@ end
 
 # Assumes that the interface has been tested, and we can simply check for numerical issues.
 function test_frule_correctness(
-    rng::AbstractRNG, x_ẋ...; frule, unsafe_perturb::Bool, rtol=1e-3, atol=1e-3
+    rng::AbstractRNG,
+    x_ẋ...;
+    frule,
+    unsafe_perturb::Bool,
+    rtol=1e-3,
+    atol=1e-3,
+    max_norm_perturbation::Union{Nothing,Float64}=nothing,
 )
-    @nospecialize rng x_ẋ
+    @nospecialize rng x_ẋ
 
-    x_ẋ = map(_deepcopy, x_ẋ) # defensive copy
+    x_ẋ = map(_deepcopy, x_ẋ) # defensive copy
 
     # Run original function on deep-copies of inputs.
-    x = map(primal, x_ẋ)
-    ẋ = map(tangent, x_ẋ)
+    x = map(primal, x_ẋ)
+    ẋ = map(normalize_tangent ∘ tangent, x_ẋ)
     x_primal = _deepcopy(x)
     y_primal = x_primal[1](x_primal[2:end]...)
 
     # Use finite differences to estimate Frechet derivative. Compute the estimate at a range
     # of different step sizes. We'll just require that one of them ends up being close to
     # what AD gives.
-    ε_list = [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8]
+    ε_list = filter(
+        ε -> isnothing(max_norm_perturbation) || ε <= max_norm_perturbation,
+        [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8],
+    )
     fd_results = Vector{Any}(undef, length(ε_list))
     for (n, ε) in enumerate(ε_list)
         x′_l = _add_to_primal(x, _scale(ε, ẋ), unsafe_perturb)
@@ -567,6 +576,7 @@ function test_rrule_correctness(
     output_tangent=nothing,
     rtol=1e-3,
     atol=1e-3,
+    max_norm_perturbation::Union{Nothing,Float64}=nothing,
 )
     @nospecialize rng x_x̄
 
@@ -586,7 +596,10 @@ function test_rrule_correctness(
 
     # Use finite differences to estimate vjps. Compute the estimate at a range of different
     # step sizes. We'll just require that one of them ends up being close to what AD gives.
-    ε_list = [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8]
+    ε_list = filter(
+        ε -> isnothing(max_norm_perturbation) || ε <= max_norm_perturbation,
+        [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8],
+    )
     fd_results = Vector{Any}(undef, length(ε_list))
     for (n, ε) in enumerate(ε_list)
         x′_l = _add_to_primal(x, _scale(ε, ẋ), unsafe_perturb)
@@ -959,9 +972,15 @@ signature associated to `x` corresponds to a primitive, a hand-written rule will
     Should usually be left `false` -- consult the docstring for `_add_to_primal` for more
     info on when you might wish to set it to `true`.
 - `output_tangent=nothing`: final output tangent to initialize reverse mode with for testing
-    the correctnes of reverse rules.
+    the correctness of reverse rules.
 - `atol=1e-3`: absolute tolerance for correctness check of the Frechet derivatives.
 - `rtol=1e-3`: relative tolerance for correctness check of the Frechet derivatives.
+- `max_norm_perturbation::Union{Nothing,Float64}=nothing`: if provided, only finite-difference
+    step sizes `ε ≤ max_norm_perturbation` are used. Set this when the function is only
+    defined on a restricted domain (e.g. `log`, `sqrt`, `cholesky`) and large perturbations
+    would step outside it. The tangent direction `ẋ` is normalised to unit length before
+    finite differences are computed, so this bound directly controls the size of the step
+    in input space.
 """
 function test_rule(
     rng::AbstractRNG,
@@ -978,6 +997,7 @@ function test_rule(
     rtol=1e-3,
     frule=nothing,
     rrule=nothing,
+    max_norm_perturbation::Union{Nothing,Float64}=nothing,
 )
     # Take a copy of `x` to ensure that we do not mutate the original.
     x = deepcopy(x)
@@ -1037,11 +1057,26 @@ function test_rule(
             # Test that answers are numerically correct / consistent.
             @testset "Correctness" begin
                 if test_fwd && !interface_only
-                    test_frule_correctness(rng, x_ẋ...; frule, unsafe_perturb, atol, rtol)
+                    test_frule_correctness(
+                        rng,
+                        x_ẋ...;
+                        frule,
+                        unsafe_perturb,
+                        atol,
+                        rtol,
+                        max_norm_perturbation,
+                    )
                 end
                 if test_rvs && !interface_only
                     test_rrule_correctness(
-                        rng, x_x̄...; rrule, unsafe_perturb, output_tangent, atol, rtol
+                        rng,
+                        x_x̄...;
+                        rrule,
+                        unsafe_perturb,
+                        output_tangent,
+                        atol,
+                        rtol,
+                        max_norm_perturbation,
                     )
                 end
             end

--- a/test/rules/low_level_maths.jl
+++ b/test/rules/low_level_maths.jl
@@ -135,8 +135,6 @@
     end
 
     @testset "near-boundary domain-restricted functions" begin
-        test_rule(
-            StableRNG(123), sqrt, 0.005; is_primitive=true, max_norm_perturbation=1e-3
-        )
+        test_rule(StableRNG(123), sqrt, 0.005; is_primitive=true, max_fd_step=1e-3)
     end
 end

--- a/test/rules/low_level_maths.jl
+++ b/test/rules/low_level_maths.jl
@@ -133,4 +133,19 @@
         @test !is_primitive(C, M, Tuple{typeof(/),T,T}, world)
         @test !is_primitive(C, M, Tuple{typeof(\),T,T}, world)
     end
+
+    @testset "near-boundary domain-restricted functions" begin
+        for T in [Float32, Float64]
+            test_rule(
+                StableRNG(123), log, T(0.005); is_primitive=true, max_norm_perturbation=1e-3
+            )
+            test_rule(
+                StableRNG(123),
+                sqrt,
+                T(0.005);
+                is_primitive=true,
+                max_norm_perturbation=1e-3,
+            )
+        end
+    end
 end

--- a/test/rules/low_level_maths.jl
+++ b/test/rules/low_level_maths.jl
@@ -135,17 +135,9 @@
     end
 
     @testset "near-boundary domain-restricted functions" begin
-        for T in [Float32, Float64]
-            test_rule(
-                StableRNG(123), log, T(0.005); is_primitive=true, max_norm_perturbation=1e-3
-            )
-            test_rule(
-                StableRNG(123),
-                sqrt,
-                T(0.005);
-                is_primitive=true,
-                max_norm_perturbation=1e-3,
-            )
-        end
+        test_rule(StableRNG(123), log, 0.005; is_primitive=true, max_norm_perturbation=1e-3)
+        test_rule(
+            StableRNG(123), sqrt, 0.005; is_primitive=true, max_norm_perturbation=1e-3
+        )
     end
 end

--- a/test/rules/low_level_maths.jl
+++ b/test/rules/low_level_maths.jl
@@ -135,7 +135,6 @@
     end
 
     @testset "near-boundary domain-restricted functions" begin
-        test_rule(StableRNG(123), log, 0.005; is_primitive=true, max_norm_perturbation=1e-3)
         test_rule(
             StableRNG(123), sqrt, 0.005; is_primitive=true, max_norm_perturbation=1e-3
         )

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -147,4 +147,21 @@
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Float64}) == 0
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Vector{Float64}}) == 0
     end
+    @testset "max_norm_perturbation kwarg for testing rules" begin
+        rng = Xoshiro(1)
+        # log is undefined for x ≤ 0: without a bound, the ε=1e-2 step evaluates
+        # log(0.005 - 0.01) = log(-0.005) and throws a DomainError.
+        @test_throws DomainError log(0.005 - 1.0e-2)
+
+        # With a bound of 1e-3, all ε values keep x+ε*ẋ > 0 and the rule test passes.
+        ts = TestUtils.test_rule(
+            rng,
+            log,
+            0.005;
+            is_primitive=false,
+            print_results=false,
+            max_norm_perturbation=1.0e-3,
+        )
+        @test !ts.anynonpass
+    end
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -148,16 +148,13 @@
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Vector{Float64}}) == 0
     end
     @testset "max_norm_perturbation kwarg for testing rules" begin
-        rng = Xoshiro(1)
-        # With a bound of 1e-3, all ε values keep x+ε*ẋ > 0 and the rule test passes.
-        ts = TestUtils.test_rule(
-            rng,
-            log,
+        TestUtils.test_rule(
+            StableRNG(123),
+            x -> log(x),
             0.005;
             is_primitive=false,
             print_results=false,
-            max_norm_perturbation=1.0e-3,
+            max_norm_perturbation=1e-3,
         )
-        @test !ts.anynonpass
     end
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -149,10 +149,6 @@
     end
     @testset "max_norm_perturbation kwarg for testing rules" begin
         rng = Xoshiro(1)
-        # log is undefined for x ≤ 0: without a bound, the ε=1e-2 step evaluates
-        # log(0.005 - 0.01) = log(-0.005) and throws a DomainError.
-        @test_throws DomainError log(0.005 - 1.0e-2)
-
         # With a bound of 1e-3, all ε values keep x+ε*ẋ > 0 and the rule test passes.
         ts = TestUtils.test_rule(
             rng,

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -147,14 +147,17 @@
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Float64}) == 0
         @test TestUtils.count_allocs(Mooncake.fdata_type, Tuple{Vector{Float64}}) == 0
     end
-    @testset "max_norm_perturbation kwarg for testing rules" begin
+    @testset "max_fd_step kwarg for testing rules" begin
+        # log is a primitive in Mooncake, so we wrap it in a lambda to test the derived-rule
+        # path. The input 0.005 is close to the boundary of log's domain (x > 0), so we cap
+        # the FD step at 1e-3 to avoid perturbing into x ≤ 0.
         TestUtils.test_rule(
             StableRNG(123),
             x -> log(x),
             0.005;
             is_primitive=false,
             print_results=false,
-            max_norm_perturbation=1e-3,
+            max_fd_step=1e-3,
         )
     end
 end


### PR DESCRIPTION
closes #765 

This PR adds a `max_fd_step` keyword argument to test_rule, `test_frule_correctness`, and `test_rrule_correctness`. When provided, only finite-difference step sizes `ε ≤ max_fd_step` are used. This is useful for functions defined on a restricted domain (e.g. `log`, `sqrt`, `cholesky`) where large perturbations would step outside it.

Behaviour change: tangent normalisation in `test_frule_correctness`

`test_frule_correctness` now normalises the tangent direction before running finite differences:
`ẋ = map(normalize_tangent ∘ tangent, x_ẋ)`

Previously the raw tangent from x_ẋ was used directly. With normalisation, ẋ has unit norm, so `max_fd_step` directly controls the step size in input space (rather than a step scaled by the tangent magnitude). The correctness check is unaffected, the `FD` estimate and the `AD` result are both linear in `ẋ`, so scaling `ẋ` scales both by the same factor. `test_rrule_correctness` already normalised its tangent direction; this makes `test_frule_correctness` consistent with it.


<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1173 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1173/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 170.0 ns │     1.59 │        1.76 │   0.706 │        3.42 │    6.6 │
│             _sum_1000 │ 972.0 ns │     7.16 │        1.04 │  1990.0 │        40.0 │   1.06 │
│          sum_sin_1000 │  7.25 μs │      3.5 │        1.36 │    1.46 │        10.9 │   1.74 │
│         _sum_sin_1000 │  6.47 μs │      3.5 │        1.77 │   228.0 │        12.4 │   2.05 │
│              kron_sum │ 219.0 μs │     12.7 │         3.6 │    13.4 │       347.0 │   19.7 │
│         kron_view_sum │ 300.0 μs │     11.1 │        5.26 │    24.4 │       313.0 │   11.8 │
│ naive_map_sin_cos_exp │  2.32 μs │     3.08 │        1.54 │ missing │        7.65 │   2.14 │
│       map_sin_cos_exp │  2.29 μs │     3.59 │        1.69 │    1.55 │        6.71 │   2.72 │
│ broadcast_sin_cos_exp │  2.32 μs │     3.19 │        1.59 │    3.81 │        1.45 │   2.12 │
│            simple_mlp │ 352.0 μs │     5.26 │        2.68 │    2.21 │        9.67 │   2.95 │
│                gp_lml │ 172.0 μs │     11.3 │        2.54 │    4.84 │     missing │   5.31 │
│    large_single_block │ 421.0 ns │     6.09 │         1.9 │  4910.0 │        33.3 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->