### PR TITLE
Add docs on overlay and primitive interaction

### DIFF
--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -101,15 +101,23 @@ If you encounter a practical situation in which it is very important that this e
 
 ## Primitives and Overlays
 
-[`@mooncake_overlay`](@ref Mooncake.@mooncake_overlay) and [`@is_primitive`](@ref Mooncake.@is_primitive) both let you change what Mooncake sees when it differentiates a function, but they hook in at different layers and do not compose. `@mooncake_overlay` swaps in a replacement body Mooncake walks through; `@is_primitive` stops Mooncake walking and dispatches to a hand-written rule instead. Marking a signature as a primitive shadows any overlay reachable through it — the rule fires, the overlay does not, and Mooncake reads return types off the original code.
+[`@mooncake_overlay`](@ref Mooncake.@mooncake_overlay) and [`@is_primitive`](@ref Mooncake.@is_primitive) both let you change what Mooncake sees when it differentiates a function, but they hook in at different layers and do not compose.
+`@mooncake_overlay` swaps in a replacement body Mooncake walks through; `@is_primitive` stops Mooncake walking and dispatches to a hand-written rule instead.
+Marking a signature as a primitive shadows any overlay reachable through it — the rule fires, the overlay does not, and Mooncake infers return types from the original method, not from the overlay.
 
 This causes two failure modes:
 
-1. **An overlay that changes the return type breaks the rule's type signature.** Mooncake infers the original return type, so a rule that returns the overlaid value mismatches the expected `CoDual` type and throws a runtime `TypeError`. If the return type is a singleton the check can pass anyway, and the rule may silently produce an incorrect gradient.
+1. **An overlay that changes the return type breaks the rule's return-type contract.**
+   Mooncake infers the return type from the original method, so a manual rule that returns a value of the overlaid type produces a `CoDual` that disagrees with that inferred type, triggering a runtime `TypeError`.
+   When the original and overlaid methods return the same type, the runtime check is trivially satisfied and the bug surfaces only as an incorrect gradient.
 
-2. **An overlay inside a primitive's body never runs.** The rule replaces the body and runs the primal through ordinary Julia dispatch, which ignores overlays. An overlay written to patch unsupported code inside the primitive is silently inert — move it to a signature Mooncake still differentiates, or fold the workaround into the rule.
+2. **An overlay inside a primitive's body never runs.**
+   The rule replaces the body and runs the primal through ordinary Julia dispatch, which ignores overlays.
+   An overlay introduced to work around unsupported code reached from inside the primitive is silently inert — move it to a signature Mooncake still differentiates, or fold the workaround into the rule.
 
-The example below covers both cases. Case (1) overlays the primitive itself; case (2) overlays a helper called from the primitive's body. Each identity check asks whether Mooncake's inferred return type for the caller is `A` (the original) rather than `B` (what the overlay would produce):
+The example below covers both cases.
+Case (1) overlays the primitive itself; case (2) overlays a helper called from the primitive's body.
+Each identity check asks whether Mooncake's inferred return type for the caller is `A` (the original) rather than `B` (what the overlay would produce):
 
 ```jldoctest overlay-primitive-doctest
 julia> struct A end
@@ -148,7 +156,8 @@ julia> Base.code_ircode_by_type(Tuple{typeof(caller_indirect), A}; interp)[1][2]
 true
 ```
 
-Both overlays would produce a `B`, but Mooncake infers `A` — and a rule shaped around `B` would mismatch the expected `CoDual{A}`. Apply only one of `@mooncake_overlay` or `@is_primitive` to a given signature, and make sure no overlay you rely on sits behind a primitive's rule.
+Mooncake infers `A` for both callers, even though the overlays would produce a `B` — so any rule written against the overlay's return type fails the runtime check.
+Apply only one of `@mooncake_overlay` or `@is_primitive` to a given signature, and make sure no overlay you rely on sits behind a primitive's rule.
 
 ## Differentiating CUDA Kernels
 

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -109,35 +109,43 @@ This causes two failure modes:
 
 2. **An overlay inside a primitive's body never runs.** The rule replaces the body and runs the primal through ordinary Julia dispatch, which ignores overlays. An overlay written to patch unsupported code inside the primitive is silently inert — move it to a signature Mooncake still differentiates, or fold the workaround into the rule.
 
-The example below covers both cases and prints the return type Mooncake infers for each caller:
+The example below covers both cases. Case (1) overlays the primitive itself; case (2) overlays a helper called from the primitive's body. Each identity check asks whether Mooncake's inferred return type for the caller is `A` (the original) rather than `B` (what the overlay would produce):
 
-```julia
-using Mooncake
+```jldoctest overlay-primitive-doctest
+julia> struct A end
 
-struct A end
-struct B end
+julia> struct B end
 
