### PR TITLE
Fix missing space in error message

### DIFF
--- a/src/rules/foreigncall.jl
+++ b/src/rules/foreigncall.jl
@@ -24,7 +24,7 @@ function throw_missing_foreigncall_rule_error(rule_name::Symbol, args...)
             "$(typeof(map(primal, args))). " *
             "This problem has most likely arisen because there is a ccall somewhere in the " *
             "function you are trying to differentiate, for which an $rule_name has not been " *
-            "explicitly written." *
+            "explicitly written. " *
             "You have three options: write an $rule_name for this foreigncall, write an $rule_name " *
             "for a Julia function that calls this foreigncall, or re-write your code to " *
             "avoid this foreigncall entirely. " *


### PR DESCRIPTION
Stupid small nit but this currently renders as 

```julia
This
  │ problem has most likely arisen because there is a ccall somewhere in the
  │ function you are trying to differentiate, for which an rrule!! has not been
  │ explicitly written.You have three options:
```

There should be a space before "You".

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1187 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1187/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.56 │        1.72 │   0.722 │        3.56 │   7.01 │
│             _sum_1000 │   1.1 μs │     5.92 │        1.01 │  4250.0 │        41.4 │   1.05 │
│          sum_sin_1000 │  7.43 μs │     2.55 │         1.1 │    1.65 │        10.8 │   1.72 │
│         _sum_sin_1000 │  4.73 μs │     9.93 │        2.59 │   371.0 │        17.4 │    3.0 │
│              kron_sum │ 191.0 μs │     13.5 │        3.34 │    7.57 │       525.0 │   20.8 │
│         kron_view_sum │ 262.0 μs │     12.9 │        5.33 │    29.1 │       486.0 │   14.0 │
│ naive_map_sin_cos_exp │  2.17 μs │     2.96 │        1.52 │ missing │        8.63 │   2.19 │
│       map_sin_cos_exp │  2.21 μs │     3.27 │        1.58 │    1.58 │        7.16 │   2.68 │
│ broadcast_sin_cos_exp │  2.23 μs │     3.05 │        1.57 │    4.46 │        1.46 │   2.17 │
│            simple_mlp │ 345.0 μs │     5.32 │        2.93 │    2.02 │        10.3 │   3.19 │
│                gp_lml │ 165.0 μs │     12.1 │        2.59 │    5.15 │     missing │   5.67 │
│    large_single_block │ 471.0 ns │     6.23 │        1.98 │  4330.0 │        31.6 │   2.08 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->