### PR TITLE
Add a buffer for the Hessian cache to avoid allocation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.28"
+version = "0.5.29"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2160,7 +2160,7 @@ struct HVPCache{Tf,Tgrad_f,Tgrad_tangent,Tfwd_cache,TOS,THB}
 end
 
 function Base.show(io::IO, cache::HVPCache)
-    return print(
+    print(
         io,
         "Mooncake.HVPCache(",
         "mode=:forward_over_reverse, ",
@@ -2254,7 +2254,7 @@ true
         function (ys...)
             val_and_grad = value_and_gradient!!(grad_cache, f, ys...)
             # Drop the gradient w.r.t. f itself (always index 1); return only x-arg gradients.
-            return (val_and_grad[1], Base.tail(val_and_grad[2]))
+            (val_and_grad[1], Base.tail(val_and_grad[2]))
         end
     end
     fwd_cache = prepare_derivative_cache(grad_f, x...; config)
@@ -2285,6 +2285,12 @@ end
 @noinline _throw_not_hessian_cache() = throw(
     ArgumentError(
         "`cache` was not built with `prepare_hessian_cache`; rebuild via `prepare_hessian_cache(f, x...)` to use `value_gradient_and_hessian!!`",
+    ),
+)
+
+@noinline _throw_hessian_arity_mismatch(cached::Int, got::Int) = throw(
+    ArgumentError(
+        "cache was prepared for $cached argument$(cached == 1 ? "" : "s") but called with $got; rebuild via `prepare_hessian_cache`",
     ),
 )
 
@@ -2656,7 +2662,10 @@ H
         ArgumentError("`f` must be the same function object used to construct `cache`")
     )
     buf = cache.hess_buffers
-    buf isa NamedTuple{(:H, :grad, :v)} || _throw_not_hessian_cache()
+    buf === nothing && _throw_not_hessian_cache()
+    if buf isa NamedTuple{(:H_blocks, :grads, :vs)}
+        _throw_hessian_arity_mismatch(length(buf.vs), 1)
+    end
     T = _validate_hessian_argument(x1, 1)
     H = buf.H
     g = buf.grad
@@ -2696,10 +2705,13 @@ end
         ArgumentError("`f` must be the same function object used to construct `cache`")
     )
     buf = cache.hess_buffers
-    buf isa NamedTuple{(:H_blocks, :grads, :vs)} || _throw_not_hessian_cache()
+    nargs = N + 1
+    buf === nothing && _throw_not_hessian_cache()
+    if buf isa NamedTuple{(:H, :grad, :v)}
+        _throw_hessian_arity_mismatch(1, nargs)
+    end
     all_xs = (x1, xrest...)
     T = _validate_hessian_arguments(all_xs...)
-    nargs = N + 1
     ns = tuple_map(length, all_xs)
     H_blocks = buf.H_blocks
     grads = buf.grads
@@ -2707,11 +2719,7 @@ end
     # Buffer arity/sizes are fixed at cache build time; reject mismatched inputs
     # before indexing `v[k]`/`H_blocks`, otherwise the sweep below raises a raw
     # `BoundsError`.
