### PR TITLE
non const global mutation handling on v1.12

### DIFF
--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -192,6 +192,23 @@ function generate_dual_ir(
     end
     nargs = length(primal_ir.argtypes)
 
+    # On Julia 1.12+, global writes compile to setglobal! rather than a non-const
+    # GlobalRef in Expr arg position. verify_ir no longer catches this, so build_frule
+    # would silently succeed but crash at runtime with a missing frule!!. Detect it
+    # here to give a loud compile-time error.
+    @static if VERSION > v"1.12-"
+        for inst in stmt(primal_ir.stmts)
+            if Meta.isexpr(inst, :call) && inst.args[1] == GlobalRef(Base, :setglobal!)
+                unhandled_feature(
+                    "Differentiating functions which write to non-const global variables " *
+                    "is not supported by Mooncake.jl. The code being differentiated " *
+                    "contains a write to a non-const global variable. Consider refactoring " *
+                    "to avoid global writes, or providing a custom frule!!.",
+                )
+            end
+        end
+    end
+
     # Normalise the IR.
     isva, spnames = is_vararg_and_sparam_names(sig_or_mi)
     primal_ir = normalise!(primal_ir, spnames)

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -193,18 +193,19 @@ function generate_dual_ir(
     nargs = length(primal_ir.argtypes)
 
     # Check for unsupported features before normalise! runs.
-    # On Julia 1.12+, global writes compile to setglobal! rather than a non-const
-    # GlobalRef in Expr arg position. verify_ir no longer catches this, so build_frule
-    # would silently succeed but crash at runtime with a missing frule!!. Detect it
-    # here to give a loud compile-time error.
+    # Julia 1.12+ lowers non-const global writes (`global x = y`) to
+    # Base.setglobal! on 1.12 and Core.setglobal! on 1.13+.
+    # CC.verify_ir does not reject these calls because they are valid IR, so
+    # reject them here before rule construction reaches a missing frule!!.
     @static if VERSION > v"1.12-"
+        setglobal_calls = (GlobalRef(Base, :setglobal!), GlobalRef(Core, :setglobal!))
         for inst in stmt(primal_ir.stmts)
-            if Meta.isexpr(inst, :call) && inst.args[1] == GlobalRef(Base, :setglobal!)
+            if Meta.isexpr(inst, :call) && inst.args[1] in setglobal_calls
                 unhandled_feature(
-                    "Differentiating functions which write to non-const global variables " *
-                    "is not supported by Mooncake.jl. The code being differentiated " *
-                    "contains a write to a non-const global variable. Consider refactoring " *
-                    "to avoid global writes, or providing a custom frule!!.",
+                    "Mooncake.jl does not support differentiating code that assigns to " *
+                    "non-const global variables. Pass the state explicitly, return the " *
+                    "updated value, or provide a custom frule!!. See the Known Limitations " *
+                    "documentation for more context.",
                 )
             end
         end

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -192,6 +192,7 @@ function generate_dual_ir(
     end
     nargs = length(primal_ir.argtypes)
 
+    # Check for unsupported features before normalise! runs.
     # On Julia 1.12+, global writes compile to setglobal! rather than a non-const
     # GlobalRef in Expr arg position. verify_ir no longer catches this, so build_frule
     # would silently succeed but crash at runtime with a missing frule!!. Detect it

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1300,7 +1300,7 @@ function generate_ir(
     fwd_ret_type = forwards_ret_type(ir)
     rvs_ret_type = pullback_ret_type(ir)
 
-    # Check before normalise! to avoid a cryptic CC.verify_ir failure downstream.
+    # Check before normalise! to avoid cryptic failures downstream.
     for inst in stmt(ir.stmts)
         is_enter = Meta.isexpr(inst, :enter)
         @static if isdefined(Core, :EnterNode)
@@ -1315,6 +1315,20 @@ function generate_ir(
                 "conditional checks), or providing a custom rrule!! for the relevant " *
                 "function. See the known limitations documentation for more context.",
             )
+        end
+        # On Julia 1.12+, global writes compile to setglobal! rather than a non-const
+        # GlobalRef in Expr arg position. verify_ir no longer catches this, so build_rrule
+        # would silently succeed but crash at runtime with a missing frule!!. Detect it
+        # here to give a loud compile-time error.
+        @static if VERSION > v"1.12-"
+            if Meta.isexpr(inst, :call) && inst.args[1] == GlobalRef(Base, :setglobal!)
+                unhandled_feature(
+                    "Differentiating functions which write to non-const global variables " *
+                    "is not supported by Mooncake.jl. The code being differentiated " *
+                    "contains a write to a non-const global variable. Consider refactoring " *
+                    "to avoid global writes, or providing a custom rrule!!.",
+                )
+            end
         end
     end
 

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1300,7 +1300,7 @@ function generate_ir(
     fwd_ret_type = forwards_ret_type(ir)
     rvs_ret_type = pullback_ret_type(ir)
 
-    # Check before normalise! to avoid cryptic failures downstream.
+    # Check for unsupported features before normalise! runs.
     for inst in stmt(ir.stmts)
         is_enter = Meta.isexpr(inst, :enter)
         @static if isdefined(Core, :EnterNode)

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1301,6 +1301,7 @@ function generate_ir(
     rvs_ret_type = pullback_ret_type(ir)
 
     # Check for unsupported features before normalise! runs.
+    setglobal_calls = (GlobalRef(Base, :setglobal!), GlobalRef(Core, :setglobal!))
     for inst in stmt(ir.stmts)
         is_enter = Meta.isexpr(inst, :enter)
         @static if isdefined(Core, :EnterNode)
@@ -1316,17 +1317,17 @@ function generate_ir(
                 "function. See the known limitations documentation for more context.",
             )
         end
-        # On Julia 1.12+, global writes compile to setglobal! rather than a non-const
-        # GlobalRef in Expr arg position. verify_ir no longer catches this, so build_rrule
-        # would silently succeed but crash at runtime with a missing rrule!!. Detect it
-        # here to give a loud compile-time error.
+        # Julia 1.12+ lowers non-const global writes (`global x = y`) to
+        # Base.setglobal! on 1.12 and Core.setglobal! on 1.13+.
+        # CC.verify_ir does not reject these calls because they are valid IR, so
+        # reject them here before rule construction reaches a missing rrule!!.
         @static if VERSION > v"1.12-"
-            if Meta.isexpr(inst, :call) && inst.args[1] == GlobalRef(Base, :setglobal!)
+            if Meta.isexpr(inst, :call) && inst.args[1] in setglobal_calls
                 unhandled_feature(
-                    "Differentiating functions which write to non-const global variables " *
-                    "is not supported by Mooncake.jl. The code being differentiated " *
-                    "contains a write to a non-const global variable. Consider refactoring " *
-                    "to avoid global writes, or providing a custom rrule!!.",
+                    "Mooncake.jl does not support differentiating code that assigns to " *
+                    "non-const global variables. Pass the state explicitly, return the " *
+                    "updated value, or provide a custom rrule!!. See the Known Limitations" *
+                    "documentation for more context.",
                 )
             end
         end

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1318,7 +1318,7 @@ function generate_ir(
         end
         # On Julia 1.12+, global writes compile to setglobal! rather than a non-const
         # GlobalRef in Expr arg position. verify_ir no longer catches this, so build_rrule
-        # would silently succeed but crash at runtime with a missing frule!!. Detect it
+        # would silently succeed but crash at runtime with a missing rrule!!. Detect it
         # here to give a loud compile-time error.
         @static if VERSION > v"1.12-"
             if Meta.isexpr(inst, :call) && inst.args[1] == GlobalRef(Base, :setglobal!)

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -23,10 +23,12 @@ end
     end
 
     @testset "integration testing for invalid global ref errors" begin
-        @test_throws(
-            Mooncake.UnhandledLanguageFeatureException,
-            Mooncake.build_frule(Mooncake.TestResources.non_const_global_ref, 5.0)
-        )
+        @static if VERSION > v"1.12-"
+            @test_throws(
+                Mooncake.UnhandledLanguageFeatureException,
+                Mooncake.build_frule(Mooncake.TestResources.non_const_global_ref, 5.0)
+            )
+        end
     end
 
     # Try try-catch statements.

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -22,6 +22,13 @@ end
         )
     end
 
+    @testset "integration testing for invalid global ref errors" begin
+        @test_throws(
+            Mooncake.UnhandledLanguageFeatureException,
+            Mooncake.build_frule(Mooncake.TestResources.non_const_global_ref, 5.0)
+        )
+    end
+
     # Try try-catch statements.
     @testset "try-catch" begin
         rng = StableRNG(123)

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -434,12 +434,12 @@ rule_type_nonreturning(e::Exception) = throw(e)
     end
 
     @testset "integration testing for invalid global ref errors" begin
-        sig = Tuple{typeof(Mooncake.TestResources.non_const_global_ref),Float64}
-        if VERSION < v"1.12-"
-            @test_throws Mooncake.MooncakeRuleCompilationError Mooncake.build_rrule(sig)
-        else
-            @test Mooncake.build_rrule(sig) isa Mooncake.DerivedRule
-        end
+        @test_throws(
+            Mooncake.MooncakeRuleCompilationError,
+            Mooncake.build_rrule(
+                Tuple{typeof(Mooncake.TestResources.non_const_global_ref),Float64}
+            )
+        )
     end
 
     # Tests designed to prevent accidentally re-introducing issues which we have fixed.

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -434,12 +434,14 @@ rule_type_nonreturning(e::Exception) = throw(e)
     end
 
     @testset "integration testing for invalid global ref errors" begin
-        @test_throws(
-            Mooncake.MooncakeRuleCompilationError,
-            Mooncake.build_rrule(
-                Tuple{typeof(Mooncake.TestResources.non_const_global_ref),Float64}
+        @static if VERSION > v"1.12-"
+            @test_throws(
+                Mooncake.MooncakeRuleCompilationError,
+                Mooncake.build_rrule(
+                    Tuple{typeof(Mooncake.TestResources.non_const_global_ref),Float64}
+                )
             )
-        )
+        end
     end
 
     # Tests designed to prevent accidentally re-introducing issues which we have fixed.


### PR DESCRIPTION
Closes part 3 of #847 

On Julia `1.12`, writes to non-const global variables compile to `Base.setglobal!` rather than the `IR` representation used pre `1.12`. The old representation put a non-const `GlobalRef` in an `Expr` argument position, which `verify_ir` caught and rejected with a `MooncakeRuleCompilationError`. The new `Base.setglobal!` form passes `verify_ir`, so `build_rrule` silently succeeds but the rule crashes at runtime with `MethodError: no method matching frule!!(::Dual{typeof(setglobal!), ...})` because Mooncake has no rule for `Base.setglobal!`.

This PR restores the loud compile-time error by detecting `Base.setglobal!` (or `Core.setglobal!` in 1.13) in the pre-`normalise!` scan (alongside the existing `try/catch` detection) and calling `unhandled_feature`, which propagates as `MooncakeRuleCompilationError`. The test is updated to remove the `VERSION < v"1.12-"` guard that just flags the rule as a `DerivedRule`.

MWE for the issue (pre-fix behaviour on 1.12):
```
julia> using Mooncake

julia> function f(y::Float64)
           global x = y   # non-const global write
           return x
       end
f (generic function with 1 method)

julia> # On 1.12 before this PR: silently succeeds
       rule = Mooncake.build_rrule(Tuple{typeof(f), Float64})
Mooncake.DerivedRule{Tuple{typeof(f), Float64}, Tuple{Mooncake.CoDual{typeof(f), Mooncake.NoFData}, Mooncake.CoDual{Float64, Mooncake.NoFData}}, Mooncake.CoDual, Tuple{Any}, Tuple{Mooncake.NoRData, Float64}, false, Val{2}}(MistyClosure (::Mooncake.CoDual{typeof(f), Mooncake.NoFData}, ::Mooncake.CoDual{Float64, Mooncake.NoFData})->◌::Mooncake.CoDual, Base.RefValue{MistyClosures.MistyClosure{Core.OpaqueClosure{Tuple{Any}, Tuple{Mooncake.NoRData, Float64}}}}(MistyClosure (::Any)->◌::Tuple{Mooncake.NoRData, Float64}), Val{2}())

julia> rule(Mooncake.zero_fcodual(f), Mooncake.zero_fcodual(1.0))
ERROR: All built-in functions are primitives by default, as they do not have any Julia code to recurse into. This means that
│ they must all have methods of `rrule!!` written for them by hand. The built-in setglobal! has been called with
│ arguments with types (Module, Symbol, Float64), but there is no specialised method of `rrule!!` for this built-in and
│ these types. In order to fix this problem, you will either need to modify your code to avoid hitting this built-in
│ function, or implement a method of `rrule!!` which is specialised to this case. Either way, please consider commenting
│ on https://github.com/chalk-lab/Mooncake.jl/issues/208/ so that the issue can be fixed more widely.
│ For reproducibility, note that the full signature is:
│ Tuple{Mooncake.CoDual{typeof(setglobal!), Mooncake.NoFData}, Mooncake.CoDual{Module, Mooncake.NoFData},
│ Mooncake.CoDual{Symbol, Mooncake.NoFData}, Mooncake.CoDual{Float64, Mooncake.NoFData}}
└

Stacktrace:
  [1] rrule!!(::Mooncake.CoDual{…}, ::Mooncake.CoDual{…}, ::Mooncake.CoDual{…}, ::Mooncake.CoDual{…})
    @ Mooncake ~/issue847-view/src/rules/builtins.jl:20
  [2] setproperty!
    @ ./Base_compiler.jl:58 [inlined]
  [3] setindex!
    @ ./refvalue.jl:60 [inlined]
  [4] macro expansion
    @ ./none:-1 [inlined]
  [5] __assemble_lazy_zero_rdata
    @ ./none:0 [inlined]
  [6] f
    @ ./REPL[37]:2 [inlined]
  [7] (::Tuple{…})(_2::Mooncake.CoDual{…}, _3::Mooncake.CoDual{…})
    @ Base.Experimental ./<missing>:0
  [8] (::MistyClosures.MistyClosure{…})(::Mooncake.CoDual{…}, ::Mooncake.CoDual{…})
    @ MistyClosures ~/.julia/packages/MistyClosures/2vtLL/src/MistyClosures.jl:22
  [9] (::Mooncake.DerivedRule{…})(::Mooncake.CoDual{…}, ::Mooncake.CoDual{…})
    @ Mooncake ~/issue847-view/src/interpreter/reverse_mode.jl:990
 [10] top-level scope
    @ REPL[39]:1
Some type information was truncated. Use `show(err)` to see complete types.

julia> 
```

This PR makes `build_rrule` throw a `MooncakeRuleCompilationError` immediately with a clear message.
The same check is also added to `generate_dual_ir` in `forward_mode.jl`, where the runtime crash would otherwise be a missing `frule!!`.

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1194 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1194/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 190.0 ns │     1.69 │        1.69 │   0.632 │        3.01 │   5.91 │
│             _sum_1000 │ 972.0 ns │     7.17 │        1.04 │  3800.0 │        42.5 │   1.06 │
│          sum_sin_1000 │  7.06 μs │     3.55 │        1.42 │    1.52 │        11.2 │   1.79 │
│         _sum_sin_1000 │  5.86 μs │     3.58 │        1.94 │   272.0 │        13.9 │   2.23 │
│              kron_sum │ 218.0 μs │     13.1 │        3.29 │    20.5 │       338.0 │   19.6 │
│         kron_view_sum │ 299.0 μs │     11.1 │        4.93 │    24.7 │       316.0 │   11.9 │
│ naive_map_sin_cos_exp │  2.32 μs │     3.04 │        1.51 │ missing │         7.6 │   2.16 │
│       map_sin_cos_exp │  2.37 μs │     3.63 │        1.59 │    1.51 │         6.4 │   2.59 │
│ broadcast_sin_cos_exp │   2.4 μs │     3.14 │        1.56 │    3.84 │        1.41 │   2.08 │
│            simple_mlp │ 361.0 μs │     4.83 │        2.59 │    2.01 │        8.62 │   2.79 │
│                gp_lml │ 167.0 μs │     11.8 │        2.52 │    5.27 │     missing │   5.46 │
│    large_single_block │ 421.0 ns │     6.33 │         1.9 │  5060.0 │        32.6 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->