### PR TITLE
Bump compat for LogExpFunctions to 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.29"
+version = "0.5.30"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -74,7 +74,7 @@ GPUArraysCore = "0.1, 0.2"
 Graphs = "1"
 JET = "0.9, 0.10, 0.11"
 LinearAlgebra = "1"
-LogExpFunctions = "0.3"
+LogExpFunctions = "0.3, 1"
 Logging = "1"
 LuxLib = "1.11"
 MLDataDevices = "1.10.0"

--- a/test/integration_testing/logexpfunctions/logexpfunctions.jl
+++ b/test/integration_testing/logexpfunctions/logexpfunctions.jl
@@ -19,12 +19,8 @@ sr(n::Int) = StableRNG(n)
                 (:allocs, true, logistic, P(0.5)),
                 (:allocs, true, logistic, P(1000.0)),
                 (:allocs, false, logit, P(0.3)),
-                # 4x < 1 selects logit's `-log(inv(x) - 1)` branch (logit rewritten in
-                # LogExpFunctions v1); the case above covers the `2*atanh(2x - 1)` branch
                 (:allocs, false, logit, P(0.1)),
                 (:allocs, false, logcosh, P(1.5)),
-                # small |x| (< 0.7373) hits the `logcosh` polynomial kernel added in
-                # LogExpFunctions v1, and checks it against Mooncake's NDual `logcosh`
                 (:allocs, false, logcosh, P(0.3)),
                 (:allocs, false, logabssinh, P(0.3)),
                 (:allocs, false, log1psq, P(0.3)),
@@ -33,8 +29,6 @@ sr(n::Int) = StableRNG(n)
                 (:allocs, false, log2mexp, P(0.1)),
                 (:allocs, false, logexpm1, P(0.1)),
                 (:allocs, false, log1pmx, -P(0.95)),
-                # -0.425 < x < 0.4 hits the `log1pmx` polynomial kernel; `_log1pmx_ker`
-                # was rewritten in LogExpFunctions v1 and gained a Float32 path
                 (:allocs, false, log1pmx, P(0.1)),
                 (:allocs, false, logmxp1, P(0.02)),
                 (:allocs, true, logaddexp, -P(0.5), P(0.4)),
@@ -84,9 +78,6 @@ sr(n::Int) = StableRNG(n)
                 (:allocs, false, log1mlogistic, -P(0.9)),
                 (:allocs, false, logit1mexp, -P(0.6)),
             ]
-            # `logabstanh` is new in LogExpFunctions v1; test it only when available, since
-            # the [compat] entry still permits 0.3, which does not define this function.
-            # 8|x| < 3 selects the `log(tanh(|x|))` branch, otherwise the `log1p` branch.
             @static if isdefined(LogExpFunctions, :logabstanh)
                 push!(cases, (:allocs, false, LogExpFunctions.logabstanh, P(0.3)))
                 push!(cases, (:allocs, false, LogExpFunctions.logabstanh, P(1.5)))