-# (1) Overlay applied to the primitive itself.
-direct_primitive(::A) = A()
-Mooncake.@mooncake_overlay direct_primitive(::A) = B()
-Mooncake.@is_primitive Mooncake.DefaultCtx Mooncake.ReverseMode Tuple{typeof(direct_primitive), A}
+julia> direct_primitive(::A) = A()
+direct_primitive (generic function with 1 method)
 
-# (2) Overlay applied to a callee inside an otherwise-untouched primitive.
-helper(::A) = A()
-Mooncake.@mooncake_overlay helper(::A) = B()
-indirect_primitive(x::A) = helper(x)
-Mooncake.@is_primitive Mooncake.DefaultCtx Mooncake.ReverseMode Tuple{typeof(indirect_primitive), A}
+julia> Mooncake.@mooncake_overlay direct_primitive(::A) = B()
 
-caller_direct(x::A)   = direct_primitive(x)
-caller_indirect(x::A) = indirect_primitive(x)
+julia> Mooncake.@is_primitive Mooncake.DefaultCtx Mooncake.ReverseMode Tuple{typeof(direct_primitive), A}
 
-interp = Mooncake.MooncakeInterpreter(Mooncake.DefaultCtx, Mooncake.ReverseMode)
-for sig in (Tuple{typeof(caller_direct), A}, Tuple{typeof(caller_indirect), A})
-    _, rt = Base.code_ircode_by_type(sig; interp)[1]
-    println(sig, " => ", rt)
-end
-# Tuple{typeof(caller_direct), A}   => A
-# Tuple{typeof(caller_indirect), A} => A
+julia> helper(::A) = A()
+helper (generic function with 1 method)
+
+julia> Mooncake.@mooncake_overlay helper(::A) = B()
+
+julia> indirect_primitive(x::A) = helper(x)
+indirect_primitive (generic function with 1 method)
+
+julia> Mooncake.@is_primitive Mooncake.DefaultCtx Mooncake.ReverseMode Tuple{typeof(indirect_primitive), A}
+
+julia> caller_direct(x::A) = direct_primitive(x)
+caller_direct (generic function with 1 method)
+
+julia> caller_indirect(x::A) = indirect_primitive(x)
+caller_indirect (generic function with 1 method)
+
+julia> interp = Mooncake.MooncakeInterpreter(Mooncake.DefaultCtx, Mooncake.ReverseMode);
+
+julia> Base.code_ircode_by_type(Tuple{typeof(caller_direct), A}; interp)[1][2] === A
+true
+
+julia> Base.code_ircode_by_type(Tuple{typeof(caller_indirect), A}; interp)[1][2] === A
+true
 ```
 
 Both overlays would produce a `B`, but Mooncake infers `A` — and a rule shaped around `B` would mismatch the expected `CoDual{A}`. Apply only one of `@mooncake_overlay` or `@is_primitive` to a given signature, and make sure no overlay you rely on sits behind a primitive's rule.

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -99,6 +99,49 @@ As you can see, the tangent is `0.0` rather than `6.0`.
 However, we view this as a pathological use of Julia's language features, and believe it is unlikely to cause trouble in practice.
 If you encounter a practical situation in which it is very important that this example work correctly, please open an issue.
 
+## Primitives and Overlays
+
+[`@mooncake_overlay`](@ref Mooncake.@mooncake_overlay) and [`@is_primitive`](@ref Mooncake.@is_primitive) both let you change what Mooncake sees when it differentiates a function, but they hook in at different layers and do not compose. `@mooncake_overlay` swaps in a replacement body Mooncake walks through; `@is_primitive` stops Mooncake walking and dispatches to a hand-written rule instead. Marking a signature as a primitive shadows any overlay reachable through it — the rule fires, the overlay does not, and Mooncake reads return types off the original code.
+
+This causes two failure modes:
+
+1. **An overlay that changes the return type breaks the rule's type signature.** Mooncake infers the original return type, so a rule that returns the overlaid value mismatches the expected `CoDual` type and throws a runtime `TypeError`. If the return type is a singleton the check can pass anyway, and the rule may silently produce an incorrect gradient.
+
+2. **An overlay inside a primitive's body never runs.** The rule replaces the body and runs the primal through ordinary Julia dispatch, which ignores overlays. An overlay written to patch unsupported code inside the primitive is silently inert — move it to a signature Mooncake still differentiates, or fold the workaround into the rule.
+
+The example below covers both cases and prints the return type Mooncake infers for each caller:
+
+```julia
+using Mooncake
+
+struct A end
+struct B end
+
+# (1) Overlay applied to the primitive itself.
+direct_primitive(::A) = A()
+Mooncake.@mooncake_overlay direct_primitive(::A) = B()
+Mooncake.@is_primitive Mooncake.DefaultCtx Mooncake.ReverseMode Tuple{typeof(direct_primitive), A}
+
+# (2) Overlay applied to a callee inside an otherwise-untouched primitive.
+helper(::A) = A()
+Mooncake.@mooncake_overlay helper(::A) = B()
+indirect_primitive(x::A) = helper(x)
+Mooncake.@is_primitive Mooncake.DefaultCtx Mooncake.ReverseMode Tuple{typeof(indirect_primitive), A}
+
+caller_direct(x::A)   = direct_primitive(x)
+caller_indirect(x::A) = indirect_primitive(x)
+
+interp = Mooncake.MooncakeInterpreter(Mooncake.DefaultCtx, Mooncake.ReverseMode)
+for sig in (Tuple{typeof(caller_direct), A}, Tuple{typeof(caller_indirect), A})
+    _, rt = Base.code_ircode_by_type(sig; interp)[1]
+    println(sig, " => ", rt)
+end
+# Tuple{typeof(caller_direct), A}   => A
+# Tuple{typeof(caller_indirect), A} => A
+```
+
+Both overlays would produce a `B`, but Mooncake infers `A` — and a rule shaped around `B` would mismatch the expected `CoDual{A}`. Apply only one of `@mooncake_overlay` or `@is_primitive` to a given signature, and make sure no overlay you rely on sits behind a primitive's rule.
+
 ## Differentiating CUDA Kernels
 
 Mooncake.jl supports differentiation of CUDA kernels in general, provided a suitable rule exists. However, it does not support kernels that surface as foreign calls, such as those generated via KernelAbstractions.jl (see [issue #648](https://github.com/chalk-lab/Mooncake.jl/issues/648) and [issue #835](https://github.com/chalk-lab/Mooncake.jl/issues/835)). Support for these foreign-call kernels is outside the scope of the project and is considered a non-goal.

--- a/src/interpreter/contexts.jl
+++ b/src/interpreter/contexts.jl
@@ -86,6 +86,12 @@ true
 julia> is_primitive(DefaultCtx, ReverseMode, Tuple{typeof(bar),Float64}, Base.get_world_counter())
 false
 ```
