### PR TITLE
`idDict` over `Dict` in `TestUtils.has_equal_data_internal`

### DIFF
--- a/docs/src/developer_documentation/custom_tangent_type.md
+++ b/docs/src/developer_documentation/custom_tangent_type.md
@@ -749,8 +749,8 @@ function Mooncake.TestUtils.populate_address_map_internal(m::Mooncake.TestUtils.
     return m
 end
 
-function Mooncake.TestUtils.has_equal_data_internal(x::A{T}, y::A{T}, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}) where {T}
-    id_pair = (objectid(x), objectid(y))
+function Mooncake.TestUtils.has_equal_data_internal(x::A{T}, y::A{T}, equal_undefs::Bool, d::IdDict{Any,Bool}) where {T}
+    id_pair = (x, y)
     haskey(d, id_pair) && return d[id_pair]
     d[id_pair] = true
     eq = Mooncake.TestUtils.has_equal_data_internal(x.x, y.x, equal_undefs, d)
@@ -763,8 +763,8 @@ function Mooncake.TestUtils.has_equal_data_internal(x::A{T}, y::A{T}, equal_unde
     end
 end
 
-function Mooncake.TestUtils.has_equal_data_internal(t::TangentForA{Tx}, s::TangentForA{Tx}, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}) where {Tx}
-    id_pair = (objectid(t), objectid(s))
+function Mooncake.TestUtils.has_equal_data_internal(t::TangentForA{Tx}, s::TangentForA{Tx}, equal_undefs::Bool, d::IdDict{Any,Bool}) where {Tx}
+    id_pair = (t, s)
     haskey(d, id_pair) && return d[id_pair]
     d[id_pair] = true
     eq = Mooncake.TestUtils.has_equal_data_internal(t.x, s.x, equal_undefs, d)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -464,13 +464,13 @@ function randn_tangent_internal(rng::AbstractRNG, x::CuMaybeComplexArray, dict::
     return t
 end
 function TestUtils.has_equal_data_internal(
-    x::P, y::P, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::P, y::P, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {P<:CuMaybeComplexArray}
     # allow nan comparisons to return true, real() to cover complex case
     return isapprox(x, y; atol=(√eps(real(eltype(P)))), nans=true)
 end
 function TestUtils.has_equal_data_internal(
-    x::P, y::P, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::P, y::P, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {P<:CuArray{<:Union{Integer,Bool}}}
     # For integer/bool CuArrays, compare by content by downloading to CPU.
     size(x) != size(y) && return false

--- a/ext/MooncakeDynamicExpressionsExt.jl
+++ b/ext/MooncakeDynamicExpressionsExt.jl
@@ -814,19 +814,13 @@ function Mooncake.TestUtils.has_equal_data_internal(
 end
 
 function Mooncake.TestUtils.has_equal_data_internal(
-    t::TangentNode{Tv,D},
-    s::TangentNode{Tv,D},
-    equndef::Bool,
-    d::IdDict{Any,Bool},
+    t::TangentNode{Tv,D}, s::TangentNode{Tv,D}, equndef::Bool, d::IdDict{Any,Bool}
 ) where {Tv,D}
     idp = (t, s)
     return get!(() -> _has_equal_data_internal_helper(t, s, equndef, d), d, idp)
 end
 function _has_equal_data_internal_helper(
-    t::TangentNode{Tv,D},
-    s::TangentNode{Tv,D},
-    equndef::Bool,
-    d::IdDict{Any,Bool},
+    t::TangentNode{Tv,D}, s::TangentNode{Tv,D}, equndef::Bool, d::IdDict{Any,Bool}
 ) where {Tv,D}
     deg = t.degree
     return deg == s.degree && if t.degree == 0

--- a/ext/MooncakeDynamicExpressionsExt.jl
+++ b/ext/MooncakeDynamicExpressionsExt.jl
@@ -806,9 +806,9 @@ function Mooncake.TestUtils.populate_address_map_internal(
 end
 
 function Mooncake.TestUtils.has_equal_data_internal(
-    x::N, y::N, equndef::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::N, y::N, equndef::Bool, d::IdDict{Any,Bool}
 ) where {T,N<:AbstractExpressionNode{T}}
-    idp = (objectid(x), objectid(y))
+    idp = (x, y)
     # Just use regular `AbstractExpressionNode` Base.:(==)
     return get!(() -> x == y, d, idp)
 end
@@ -817,16 +817,16 @@ function Mooncake.TestUtils.has_equal_data_internal(
     t::TangentNode{Tv,D},
     s::TangentNode{Tv,D},
     equndef::Bool,
-    d::Dict{Tuple{UInt,UInt},Bool},
+    d::IdDict{Any,Bool},
 ) where {Tv,D}
-    idp = (objectid(t), objectid(s))
+    idp = (t, s)
     return get!(() -> _has_equal_data_internal_helper(t, s, equndef, d), d, idp)
 end
 function _has_equal_data_internal_helper(
     t::TangentNode{Tv,D},
     s::TangentNode{Tv,D},
     equndef::Bool,
-    d::Dict{Tuple{UInt,UInt},Bool},
+    d::IdDict{Any,Bool},
 ) where {Tv,D}
     deg = t.degree
     return deg == s.degree && if t.degree == 0

--- a/ext/MooncakeFunctionWrappersExt.jl
+++ b/ext/MooncakeFunctionWrappersExt.jl
@@ -91,12 +91,12 @@ end
 
 import .TestUtils: has_equal_data_internal
 function has_equal_data_internal(
-    p::P, q::P, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    p::P, q::P, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {P<:FunctionWrapper}
     return has_equal_data_internal(p.obj, q.obj, equal_undefs, d)
 end
 function has_equal_data_internal(
-    t::T, s::T, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    t::T, s::T, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {T<:FunctionWrapperTangent}
     return has_equal_data_internal(t.dobj_ref[], s.dobj_ref[], equal_undefs, d)
 end

--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -100,7 +100,7 @@ function TestUtils.populate_address_map_internal(
     return m
 end
 function TestUtils.has_equal_data_internal(
-    p::P, q::P, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    p::P, q::P, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {P<:IdDict}
     ks = union(keys(p), keys(q))
     ks != keys(p) && return false

--- a/src/rules/memory.jl
+++ b/src/rules/memory.jl
@@ -46,10 +46,10 @@ function randn_tangent_internal(rng::AbstractRNG, x::Memory, dict::MaybeCache)
 end
 
 function TestUtils.has_equal_data_internal(
-    x::Memory{P}, y::Memory{P}, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::Memory{P}, y::Memory{P}, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {P}
     length(x) == length(y) || return false
-    id_pair = (objectid(x), objectid(y))
+    id_pair = (x, y)
     haskey(d, id_pair) && return d[id_pair]
 
     d[id_pair] = true
@@ -329,7 +329,7 @@ function randn_tangent_internal(rng::AbstractRNG, x::MemoryRef, dict::MaybeCache
 end
 
 function TestUtils.has_equal_data_internal(
-    x::MemoryRef{P}, y::MemoryRef{P}, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::MemoryRef{P}, y::MemoryRef{P}, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {P}
     equal_refs = Core.memoryrefoffset(x) == Core.memoryrefoffset(y)
     equal_data = TestUtils.has_equal_data_internal(x.mem, y.mem, equal_undefs, d)

--- a/src/rules/misty_closures.jl
+++ b/src/rules/misty_closures.jl
@@ -104,10 +104,7 @@ function populate_address_map_internal(
 end
 
 function has_equal_data_internal(
-    x::MistyClosureTangent,
-    y::MistyClosureTangent,
-    equal_undefs::Bool,
-    d::IdDict{Any,Bool},
+    x::MistyClosureTangent, y::MistyClosureTangent, equal_undefs::Bool, d::IdDict{Any,Bool}
 )
     # Only compare captures_tangent. The dual_callable field is a forward-mode rule
     # built on-demand by _dual_mc, which creates a new interpreter each time. Different

--- a/src/rules/misty_closures.jl
+++ b/src/rules/misty_closures.jl
@@ -107,7 +107,7 @@ function has_equal_data_internal(
     x::MistyClosureTangent,
     y::MistyClosureTangent,
     equal_undefs::Bool,
-    d::Dict{Tuple{UInt,UInt},Bool},
+    d::IdDict{Any,Bool},
 )
     # Only compare captures_tangent. The dual_callable field is a forward-mode rule
     # built on-demand by _dual_mc, which creates a new interpreter each time. Different

--- a/src/rules/twice_precision.jl
+++ b/src/rules/twice_precision.jl
@@ -22,7 +22,7 @@ end
 
 import .TestUtils: has_equal_data_internal
 function has_equal_data_internal(
-    p::P, q::P, ::Bool, ::Dict{Tuple{UInt,UInt},Bool}
+    p::P, q::P, ::Bool, ::IdDict{Any,Bool}
 ) where {P<:TWP}
     return Float64(p) ≈ Float64(q)
 end

--- a/src/rules/twice_precision.jl
+++ b/src/rules/twice_precision.jl
@@ -21,9 +21,7 @@ function randn_tangent_internal(rng::AbstractRNG, p::TWP{F}, ::MaybeCache) where
 end
 
 import .TestUtils: has_equal_data_internal
-function has_equal_data_internal(
-    p::P, q::P, ::Bool, ::IdDict{Any,Bool}
-) where {P<:TWP}
+function has_equal_data_internal(p::P, q::P, ::Bool, ::IdDict{Any,Bool}) where {P<:TWP}
     return Float64(p) ≈ Float64(q)
 end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -201,42 +201,42 @@ that takes an additional `visited` dictionary to track visited objects and avoid
 recursion in cases of circular references.
 """
 function has_equal_data(x, y; equal_undefs=true)
-    return has_equal_data_internal(x, y, equal_undefs, Dict{Tuple{UInt,UInt},Bool}())
+    return has_equal_data_internal(x, y, equal_undefs, IdDict{Any,Bool}())
 end
 
 function has_equal_data_internal(
-    x::Type, y::Type, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::Type, y::Type, equal_undefs::Bool, d::IdDict{Any,Bool}
 )
     return x == y
 end
 function has_equal_data_internal(
-    x::T, y::T, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::T, y::T, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {T<:String}
     return x == y
 end
 function has_equal_data_internal(
-    x::Core.TypeName, y::Core.TypeName, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::Core.TypeName, y::Core.TypeName, equal_undefs::Bool, d::IdDict{Any,Bool}
 )
     return x == y
 end
 function has_equal_data_internal(
-    x::P, y::P, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::P, y::P, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {P<:Base.IEEEFloat}
     # Pass an atol such that we can compare approximately against 0 values.
     return isapprox(x, y; atol=(√eps(P)), nans=true)
 end
 function has_equal_data_internal(
-    x::Module, y::Module, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::Module, y::Module, equal_undefs::Bool, d::IdDict{Any,Bool}
 )
     return x == y
 end
 function has_equal_data_internal(
-    x::GlobalRef, y::GlobalRef; equal_undefs=true, d::Dict{Tuple{UInt,UInt},Bool}
+    x::GlobalRef, y::GlobalRef; equal_undefs=true, d::IdDict{Any,Bool}
 )
     return x.mod == y.mod && x.name == y.name
 end
 function has_equal_data_internal(
-    x::T, y::T, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::T, y::T, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {T<:Array}
     size(x) != size(y) && return false
 
@@ -252,7 +252,7 @@ function has_equal_data_internal(
     # - We consider "circular references to itself" as equal data for this subcomponent.
     # - However, other parts of x and y may still differ, so we continue checking.
 
-    id_pair = (objectid(x), objectid(y))
+    id_pair = (x, y)
     if haskey(d, id_pair)
         return d[id_pair]
     end
@@ -270,25 +270,25 @@ function has_equal_data_internal(
     return all(equality)
 end
 function has_equal_data_internal(
-    x::T, y::T, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::T, y::T, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {T<:Core.SimpleVector}
     return all(map((a, b) -> has_equal_data_internal(a, b, equal_undefs, d), x, y))
 end
 
 for T in (:(Core.Method), :(Core.CodeInstance), :(Core.MethodInstance))
     @eval function has_equal_data_internal(
-        x::$T, y::$T, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+        x::$T, y::$T, equal_undefs::Bool, d::IdDict{Any,Bool}
     )
         return x == y
     end
 end
 
 function has_equal_data_internal(
-    x::T, y::T, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::T, y::T, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {T}
     isprimitivetype(T) && return isequal(x, y)
 
-    id_pair = (objectid(x), objectid(y))
+    id_pair = (x, y)
     if haskey(d, id_pair)
         return d[id_pair]
     end
@@ -325,12 +325,12 @@ function has_equal_data_internal(
     end
 end
 function has_equal_data_internal(
-    x::T, y::P, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::T, y::P, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {T,P}
     return false
 end
 function has_equal_data_internal(
-    x::T, y::T, equal_undefs::Bool, d::Dict{Tuple{UInt,UInt},Bool}
+    x::T, y::T, equal_undefs::Bool, d::IdDict{Any,Bool}
 ) where {T<:Dict}
     f(x, y) = has_equal_data_internal(x, y, equal_undefs, d)
     return length(x) == length(y) &&
@@ -1693,10 +1693,10 @@ function test_equality_comparison(x)
 
     # Check that the internal methods have been implemented.
     function _has_equal_data(x, y)
-        return has_equal_data_internal(x, y, true, Dict{Tuple{UInt,UInt},Bool}())
+        return has_equal_data_internal(x, y, true, IdDict{Any,Bool}())
     end
     function _has_equal_data_up_to_undefs(x, y)
-        return has_equal_data_internal(x, y, false, Dict{Tuple{UInt,UInt},Bool}())
+        return has_equal_data_internal(x, y, false, IdDict{Any,Bool}())
     end
 
     @test _has_equal_data(x, x) isa Bool

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -204,9 +204,7 @@ function has_equal_data(x, y; equal_undefs=true)
     return has_equal_data_internal(x, y, equal_undefs, IdDict{Any,Bool}())
 end
 
-function has_equal_data_internal(
-    x::Type, y::Type, equal_undefs::Bool, d::IdDict{Any,Bool}
-)
+function has_equal_data_internal(x::Type, y::Type, equal_undefs::Bool, d::IdDict{Any,Bool})
     return x == y
 end
 function has_equal_data_internal(

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -64,7 +64,7 @@
         # Test that has_equal_data works on Method and MethodInstance objects
         m = only(methods(sin, (Float64,)))
         @test has_equal_data(m, m)
-        mi = m.specializations[1]
+        mi = first(m.specializations)
         @test has_equal_data(mi, mi)
     end
     @testset "populate_address_map" begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -60,6 +60,12 @@
             (a=make_indirect_circular_reference_array(); a[1][1]=1.0; a),
             (b=make_indirect_circular_reference_array(); b[1][1]=2.0; b),
         )
+
+        # Test that has_equal_data works on Method and MethodInstance objects
+        m = only(methods(sin, (Float64,)))
+        @test has_equal_data(m, m)
+        mi = m.specializations[1]
+        @test has_equal_data(mi, mi)
     end
     @testset "populate_address_map" begin
         @testset "primitive types" begin


### PR DESCRIPTION
closes #864.

`has_equal_data_internal` maintains a visited-pair cache to break cycles (circular reference detection) during recursive comparison. The cache was keyed on `(objectid(x), objectid(y))` in a plain `Dict{Tuple{UInt,UInt},Bool}`. `objectid` is a hash (for immutable objects), not a unique identifier and two distinct objects can produce the same `UInt` hash (although very low probability):

```
 struct Wrapper
      x::Float64
      y::Float64
  end

  w1 = Wrapper(1.0, 2.0)
  w2 = Wrapper(3.0, 4.0)  # w1 !== w2

# Both are immutable isbits structs, so objectid is a hash of the raw bit values, not a memory address. 
# Two different bit patterns can produce the same UInt hash (pigeonhole: 2^128 possible inputs, only 2^64
# possible outputs): objectid(w1) == objectid(w2) is possible with both objects simultaneously live.
```

`IdDict` uses `objectid` as the hash but additionally checks === to confirm identity, so a hash collision between two  different objects is caught rather than producing a false cache hit. The PR only changes the visited-pair cache used by `TestUtils.has_equal_data_internal` for cycle detection:

1. `Dict{Tuple{UInt,UInt},Bool}`    ->   `IdDict{Any,Bool}`
2.  `key: (objectid(x), objectid(y))`  ->    `key: (x, y)`

This is applied consistently across all overloads in `src/test_utils.jl, src/rules/ (memory.jl, iddict.jl, misty_closures.jl, twice_precision.jl), and ext/ (MooncakeCUDAExt, MooncakeDynamicExpressionsExt, MooncakeFunctionWrappersExt)`.

Note: PR Also updates the custom_tangent_type.md documentation to reflect the new signature, and adds test coverage for the `TestUtils.has_equal_data_internal` overloads covering `Method` and `MethodInstance`.

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1189 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1189/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 190.0 ns │     1.58 │        1.58 │   0.684 │        3.43 │   6.64 │
│             _sum_1000 │   1.1 μs │     6.11 │        1.01 │  3950.0 │        39.3 │   1.06 │
│          sum_sin_1000 │  7.46 μs │     2.52 │        1.12 │    1.65 │        11.0 │   1.77 │
│         _sum_sin_1000 │  4.77 μs │     3.73 │        2.59 │   417.0 │        17.5 │   2.99 │
│              kron_sum │ 267.0 μs │     10.5 │        3.26 │    5.73 │       389.0 │   17.5 │
│         kron_view_sum │ 339.0 μs │     10.8 │        4.57 │    22.5 │       402.0 │   11.2 │
│ naive_map_sin_cos_exp │  2.36 μs │     2.88 │         1.5 │ missing │        8.02 │   2.04 │
│       map_sin_cos_exp │  2.36 μs │     3.35 │        1.67 │    1.42 │        7.18 │   2.46 │
│ broadcast_sin_cos_exp │  2.43 μs │     3.24 │        1.65 │    4.32 │        1.34 │   2.13 │
│            simple_mlp │ 379.0 μs │     4.67 │        2.81 │    2.13 │        9.28 │   2.91 │
│                gp_lml │ 161.0 μs │     12.7 │        2.68 │    5.01 │     missing │   6.27 │
│    large_single_block │ 471.0 ns │     7.53 │        1.98 │  4470.0 │        32.1 │   2.06 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->