--- a/test/integration_testing/logexpfunctions/logexpfunctions.jl
+++ b/test/integration_testing/logexpfunctions/logexpfunctions.jl
@@ -10,7 +10,7 @@ sr(n::Int) = StableRNG(n)
 @testset "logexpfunctions" begin
     @testset for (perf_flag, is_primitive, f, x...) in vcat(
         map([Float64, Float32]) do P
-            return Any[
+            cases = Any[
                 (:allocs, false, xlogx, P(1.1)),
                 (:allocs, false, xlogy, P(0.3), P(1.2)),
                 (:allocs, false, xlog1py, P(0.3), -P(0.5)),
@@ -19,7 +19,13 @@ sr(n::Int) = StableRNG(n)
                 (:allocs, true, logistic, P(0.5)),
                 (:allocs, true, logistic, P(1000.0)),
                 (:allocs, false, logit, P(0.3)),
+                # 4x < 1 selects logit's `-log(inv(x) - 1)` branch (logit rewritten in
+                # LogExpFunctions v1); the case above covers the `2*atanh(2x - 1)` branch
+                (:allocs, false, logit, P(0.1)),
                 (:allocs, false, logcosh, P(1.5)),
+                # small |x| (< 0.7373) hits the `logcosh` polynomial kernel added in
+                # LogExpFunctions v1, and checks it against Mooncake's NDual `logcosh`
+                (:allocs, false, logcosh, P(0.3)),
                 (:allocs, false, logabssinh, P(0.3)),
                 (:allocs, false, log1psq, P(0.3)),
                 (:allocs, false, log1pexp, P(0.1)),
@@ -27,6 +33,9 @@ sr(n::Int) = StableRNG(n)
                 (:allocs, false, log2mexp, P(0.1)),
                 (:allocs, false, logexpm1, P(0.1)),
                 (:allocs, false, log1pmx, -P(0.95)),
+                # -0.425 < x < 0.4 hits the `log1pmx` polynomial kernel; `_log1pmx_ker`
+                # was rewritten in LogExpFunctions v1 and gained a Float32 path
+                (:allocs, false, log1pmx, P(0.1)),
                 (:allocs, false, logmxp1, P(0.02)),
                 (:allocs, true, logaddexp, -P(0.5), P(0.4)),
                 # edge case with two equal inputs: see #881 for discussion
@@ -75,6 +84,14 @@ sr(n::Int) = StableRNG(n)
                 (:allocs, false, log1mlogistic, -P(0.9)),
                 (:allocs, false, logit1mexp, -P(0.6)),
             ]
+            # `logabstanh` is new in LogExpFunctions v1; test it only when available, since
+            # the [compat] entry still permits 0.3, which does not define this function.
+            # 8|x| < 3 selects the `log(tanh(|x|))` branch, otherwise the `log1p` branch.
+            @static if isdefined(LogExpFunctions, :logabstanh)
+                push!(cases, (:allocs, false, LogExpFunctions.logabstanh, P(0.3)))
+                push!(cases, (:allocs, false, LogExpFunctions.logabstanh, P(1.5)))
+            end
+            return cases
         end...,
     )
         test_rule(sr(123456), f, x...; perf_flag, is_primitive)


### PR DESCRIPTION
combine https://github.com/chalk-lab/Mooncake.jl/pull/1182 and https://github.com/chalk-lab/Mooncake.jl/pull/1181 (avoid branch name prefix with `compathelper` to run CI properly, ref https://github.com/julia-actions/julia-runtest/blob/main/kwargs.jl)

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1186 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1186/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.56 │        1.84 │   0.667 │        3.17 │   6.23 │
│             _sum_1000 │ 972.0 ns │     6.77 │        1.01 │  4630.0 │        42.4 │   1.06 │
│          sum_sin_1000 │  7.03 μs │     3.44 │        1.32 │    1.52 │        11.3 │   1.78 │
│         _sum_sin_1000 │  6.15 μs │     3.46 │        1.84 │   245.0 │        12.9 │   2.13 │
│              kron_sum │ 221.0 μs │     13.2 │        3.43 │    9.05 │       320.0 │   19.9 │
│         kron_view_sum │ 306.0 μs │     10.9 │        5.09 │    24.0 │       295.0 │   11.9 │
│ naive_map_sin_cos_exp │  2.31 μs │      3.1 │        1.53 │ missing │        7.75 │   2.16 │
│       map_sin_cos_exp │  2.26 μs │     3.64 │        1.63 │    1.65 │        6.75 │   2.72 │
│ broadcast_sin_cos_exp │  2.38 μs │     3.14 │        1.55 │    3.95 │        1.45 │    2.1 │
│            simple_mlp │ 404.0 μs │     4.68 │        2.62 │    1.84 │        8.31 │   2.58 │
│                gp_lml │ 178.0 μs │     11.0 │        2.51 │    6.62 │     missing │   5.33 │
│    large_single_block │ 421.0 ns │     5.28 │         1.9 │  4880.0 │        32.1 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->