-    nargs == length(v) || throw(
-        ArgumentError(
-            "cache was prepared for $(length(v)) arguments but called with $nargs; rebuild via `prepare_hessian_cache`",
-        ),
-    )
+    nargs == length(v) || _throw_hessian_arity_mismatch(length(v), nargs)
     for k in 1:nargs
         ns[k] == length(v[k]) || throw(
             ArgumentError(

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2704,8 +2704,14 @@ end
     H_blocks = buf.H_blocks
     grads = buf.grads
     v = buf.vs
-    # Buffer sizes are fixed at cache build time; reject mismatched inputs before
-    # indexing `v[k]`/`H_blocks`, otherwise the sweep below raises a raw `BoundsError`.
+    # Buffer arity/sizes are fixed at cache build time; reject mismatched inputs
+    # before indexing `v[k]`/`H_blocks`, otherwise the sweep below raises a raw
+    # `BoundsError`.
+    nargs == length(v) || throw(
+        ArgumentError(
+            "cache was prepared for $(length(v)) arguments but called with $nargs; rebuild via `prepare_hessian_cache`",
+        ),
+    )
     for k in 1:nargs
         ns[k] == length(v[k]) || throw(
             ArgumentError(

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2142,7 +2142,7 @@ end
 Cache type used by [`prepare_hvp_cache`](@ref) and [`prepare_hessian_cache`](@ref) for
 repeated Hessian-vector product and Hessian evaluations.
 """
-struct HVPCache{Tf,Tgrad_f,Tgrad_tangent,Tfwd_cache,TOS}
+struct HVPCache{Tf,Tgrad_f,Tgrad_tangent,Tfwd_cache,TOS,THB}
     f::Tf
     grad_f::Tgrad_f
     # Pre-computed zero tangent for grad_f; the function is never perturbed, only x is.
@@ -2152,10 +2152,15 @@ struct HVPCache{Tf,Tgrad_f,Tgrad_tangent,Tfwd_cache,TOS}
     grad_tangent::Tgrad_tangent
     fwd_cache::Tfwd_cache
     output_spec::TOS
+    # Hessian-assembly buffers populated by `prepare_hessian_cache`, `nothing` for caches
+    # built via `prepare_hvp_cache`. `value_gradient_and_hessian!!` writes into these.
+    # Single-arg layout: `(; H::Matrix, grad::Vector, v::Vector)`.
+    # Multi-arg layout:  `(; H_blocks::Tuple, grads::Tuple, vs::Tuple)`.
+    hess_buffers::THB
 end
 
 function Base.show(io::IO, cache::HVPCache)
-    print(
+    return print(
         io,
         "Mooncake.HVPCache(",
         "mode=:forward_over_reverse, ",
@@ -2249,14 +2254,39 @@ true
         function (ys...)
             val_and_grad = value_and_gradient!!(grad_cache, f, ys...)
             # Drop the gradient w.r.t. f itself (always index 1); return only x-arg gradients.
-            (val_and_grad[1], Base.tail(val_and_grad[2]))
+            return (val_and_grad[1], Base.tail(val_and_grad[2]))
         end
     end
     fwd_cache = prepare_derivative_cache(grad_f, x...; config)
     return HVPCache(
-        f, grad_f, zero_tangent(grad_f), fwd_cache, getfield(grad_cache, :output_spec)
+        f,
+        grad_f,
+        zero_tangent(grad_f),
+        fwd_cache,
+        getfield(grad_cache, :output_spec),
+        nothing,
     )
 end
+
+function _make_hessian_buffers(::Type{T}, xs::Tuple) where {T}
+    if length(xs) == 1
+        n = length(xs[1])
+        return (; H=zeros(T, n, n), grad=zeros(T, n), v=zeros(T, n))
+    end
+    ns = tuple_map(length, xs)
+    nargs = length(xs)
+    # H_blocks[k][j] = ∂²f/∂xk∂xj, shape ns[k] × ns[j]
+    H_blocks = ntuple(k -> ntuple(j -> zeros(T, ns[k], ns[j]), nargs), nargs)
+    grads = tuple_map(ni -> zeros(T, ni), ns)
+    vs = tuple_map(ni -> zeros(T, ni), ns)
+    return (; H_blocks, grads, vs)
+end
+
+@noinline _throw_not_hessian_cache() = throw(
+    ArgumentError(
+        "`cache` was not built with `prepare_hessian_cache`; rebuild via `prepare_hessian_cache(f, x...)` to use `value_gradient_and_hessian!!`",
+    ),
+)
 
 """
     value_and_hvp!!(cache::HVPCache, f, v, x...)
@@ -2334,13 +2364,14 @@ end
     prepare_hessian_cache(f, x...; config=Mooncake.Config())
 
 Return a cache for computing `f(x...)`, gradients `∇f`, and the Hessian (or Hessian
-blocks) of `f` via [`value_gradient_and_hessian!!`](@ref). Returns an [`HVPCache`](@ref),
-which can also be used directly with [`value_and_hvp!!`](@ref).
+blocks) of `f` via [`value_gradient_and_hessian!!`](@ref). Returns an [`HVPCache`](@ref).
 
-`prepare_hessian_cache` reuses the generic HVP cache builder. It eagerly checks only
-that at least one `x` argument was provided; validation that the `x...` inputs are
-`AbstractVector`s of IEEE floats, all with the same element type, is deferred to
-[`value_gradient_and_hessian!!`](@ref).
+The `x...` inputs must be `AbstractVector`s of a single IEEE-float element type;
+validation is eager and raises `ArgumentError` here rather than at evaluation time.
+The cache pre-allocates the Hessian, gradient, and basis-direction buffers that
+[`value_gradient_and_hessian!!`](@ref) writes into, so subsequent calls do not allocate
+fresh outputs. The returned `gradient` and Hessian alias cache storage; copy them if
+you need to retain previous results.
 
 Hessian computation uses forward-over-reverse AD: one forward-mode pass per input
 dimension over the reverse-mode gradient function.
@@ -2365,7 +2396,17 @@ Mooncake.value_gradient_and_hessian!!(cache, f, x)
 @unstable @inline function prepare_hessian_cache(
     f::F, x::Vararg{Any,N}; config=Config()
 ) where {F,N}
-    return prepare_hvp_cache(f, x...; config)
+    N == 0 && throw(ArgumentError("prepare_hessian_cache requires at least one x argument"))
+    T = _validate_hessian_arguments(x...)
+    base = prepare_hvp_cache(f, x...; config)
+    return HVPCache(
+        base.f,
+        base.grad_f,
+        base.grad_tangent,
+        base.fwd_cache,
+        base.output_spec,
+        _make_hessian_buffers(T, x),
+    )
 end
 
 function _validate_hessian_argument(x, i::Int)
@@ -2564,8 +2605,8 @@ end
 """
     value_gradient_and_hessian!!(cache::HVPCache, f, x...)
 
-Using a pre-built `cache` (from [`prepare_hessian_cache`](@ref) or
-[`prepare_hvp_cache`](@ref)), compute and return `(value, gradient, hessian)` of `f`.
+Using a pre-built `cache` from [`prepare_hessian_cache`](@ref), compute and return
+`(value, gradient, hessian)` of `f`.
 
 **Single argument:** returns `(f(x), ∇f(x), ∇²f(x))` — value, gradient vector, Hessian
 matrix.
@@ -2577,15 +2618,17 @@ from the single-argument case.
 Uses forward-over-reverse AD: one forward-mode pass per total input dimension.
 
 !!! info
-    `cache` must be the output of [`prepare_hessian_cache`](@ref) or
-    [`prepare_hvp_cache`](@ref), and `f` must be the same function object used to
-    construct `cache`. All `x` arguments must have the same sizes and element types as
-    used to construct the cache. The current implementation supports only
-    `AbstractVector`s of IEEE floats, with all arguments sharing the same element type.
-    This restriction comes from the Hessian assembly logic, which sweeps a standard
-    basis of tangent vectors and materialises dense matrix / block-matrix outputs. For
-    non-vector inputs, use [`value_and_hvp!!`](@ref) to obtain second-order directional
-    derivatives without forming a full Hessian.
+    `cache` must be the output of [`prepare_hessian_cache`](@ref), and `f` must be the
+    same function object used to construct `cache`. All `x` arguments must have the
+    same sizes and element types as used to construct the cache. The implementation
+    supports only `AbstractVector`s of IEEE floats, with all arguments sharing the same
+    element type. For non-vector inputs, use [`value_and_hvp!!`](@ref) to obtain
+    second-order directional derivatives without forming a full Hessian.
+
+!!! warning
+    The returned `gradient` and Hessian alias buffers owned by `cache` and are
+    overwritten on the next call with the same cache. Copy them (`copy`/`deepcopy`)
+    before mutating or if you need to retain previous results.
 
 !!! warning
     `HVPCache` is not safe for concurrent reuse across threads. Use a separate cache per
@@ -2612,27 +2655,38 @@ H
     cache.f === f || throw(
         ArgumentError("`f` must be the same function object used to construct `cache`")
     )
+    buf = cache.hess_buffers
+    buf isa NamedTuple{(:H, :grad, :v)} || _throw_not_hessian_cache()
     T = _validate_hessian_argument(x1, 1)
-    if length(x1) == 0
-        v = similar(x1, T)
-        fval, grad, _ = value_and_hvp!!(cache, f, v, x1)
-        return fval, copy(grad), zeros(T, 0, 0)
-    end
+    H = buf.H
+    g = buf.grad
+    v = buf.v
     n = length(x1)
-    H = zeros(T, n, n)
-    v = zeros(T, n)
-    local value, gradient
+    # Buffer sizes are fixed at cache build time; reject mismatched inputs before
+    # indexing `v`/`H`, otherwise the sweep below raises a raw `BoundsError`.
+    n == length(v) || throw(
+        ArgumentError(
+            "input vector has length $n but cache was prepared for length $(length(v)); rebuild via `prepare_hessian_cache`",
+        ),
+    )
+    # Reset `v` in case a prior call threw between `v[i] = one(T)` and `v[i] = zero(T)`.
+    fill!(v, zero(T))
+    if n == 0
+        fval, _, _ = value_and_hvp!!(cache, f, v, x1)
+        return fval, g, H
+    end
+    local value
     for i in 1:n
         v[i] = one(T)
-        fval, grad, hvp = value_and_hvp!!(cache, f, v, x1)
+        fval, grad_alias, hvp = value_and_hvp!!(cache, f, v, x1)
         if i == 1
             value = fval
-            gradient = copy(grad)
+            g .= grad_alias
         end
-        H[:, i] .= hvp
+        @inbounds @views H[:, i] .= hvp
         v[i] = zero(T)
     end
-    return value, gradient, H
+    return value, g, H
 end
 
 @unstable @inline function value_gradient_and_hessian!!(
@@ -2641,34 +2695,44 @@ end
     cache.f === f || throw(
         ArgumentError("`f` must be the same function object used to construct `cache`")
     )
+    buf = cache.hess_buffers
+    buf isa NamedTuple{(:H_blocks, :grads, :vs)} || _throw_not_hessian_cache()
     all_xs = (x1, xrest...)
     T = _validate_hessian_arguments(all_xs...)
     nargs = N + 1
-    ns = map(length, all_xs)
-    # H_blocks[k][j] = ∂²f/∂xk∂xj, shape ns[k] × ns[j]
-    H_blocks = ntuple(k -> ntuple(j -> zeros(T, ns[k], ns[j]), nargs), nargs)
-    # one mutable tangent-direction buffer per argument (reused across HVP calls)
-    v = map(ni -> zeros(T, ni), ns)
-    # if all arguments are empty, skip the HVP loop and recover value/grads directly
-    if all(==(0), ns)
-        fval, gs, _ = value_and_hvp!!(cache, f, v, all_xs...)
-        return fval, map(copy, gs), H_blocks
+    ns = tuple_map(length, all_xs)
+    H_blocks = buf.H_blocks
+    grads = buf.grads
+    v = buf.vs
+    # Buffer sizes are fixed at cache build time; reject mismatched inputs before
+    # indexing `v[k]`/`H_blocks`, otherwise the sweep below raises a raw `BoundsError`.
+    for k in 1:nargs
+        ns[k] == length(v[k]) || throw(
+            ArgumentError(
+                "argument $k has length $(ns[k]) but cache was prepared for length $(length(v[k])); rebuild via `prepare_hessian_cache`",
+            ),
+        )
     end
-    local value, grads
+    # Reset each `v[k]` in case a prior call threw between `v[k][i] = one(T)` and
+    # `v[k][i] = zero(T)`.
+    tuple_map(vk -> fill!(vk, zero(T)), v)
+    if all(==(0), ns)
+        fval, _, _ = value_and_hvp!!(cache, f, v, all_xs...)
+        return fval, grads, H_blocks
+    end
+    local value
     first_iter = true
     for argidx in 1:nargs
         v_i = v[argidx]
         for i in 1:ns[argidx]
             v_i[i] = one(T)
-            fval, gs, hvps = value_and_hvp!!(cache, f, v, all_xs...)
+            fval, gs_alias, hvps = value_and_hvp!!(cache, f, v, all_xs...)
             if first_iter
                 value = fval
-                grads = map(copy, gs)
+                tuple_map((g, a) -> (g .= a), grads, gs_alias)
                 first_iter = false
             end
-            for k in 1:nargs
-                H_blocks[k][argidx][:, i] .= hvps[k]
-            end
+            tuple_map((Hk, hk) -> (@inbounds @views Hk[argidx][:, i] .= hk), H_blocks, hvps)
             v_i[i] = zero(T)
         end
     end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2370,7 +2370,8 @@ end
     prepare_hessian_cache(f, x...; config=Mooncake.Config())
 
 Return a cache for computing `f(x...)`, gradients `∇f`, and the Hessian (or Hessian
-blocks) of `f` via [`value_gradient_and_hessian!!`](@ref). Returns an [`HVPCache`](@ref).
+blocks) of `f` via [`value_gradient_and_hessian!!`](@ref). Returns an [`HVPCache`](@ref),
+which is also accepted by [`value_and_hvp!!`](@ref).
 
 The `x...` inputs must be `AbstractVector`s of a single IEEE-float element type;
 validation is eager and raises `ArgumentError` here rather than at evaluation time.
@@ -2418,13 +2419,13 @@ end
 function _validate_hessian_argument(x, i::Int)
     x isa AbstractVector || throw(
         ArgumentError(
-            "value_gradient_and_hessian!! only supports AbstractVector inputs; argument $i has type $(typeof(x))",
+            "Hessian computation only supports AbstractVector inputs; argument $i has type $(typeof(x))",
         ),
     )
     T = eltype(x)
     T <: IEEEFloat || throw(
         ArgumentError(
-            "value_gradient_and_hessian!! only supports AbstractVector inputs with IEEEFloat element types; argument $i has eltype $T",
+            "Hessian computation only supports AbstractVector inputs with IEEEFloat element types; argument $i has eltype $T",
         ),
     )
     return T
@@ -2436,7 +2437,7 @@ function _validate_hessian_arguments(x::Vararg{Any,N}) where {N}
         Ti = _validate_hessian_argument(x[i], i)
         Ti == T || throw(
             ArgumentError(
-                "value_gradient_and_hessian!! requires all arguments to share the same IEEEFloat element type; argument 1 has eltype $T but argument $i has eltype $Ti",
+                "Hessian computation requires all arguments to share the same IEEEFloat element type; argument 1 has eltype $T but argument $i has eltype $Ti",
             ),
         )
     end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1458,6 +1458,8 @@ end
                 x2 = [2.0, 3.0]
                 cache = prepare_hessian_cache(f, x1)
                 v1, g1, H1 = value_gradient_and_hessian!!(cache, f, x1)
+                # `cache` owns the returned `g`/`H`; snapshot before reusing the cache.
+                g1, H1 = copy(g1), copy(H1)
                 v2, g2, H2 = value_gradient_and_hessian!!(cache, f, x2)
                 @test v1 ≈ 1.0
                 @test v2 ≈ 13.0
@@ -1521,6 +1523,8 @@ end
                 v1, (gx1, gy1), ((Hxx1, _), (_, Hyy1)) = value_gradient_and_hessian!!(
                     cache, f, x1, y1
                 )
+                # `cache` owns the returned tuples; snapshot before reusing the cache.
+                gx1, gy1, Hxx1, Hyy1 = copy(gx1), copy(gy1), copy(Hxx1), copy(Hyy1)
                 v2, (gx2, gy2), ((Hxx2, _), (_, Hyy2)) = value_gradient_and_hessian!!(
                     cache, f, x2, y2
                 )
@@ -1569,23 +1573,20 @@ end
             @testset "reject non-vector inputs" begin
                 f(x) = sum(x .^ 2)
                 x = [1.0 2.0; 3.0 4.0]
-                cache = prepare_hessian_cache(f, x)
-                @test_throws ArgumentError value_gradient_and_hessian!!(cache, f, x)
+                @test_throws ArgumentError prepare_hessian_cache(f, x)
             end
 
             @testset "reject non-IEEEFloat element types" begin
                 f(x) = sum(abs2, x)
                 x = ComplexF64[1 + 0im, 2 + 0im]
-                cache = prepare_hessian_cache(f, x)
-                @test_throws ArgumentError value_gradient_and_hessian!!(cache, f, x)
+                @test_throws ArgumentError prepare_hessian_cache(f, x)
             end
 
             @testset "reject mismatched element types across arguments" begin
                 f(x, y) = sum(x .^ 2) + sum(y .^ 2)
                 x = Float64[1.0, 2.0]
                 y = Float32[3.0, 4.0]
-                cache = prepare_hessian_cache(f, x, y)
-                @test_throws ArgumentError value_gradient_and_hessian!!(cache, f, x, y)
+                @test_throws ArgumentError prepare_hessian_cache(f, x, y)
             end
 
             @testset "reject mismatched function object" begin
@@ -1596,11 +1597,58 @@ end
                 @test_throws ArgumentError value_gradient_and_hessian!!(cache, g, x)
             end
 
+            @testset "reject HVP-only cache" begin
+                f(x) = sum(x .^ 2)
+                x = [1.0, 2.0]
+                cache = Mooncake.prepare_hvp_cache(f, x)
+                @test_throws ArgumentError value_gradient_and_hessian!!(cache, f, x)
+            end
+
+            @testset "cache buffer reuse (output aliasing)" begin
+                f(x) = sum(x .^ 2)
+                x = [1.0, 2.0, 3.0]
+                cache = prepare_hessian_cache(f, x)
+                _, g1, H1 = value_gradient_and_hessian!!(cache, f, x)
+                _, g2, H2 = value_gradient_and_hessian!!(cache, f, x)
+                # Both calls return the same cache-owned buffers.
+                @test g1 === g2
+                @test H1 === H2
+            end
+
+            @testset "multi-arg cache buffer reuse" begin
+                f(x, y) = sum(x .^ 2) + sum(y .^ 2) + x[1] * y[1]
+                x = [1.0, 2.0]
+                y = [3.0, 4.0]
+                cache = prepare_hessian_cache(f, x, y)
+                _, (gx1, gy1), ((Hxx1, Hxy1), (Hyx1, Hyy1)) = value_gradient_and_hessian!!(
+                    cache, f, x, y
+                )
+                _, (gx2, gy2), ((Hxx2, Hxy2), (Hyx2, Hyy2)) = value_gradient_and_hessian!!(
+                    cache, f, x, y
+                )
+                @test gx1 === gx2 && gy1 === gy2
+                @test Hxx1 === Hxx2 && Hxy1 === Hxy2
+                @test Hyx1 === Hyx2 && Hyy1 === Hyy2
+            end
+
+            @testset "empty-cache reused at non-empty input" begin
+                f(x) = sum(x .^ 2)
+                cache = prepare_hessian_cache(f, Float64[])
+                @test_throws ArgumentError value_gradient_and_hessian!!(
+                    cache, f, [1.0, 2.0]
+                )
+                g(x, y) = sum(x .^ 2) + sum(y .^ 2)
+                cache2 = prepare_hessian_cache(g, Float64[], Float64[])
+                @test_throws ArgumentError value_gradient_and_hessian!!(
+                    cache2, g, [1.0], Float64[]
+                )
+            end
+
             @testset "hessian cache mismatch errors" begin
                 f(x) = sum(x .^ 2)
                 x = [1.0, 2.0]
                 cache = prepare_hessian_cache(f, x)
-                @test_throws r"Cached autodiff call has a size mismatch for `x1`" value_gradient_and_hessian!!(
+                @test_throws r"input vector has length 3 but cache was prepared for length 2" value_gradient_and_hessian!!(
                     cache, f, [1.0, 2.0, 3.0]
                 )
                 @test_throws r"Cached autodiff call has a type mismatch for `x1`" value_gradient_and_hessian!!(

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1631,6 +1631,14 @@ end
                 @test Hyx1 === Hyx2 && Hyy1 === Hyy2
             end
 
+            @testset "reject mismatched cache arity" begin
+                f(x, y) = sum(x .^ 2) + sum(y .^ 2)
+                cache = prepare_hessian_cache(f, [1.0], [2.0])
+                @test_throws r"cache was prepared for 2 arguments but called with 3" value_gradient_and_hessian!!(
+                    cache, f, [1.0], [2.0], [3.0]
+                )
+            end
+
             @testset "empty-cache reused at non-empty input" begin
                 f(x) = sum(x .^ 2)
                 cache = prepare_hessian_cache(f, Float64[])

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1632,10 +1632,22 @@ end
             end
 
             @testset "reject mismatched cache arity" begin
-                f(x, y) = sum(x .^ 2) + sum(y .^ 2)
-                cache = prepare_hessian_cache(f, [1.0], [2.0])
+                f(x) = sum(abs2, x)
+                f(x, y) = sum(abs2, x) + sum(abs2, y)
+                # 2-arg cache, 3-arg call.
+                cache2 = prepare_hessian_cache(f, [1.0], [2.0])
                 @test_throws r"cache was prepared for 2 arguments but called with 3" value_gradient_and_hessian!!(
-                    cache, f, [1.0], [2.0], [3.0]
+                    cache2, f, [1.0], [2.0], [3.0]
+                )
+                # 2-arg cache, 1-arg call — single-arg dispatch must report arity, not
+                # the generic "not a hessian cache" error.
+                @test_throws r"cache was prepared for 2 arguments but called with 1" value_gradient_and_hessian!!(
+                    cache2, f, [1.0]
+                )
+                # 1-arg cache, 2-arg call — multi-arg dispatch, same expectation.
+                cache1 = prepare_hessian_cache(f, [1.0, 2.0])
+                @test_throws r"cache was prepared for 1 argument but called with 2" value_gradient_and_hessian!!(
+                    cache1, f, [1.0, 2.0], [3.0]
                 )
             end
 


### PR DESCRIPTION
<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1178 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1178/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 327.0 ns │     1.51 │        1.55 │   0.361 │        1.47 │   5.78 │
│             _sum_1000 │  1.18 μs │     11.7 │        1.07 │  3020.0 │        27.1 │   1.45 │
│          sum_sin_1000 │  6.03 μs │     5.66 │        4.42 │    2.31 │        12.4 │   2.19 │
│         _sum_sin_1000 │  6.02 μs │     3.94 │        1.74 │   250.0 │        12.8 │   2.07 │
│              kron_sum │ 400.0 μs │     9.08 │        2.91 │    14.7 │       224.0 │   12.7 │
│         kron_view_sum │ 482.0 μs │     8.64 │        4.05 │    17.0 │       237.0 │   10.4 │
│ naive_map_sin_cos_exp │  3.23 μs │     2.52 │        1.18 │ missing │        5.01 │   1.51 │
│       map_sin_cos_exp │  3.12 μs │     3.75 │        2.63 │    1.34 │        4.44 │   1.93 │
│ broadcast_sin_cos_exp │  3.18 μs │     2.81 │        2.67 │    2.44 │       0.985 │   1.55 │
│            simple_mlp │ 510.0 μs │      4.5 │         2.6 │    1.46 │        8.18 │   2.64 │
│                gp_lml │ 300.0 μs │     8.45 │        2.31 │    4.46 │     missing │   3.76 │
│    large_single_block │ 518.0 ns │     8.86 │        2.03 │  3940.0 │        24.5 │   1.75 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->