### PR TITLE
Pin JuliaFormatter to 2.4 in the format test env

### DIFF
--- a/test/integration_testing/format/Project.toml
+++ b/test/integration_testing/format/Project.toml
@@ -3,5 +3,5 @@ JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-JuliaFormatter = "2"
+JuliaFormatter = "2 - 2.4"
 Test = "1"


### PR DESCRIPTION
JuliaFormatter 2.5 bumped JuliaSyntax, and the format CI is failing. For now, pin it to 2.4 to reduce noise.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1190 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1190/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 190.0 ns │     1.53 │        1.58 │   0.684 │        3.48 │   6.64 │
│             _sum_1000 │   1.1 μs │      6.1 │        1.02 │  2840.0 │        40.6 │   1.06 │
│          sum_sin_1000 │  7.44 μs │     2.49 │        1.12 │    1.64 │        10.9 │   1.71 │
│         _sum_sin_1000 │   4.6 μs │      3.8 │        2.65 │   403.0 │        17.6 │    3.1 │
│              kron_sum │ 206.0 μs │     13.3 │        3.23 │    10.9 │       498.0 │   14.7 │
│         kron_view_sum │ 267.0 μs │     13.1 │        5.29 │    28.9 │       507.0 │   14.1 │
│ naive_map_sin_cos_exp │  2.35 μs │     2.81 │        1.44 │ missing │        7.89 │   2.02 │
│       map_sin_cos_exp │  2.21 μs │     3.32 │        1.72 │    1.62 │        7.22 │   2.64 │
│ broadcast_sin_cos_exp │  2.37 μs │     2.88 │        1.56 │    4.39 │        1.36 │   2.03 │
│            simple_mlp │ 353.0 μs │      5.0 │        3.01 │    2.23 │        10.3 │   3.21 │
│                gp_lml │ 162.0 μs │     12.4 │        2.72 │    6.04 │     missing │   6.57 │
│    large_single_block │ 451.0 ns │     7.35 │        2.04 │  4360.0 │        33.0 │   2.16 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->