### PR TITLE
bump compat for LogExpFunctions to 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.29"
+version = "0.5.30"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -74,7 +74,7 @@ GPUArraysCore = "0.1, 0.2"
 Graphs = "1"
 JET = "0.9, 0.10, 0.11"
 LinearAlgebra = "1"
-LogExpFunctions = "0.3"
+LogExpFunctions = "0.3, 1"
 Logging = "1"
 LuxLib = "1.11"
 MLDataDevices = "1.10.0"


### PR DESCRIPTION
combine https://github.com/chalk-lab/Mooncake.jl/pull/1182 and https://github.com/chalk-lab/Mooncake.jl/pull/1181

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1185 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1185/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 161.0 ns │     1.74 │         1.8 │   0.745 │        3.61 │   6.97 │
│             _sum_1000 │ 982.0 ns │     6.73 │        1.03 │  3830.0 │        40.2 │   1.05 │
│          sum_sin_1000 │  7.09 μs │     3.29 │        1.35 │     1.5 │        11.3 │   1.74 │
│         _sum_sin_1000 │  5.91 μs │     3.56 │         1.9 │   270.0 │        13.5 │    2.2 │
│              kron_sum │ 217.0 μs │     12.7 │        3.25 │    20.1 │       361.0 │   19.4 │
│         kron_view_sum │ 320.0 μs │     10.1 │        4.86 │    22.9 │       321.0 │   11.4 │
│ naive_map_sin_cos_exp │  2.33 μs │     3.07 │        1.53 │ missing │        7.58 │   2.15 │
│       map_sin_cos_exp │  2.24 μs │      3.6 │        1.66 │    1.59 │        6.88 │   2.77 │
│ broadcast_sin_cos_exp │  2.33 μs │     3.22 │        1.65 │    3.91 │        1.46 │   2.12 │
│            simple_mlp │ 367.0 μs │     4.79 │        2.59 │     1.9 │        9.02 │   2.82 │
│                gp_lml │ 172.0 μs │     11.3 │        2.59 │    4.84 │     missing │   5.07 │
│    large_single_block │ 421.0 ns │     5.54 │        1.95 │  4920.0 │        32.7 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->