### PR TITLE
remove redundant `resolve_unbound_globalrefs`

### DIFF
--- a/src/developer_tools.jl
+++ b/src/developer_tools.jl
@@ -30,6 +30,8 @@ true
 function primal_ir(interp::MooncakeInterpreter, sig::Type{<:Tuple}; normalize=true)::IRCode
     ir, _ = lookup_ir(interp, sig)
     @static if VERSION > v"1.12-"
+        # Pins valid_worlds to a single world so verify_ir's GlobalRef const-binding
+        # check passes for all currently-defined bindings without patching the IR.
         ir = set_valid_world!(ir, interp.world)
     end
     normalize || return ir

--- a/src/developer_tools.jl
+++ b/src/developer_tools.jl
@@ -30,8 +30,7 @@ true
 function primal_ir(interp::MooncakeInterpreter, sig::Type{<:Tuple}; normalize=true)::IRCode
     ir, _ = lookup_ir(interp, sig)
     @static if VERSION > v"1.12-"
-        # Pins valid_worlds to a single world so verify_ir's GlobalRef const-binding
-        # check passes for all currently-defined bindings without patching the IR.
+        # Pin to one world so verify_ir's GlobalRef check passes; see `set_valid_world!`.
         ir = set_valid_world!(ir, interp.world)
     end
     normalize || return ir

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -187,6 +187,8 @@ function generate_dual_ir(
     # Grab code associated to the primal.
     primal_ir, _ = lookup_ir(interp, sig_or_mi)
     @static if VERSION > v"1.12-"
+        # Pins valid_worlds to a single world so verify_ir's GlobalRef const-binding
+        # check passes for all currently-defined bindings without patching the IR.
         primal_ir = set_valid_world!(primal_ir, interp.world)
     end
     nargs = length(primal_ir.argtypes)

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -187,8 +187,7 @@ function generate_dual_ir(
     # Grab code associated to the primal.
     primal_ir, _ = lookup_ir(interp, sig_or_mi)
     @static if VERSION > v"1.12-"
-        # Pins valid_worlds to a single world so verify_ir's GlobalRef const-binding
-        # check passes for all currently-defined bindings without patching the IR.
+        # Pin to one world so verify_ir's GlobalRef check passes; see `set_valid_world!`.
         primal_ir = set_valid_world!(primal_ir, interp.world)
     end
     nargs = length(primal_ir.argtypes)

--- a/src/interpreter/ir_normalisation.jl
+++ b/src/interpreter/ir_normalisation.jl
@@ -233,7 +233,6 @@ expressions in the same way as a primitive `:call` expression, i.e. via an `rrul
 """
 splatnew_to_call(x) = Meta.isexpr(x, :splatnew) ? Expr(:call, _splat_new_, x.args...) : x
 
-
 """
     intrinsic_to_function(inst)
 

--- a/src/interpreter/ir_normalisation.jl
+++ b/src/interpreter/ir_normalisation.jl
@@ -6,11 +6,10 @@ unchanged, but makes AD more straightforward. In particular, replace
 1. `:foreigncall` `Expr`s with `:call`s to `Mooncake._foreigncall_`,
 2. `:new` `Expr`s with `:call`s to `Mooncake._new_`,
 3. `:splatnew` Expr`s with `:call`s to `Mooncake._splat_new_`,
-4. resolve unbound GlobalRefs (Julia 1.12+ only) to their actual values,
-5. `Core.IntrinsicFunction`s with counterparts from `Mooncake.IntrinsicWrappers`,
-6. `getfield(x, 1)` with `lgetfield(x, Val(1))`, and related transformations,
-7. `memoryrefget` calls to `lmemoryrefget` calls, and related transformations,
-8. `gc_preserve_begin` / `gc_preserve_end` exprs so that memory release is delayed.
+4. `Core.IntrinsicFunction`s with counterparts from `Mooncake.IntrinsicWrappers`,
+5. `getfield(x, 1)` with `lgetfield(x, Val(1))`, and related transformations,
+6. `memoryrefget` calls to `lmemoryrefget` calls, and related transformations,
+7. `gc_preserve_begin` / `gc_preserve_end` exprs so that memory release is delayed.
 
 `spnames` are the names associated to the static parameters of `ir`. These are needed when
 handling `:foreigncall` expressions, in which it is not necessarily the case that all
@@ -29,9 +28,6 @@ function normalise!(ir::IRCode, spnames::Vector{Symbol})
         inst = foreigncall_to_call(inst, sp_map)
         inst = new_to_call(inst)
         inst = splatnew_to_call(inst)
-        @static if VERSION > v"1.12-"
-            inst = resolve_unbound_globalrefs(ir, inst)
-        end
         inst = intrinsic_to_function(inst)
         inst = lift_getfield_and_others(inst)
         inst = lift_memoryrefget_and_memoryrefset_builtins(inst)
@@ -237,51 +233,6 @@ expressions in the same way as a primitive `:call` expression, i.e. via an `rrul
 """
 splatnew_to_call(x) = Meta.isexpr(x, :splatnew) ? Expr(:call, _splat_new_, x.args...) : x
 
-"""
-    resolve_unbound_globalrefs(ir, ex)
-
-Resolve GlobalRefs that are considered unbound in the given world range, but are actually
-defined due to partitioned bindings. 
-
-Only available on Julia 1.12+.
-"""
-# XXX: this is probably unsound, but the best workaround so far
-function resolve_unbound_globalrefs(ir, @nospecialize ex)
-    isa(ex, Expr) || return ex
-    args = nothing
-    for i in eachindex(ex.args)
-        arg = ex.args[i]
-        # extracted from `Compiler.check_op` (called by `Compiler.verify_ir`)
-        if isa(arg, GlobalRef) && arg.mod !== Core && arg.mod !== Base
-            (valid_worlds, alldef) = CC.scan_leaf_partitions(
-                nothing,
-                arg,
-                CC.WorldWithRange(CC.min_world(ir.valid_worlds), ir.valid_worlds),
-            ) do _, _, bpart
-                CC.is_defined_const_binding(CC.binding_kind(bpart))
-            end
-            if !alldef ||
-                CC.max_world(valid_worlds) < CC.max_world(ir.valid_worlds) ||
-                CC.min_world(valid_worlds) > CC.min_world(ir.valid_worlds)
-                # this is the potentially unsound bit, because we
-                # resolve a binding that was otherwise thought to be
-                # unbound during type inference.
-                if isdefined(arg.mod, arg.name)
-                    arg = getglobal(arg.mod, arg.name)
-                end
-            end
-            if args === nothing
-                args = ex.args[1:(i - 1)]
-            end
-        end
-        args === nothing && continue
-        push!(args, arg)
-    end
-    args === nothing && return ex
-    resolved = Expr(ex.head)
-    resolved.args = args
-    return resolved
-end
 
 """
     intrinsic_to_function(inst)

--- a/src/interpreter/ir_utils.jl
+++ b/src/interpreter/ir_utils.jl
@@ -305,6 +305,11 @@ end
     defined, `g` was not available yet. If we restrict the IR to a world where `g` is
     available then `g` can be inlined.
 
+    Pinning to a single world is also a precondition for `normalise!`: it lets
+    `CC.verify_ir`'s partitioned-binding const check accept the IR's GlobalRefs without
+    rewriting them. This is why every rule-build entry point calls `set_valid_world!`
+    immediately after `lookup_ir`, before `normalise!`.
+
     Will error if `world` is not in the existing `valid_worlds` of `ir`.
     """
     function set_valid_world!(ir::IRCode, world::UInt)

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1293,8 +1293,7 @@ function generate_ir(
     # Grab code associated to the primal.
     ir, _ = lookup_ir(interp, sig_or_mi)
     @static if VERSION > v"1.12-"
-        # Pins valid_worlds to a single world so verify_ir's GlobalRef const-binding
-        # check passes for all currently-defined bindings without patching the IR.
+        # Pin to one world so verify_ir's GlobalRef check passes; see `set_valid_world!`.
         ir = set_valid_world!(ir, interp.world)
     end
     Treturn = compute_ir_rettype(ir)

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1293,6 +1293,8 @@ function generate_ir(
     # Grab code associated to the primal.
     ir, _ = lookup_ir(interp, sig_or_mi)
     @static if VERSION > v"1.12-"
+        # Pins valid_worlds to a single world so verify_ir's GlobalRef const-binding
+        # check passes for all currently-defined bindings without patching the IR.
         ir = set_valid_world!(ir, interp.world)
     end
     Treturn = compute_ir_rettype(ir)

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -435,7 +435,7 @@ rule_type_nonreturning(e::Exception) = throw(e)
 
     @testset "integration testing for invalid global ref errors" begin
         VERSION < v"1.12-" && @test_throws(
-            Mooncake.Mooncake.MooncakeRuleCompilationError,
+            Mooncake.MooncakeRuleCompilationError,
             Mooncake.build_rrule(
                 Tuple{typeof(Mooncake.TestResources.non_const_global_ref),Float64}
             )

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -434,12 +434,12 @@ rule_type_nonreturning(e::Exception) = throw(e)
     end
 
     @testset "integration testing for invalid global ref errors" begin
-        VERSION < v"1.12-" && @test_throws(
-            Mooncake.MooncakeRuleCompilationError,
-            Mooncake.build_rrule(
-                Tuple{typeof(Mooncake.TestResources.non_const_global_ref),Float64}
-            )
-        )
+        sig = Tuple{typeof(Mooncake.TestResources.non_const_global_ref),Float64}
+        if VERSION < v"1.12-"
+            @test_throws Mooncake.MooncakeRuleCompilationError Mooncake.build_rrule(sig)
+        else
+            @test Mooncake.build_rrule(sig) isa Mooncake.DerivedRule
+        end
     end
 
     # Tests designed to prevent accidentally re-introducing issues which we have fixed.


### PR DESCRIPTION
**closes part 5 of #847** 

A constant binding is a name tied to a value that is expected never to change (eg: function names like `sin` or a package-defined constant). Julia tracks a global world age that increments every time a new function or constant is defined. Every piece of compiled code carries a `valid_worlds` range which is the span of world ages for which that compiled code is considered correct. When Mooncake calls `lookup_ir` to extract the compiled code for a function `f`, it gets back a copy of that code stamped with a wide range like `[w_compile, ∞)`.

Before Julia `v1.12`, constants could never be redefined, so this wide stamp was always safe. Julia `v1.12` introduced partitioned bindings -> constants can now be redefined at a new world age. This made Julia's internal `verify_ir` checker stricter: it now scans whether every name referenced inside the code was actually a stable constant across the entire claimed `valid_worlds` range. A name defined at world `80` inside code stamped `[50, ∞)` fails this check because it didn't exist at worlds `50–79`.

**Details about the PR fix :**
  
PR #714 introduced `resolve_unbound_globalrefs` as a workaround. Before `verify_ir` ran, it scanned the code and replaced any name that would fail the check with the actual value at that moment (baking the value directly into the code so `verify_ir` saw a concrete value instead of a name reference). It was already marked `# XXX: this is probably unsound` because if the name was later rebound to a new value, the compiled rule would silently keep using the old baked-in value and produce wrong gradients.
  
The same PR also introduced `set_valid_world!(ir, interp.world)`, called at every entry point into Mooncake's build rule pipeline, always before `normalise!` is called. This narrows the stamp from `[w_compile, ∞)` to the single point `[w_now, w_now]` (the world age the Mooncake's AD compiler sees during rule build time). 

After this narrowing, `verify_ir` only checks if the const binding names are a stable constant in that single world age. Now if you notice, by the time `resolve_unbound_globalrefs` ran, `verify_ir` already passed cleanly without any patching. The function `resolve_unbound_globalrefs` was redundant and Ive removed it. Now the behaviour is the same as before: if `f` or anything it depends on changes after the rule is built, the cached rule will silently use the old compiled version. This is expected as well because `build_rrule` is an explicit compilation step and the user is responsible for rebuilding the rule if `f` changes.
  

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1180 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1180/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.62 │        1.62 │   0.722 │        4.01 │   7.01 │
│             _sum_1000 │   1.1 μs │     5.94 │        1.02 │  4610.0 │        42.7 │   1.06 │
│          sum_sin_1000 │  7.42 μs │     2.61 │        1.11 │    1.64 │        11.3 │   1.72 │
│         _sum_sin_1000 │  4.58 μs │     3.93 │        2.68 │   396.0 │        19.6 │   3.11 │
│              kron_sum │ 195.0 μs │     13.0 │        3.29 │    13.3 │       491.0 │   22.7 │
│         kron_view_sum │ 261.0 μs │     12.8 │        5.33 │    28.9 │       455.0 │   13.8 │
│ naive_map_sin_cos_exp │  2.22 μs │     2.83 │        1.54 │ missing │        8.51 │   2.17 │
│       map_sin_cos_exp │  2.22 μs │     3.22 │        1.63 │    1.53 │        7.22 │   2.64 │
│ broadcast_sin_cos_exp │  2.31 μs │     2.93 │        1.55 │    4.64 │        1.39 │   2.09 │
│            simple_mlp │ 344.0 μs │     5.03 │        2.93 │    1.98 │        9.43 │   3.21 │
│                gp_lml │ 166.0 μs │     12.0 │        2.61 │    4.79 │     missing │   5.44 │
│    large_single_block │ 451.0 ns │     6.23 │        2.04 │  4170.0 │        41.3 │   2.18 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->