### PR TITLE
bound call `Core._call_latest(CoreLogging.handle_message` rule

### DIFF
--- a/src/rules/avoiding_non_differentiable_code.jl
+++ b/src/rules/avoiding_non_differentiable_code.jl
@@ -100,24 +100,27 @@ end
     }
 end
 
-# specialized case for Builtin primitive Core._call_latest rrule for CoreLogging.handle_message kwargs call.
-@zero_derivative(
-    MinimalCtx,
-    Tuple{
-        typeof(Core._call_latest),
-        typeof(Core.kwcall),
-        NamedTuple,
-        typeof(CoreLogging.handle_message),
-        Any,
-        Base.CoreLogging.LogLevel,
-        String,
-        Module,
-        Symbol,
-        Symbol,
-        String,
-        Int64,
-    }
-)
+# On 1.12+, @invokelatest no longer expands to Core._call_latest, so this kwargs
+# variant is also dead code on 1.12+.
+@static if VERSION < v"1.12-"
+    @zero_derivative(
+        MinimalCtx,
+        Tuple{
+            typeof(Core._call_latest),
+            typeof(Core.kwcall),
+            NamedTuple,
+            typeof(CoreLogging.handle_message),
+            Any,
+            Base.CoreLogging.LogLevel,
+            String,
+            Module,
+            Symbol,
+            Symbol,
+            String,
+            Int64,
+        }
+    )
+end
 
 function hand_written_rule_test_cases(rng_ctor, ::Val{:avoiding_non_differentiable_code})
     _x = Ref(5.0)

--- a/src/rules/avoiding_non_differentiable_code.jl
+++ b/src/rules/avoiding_non_differentiable_code.jl
@@ -60,18 +60,23 @@ import Base.CoreLogging as CoreLogging
     Symbol,
     Symbol,
 }
-@zero_derivative MinimalCtx Tuple{
-    typeof(Core._call_latest),
-    typeof(CoreLogging.handle_message),
-    Any,
-    Base.CoreLogging.LogLevel,
-    String,
-    Module,
-    Symbol,
-    Symbol,
-    String,
-    Int64,
-}
+
+# On 1.12+, @invokelatest no longer expands to Core._call_latest, it uses
+# Base.invokelatest/Base.invokelatest_gr instead.
+@static if VERSION < v"1.12-"
+    @zero_derivative MinimalCtx Tuple{
+        typeof(Core._call_latest),
+        typeof(CoreLogging.handle_message),
+        Any,
+        Base.CoreLogging.LogLevel,
+        String,
+        Module,
+        Symbol,
+        Symbol,
+        String,
+        Int64,
+    }
+end
 
 # Package loading internals; also needed for extension code paths.
 @zero_derivative MinimalCtx Tuple{Type{Base.PkgId},Module}


### PR DESCRIPTION
closes part 2 of #847 

PR #714 added `@zero_derivative` rules to prevent Mooncake from differentiating through Julia's logging internals. One of those rules covers `Core._call_latest` +  `CoreLogging.handle_message` which was needed pre-`1.12` because `@invokelatest` expanded to `Core._call_latest`. On `1.12`, `@invokelatest` was changed to expand to `Base.invokelatest/Base.invokelatest_gr` instead. This means `Core._call_latest(handle_message, ...)` never appears in any IR on `1.12` and the rule is dead code on specifically 1.12 but was left registered.

Fix description:
 
Wrap the `Core._call_latest` + `handle_message` rule (and its kwarg version) in `@static if VERSION < v"1.12-"` so it is only registered where the pattern actually occurs. No new rules are needed for 1.12, the existing `handle_message_nothrow` rules (already inside `@static if VERSION ≥ v"1.12-"`) work for that since `@logmsg` on `1.12` calls `handle_message_nothrow` directly.

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1200 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1200/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.56 │        1.61 │   0.722 │        3.56 │   7.01 │
│             _sum_1000 │   1.1 μs │      6.0 │        1.02 │  3900.0 │        39.8 │   1.06 │
│          sum_sin_1000 │  7.43 μs │     2.53 │        1.13 │    1.65 │        11.1 │   1.73 │
│         _sum_sin_1000 │  4.77 μs │     3.91 │        2.57 │   378.0 │        17.0 │   2.96 │
│              kron_sum │ 193.0 μs │     13.4 │        3.33 │     7.6 │       485.0 │   23.6 │
│         kron_view_sum │ 264.0 μs │     13.0 │        5.33 │    28.7 │       485.0 │   14.4 │
│ naive_map_sin_cos_exp │  2.27 μs │      2.9 │        1.52 │ missing │        8.12 │   2.11 │
│       map_sin_cos_exp │  2.25 μs │     3.36 │        1.65 │    1.53 │        7.14 │   2.61 │
│ broadcast_sin_cos_exp │  2.37 μs │     3.07 │        1.54 │    4.21 │        1.35 │   2.02 │
│            simple_mlp │ 357.0 μs │     4.92 │        2.92 │    1.99 │        9.56 │   3.12 │
│                gp_lml │ 167.0 μs │     12.0 │        2.58 │    5.25 │     missing │   5.49 │
│    large_single_block │ 480.0 ns │     5.88 │        1.92 │  4140.0 │        35.4 │   2.02 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->