### PR TITLE
Mark time() as zero derivative

### DIFF
--- a/src/rules/foreigncall.jl
+++ b/src/rules/foreigncall.jl
@@ -110,6 +110,7 @@ function rrule!!(f::CoDual{typeof(Base.unsafe_pointer_to_objref)}, x::CoDual{<:P
     return y, NoPullback(f, x)
 end
 
+@zero_derivative MinimalCtx Tuple{typeof(time)}
 @zero_derivative MinimalCtx Tuple{typeof(Threads.threadid)}
 @zero_derivative MinimalCtx Tuple{typeof(typeintersect),Any,Any}
 


### PR DESCRIPTION
<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1188 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1188/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 191.0 ns │     1.47 │        1.52 │   0.628 │        2.99 │   5.87 │
│             _sum_1000 │ 972.0 ns │     6.74 │        1.02 │  2640.0 │        52.0 │   1.06 │
│          sum_sin_1000 │  7.07 μs │     3.47 │        1.35 │     1.5 │        12.5 │    1.8 │
│         _sum_sin_1000 │  6.09 μs │     3.47 │        1.86 │   237.0 │        14.9 │   2.14 │
│              kron_sum │ 209.0 μs │     12.6 │        3.06 │    16.3 │       337.0 │   19.7 │
│         kron_view_sum │ 295.0 μs │     10.8 │        5.03 │    24.5 │       301.0 │   12.2 │
│ naive_map_sin_cos_exp │  2.41 μs │     2.91 │        1.47 │ missing │        7.72 │   2.08 │
│       map_sin_cos_exp │  2.33 μs │      3.6 │        1.66 │    1.49 │        6.61 │   2.66 │
│ broadcast_sin_cos_exp │  2.35 μs │     3.23 │        1.54 │    4.23 │        1.44 │   2.09 │
│            simple_mlp │ 368.0 μs │     4.85 │         2.6 │    1.97 │        8.66 │   2.71 │
│                gp_lml │ 394.0 μs │     5.66 │        1.71 │    2.79 │     missing │   2.95 │
│    large_single_block │ 421.0 ns │     5.83 │        2.05 │  4740.0 │        31.7 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->