+
+!!! warning "Combining with `@mooncake_overlay`"
+    Marking a signature as a primitive does not pick up an overlaid body for type
+    inference, so a [`@mooncake_overlay`](@ref) that changes the return type can put
+    the rule and the inferred `CoDual` type out of sync.
+    See [Primitives and Overlays](@ref).
 """
 macro is_primitive(Tctx, sig)
     return _is_primitive_expression(Tctx, :(Mooncake.Mode), sig)

--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -100,6 +100,12 @@ julia> rule = Mooncake.build_rrule(Tuple{typeof(scale), Float64});
 julia> Mooncake.value_and_gradient!!(rule, scale, 5.0)
 (20.0, (NoTangent(), 4.0))
 ```
+
+!!! warning "Combining with `@is_primitive`"
+    Applying an overlay to a signature that is also marked as a primitive via
+    [`@is_primitive`](@ref) is not generally supported: type inference uses the
+    original body, so the rule and the inferred `CoDual` type can disagree.
+    See [Primitives and Overlays](@ref).
 """
 macro mooncake_overlay(method_expr)
     def = splitdef(method_expr)


### PR DESCRIPTION
Address https://github.com/chalk-lab/Mooncake.jl/issues/1169 and replace #1170. 

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1177 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1177/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 170.0 ns │     1.71 │        1.71 │   0.706 │        3.42 │    6.6 │
│             _sum_1000 │ 972.0 ns │     6.99 │        1.01 │  4470.0 │        39.4 │   1.06 │
│          sum_sin_1000 │  7.09 μs │     3.47 │        1.31 │    1.51 │        11.0 │   1.79 │
│         _sum_sin_1000 │  6.18 μs │     3.37 │        1.83 │   261.0 │        12.8 │   2.11 │
│              kron_sum │ 207.0 μs │     12.9 │        3.16 │    22.6 │       352.0 │   19.7 │
│         kron_view_sum │ 293.0 μs │     10.9 │        5.03 │    24.7 │       306.0 │   6.63 │
│ naive_map_sin_cos_exp │  2.37 μs │     3.04 │        1.55 │ missing │        8.26 │   2.08 │
│       map_sin_cos_exp │   2.3 μs │     3.46 │        1.64 │    1.61 │        7.48 │   2.68 │
│ broadcast_sin_cos_exp │  2.33 μs │      3.1 │        1.58 │    3.67 │        1.47 │   2.09 │
│            simple_mlp │ 338.0 μs │     5.05 │        2.84 │    2.26 │         9.2 │   3.04 │
│                gp_lml │ 171.0 μs │     11.2 │         4.0 │    10.9 │     missing │   7.69 │
│    large_single_block │ 421.0 ns │     5.26 │         1.9 │  4560.0 │        32.3 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->