### PR TITLE
Fix inlining avoidance in forward-over-reverse HVP  (#1193)

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2134,8 +2134,10 @@ end
     return primal(output), tangent(output)
 end
 
-# `fwd_cache` is the derivative cache for `grad_f`. The compiled inner rrule is cached
-# across `value_and_hvp!!` calls via a `LazyFoRRule` captured inside `fwd_cache`'s frule.
+# `fwd_cache` is the derivative cache for `grad_f`. For non-primitive `f`, the compiled
+# inner rrule lives in the `DerivedFoRRule` captured by `grad_f` (built once at prep);
+# `get_inner_rrule`'s frule serves its `Dual` to the forward pass on every
+# `value_and_hvp!!` call.
 """
     HVPCache
 
@@ -2242,19 +2244,25 @@ true
     f::F, x::Vararg{Any,N}; config=Config()
 ) where {F,N}
     N == 0 && throw(ArgumentError("prepare_hvp_cache requires at least one x argument"))
-    # `prepare_gradient_cache` runs the inner rule once so captured `LazyDerivedRule`s
-    # get their `.rule` field initialised; otherwise `zero_tangent` over the captures
-    # would produce uninitialised `PossiblyUninitTangent`s that crash forward AD.
+    # Validates that `f` returns an `IEEEFloat` (running `f` once), allocates the tangent
+    # buffers reused by `grad_f`, and supplies `output_spec`. The primitive
+    # (`DerivedFoRRule{Nothing}`) branches below also evaluate gradients through
+    # `grad_cache.rule`.
     grad_cache = prepare_gradient_cache(f, x...; config)
 
     # `DerivedFoRRule` wraps a pre-built `Dual(rule, rule_tangent)` so forward AD reuses
     # the rule's forward-mode-compiled dual callables instead of `zero_tangent`
     # re-deriving them and leaking reverse-mode primitives (e.g. inlined `IdDict()`)
-    # into the forward IR. The second type parameter `D` discriminates derived
+    # into the forward IR. The type parameter `D` discriminates derived
     # (`D <: Dual`) from primitive (`D === Nothing`) rrules — primitive rrules have
     # no MistyClosure IR and keep using `grad_cache`'s rule directly.
     for_rule = compile_for_rule(f, x...; debug_mode=config.debug_mode)
 
+    # The derived branches capture only these buffers: capturing `grad_cache` itself
+    # would make `zero_tangent(grad_f)` traverse `grad_cache.rule`'s MistyClosures and
+    # eagerly build dual callables over reverse-mode-optimised IR that the derived path
+    # never invokes.
+    tangents = grad_cache.tangents
     grad_f = if N == 1
         if for_rule isa DerivedFoRRule{Nothing}
             y -> begin
@@ -2264,7 +2272,7 @@ true
         else
             y -> begin
                 inner_rule = get_inner_rrule(for_rule)
-                t_f, t_y = grad_cache.tangents
+                t_f, t_y = tangents
                 t_f = set_to_zero!!(t_f)
                 t_y = set_to_zero!!(t_y)
                 val, grad = __value_and_gradient!!(
@@ -2283,7 +2291,7 @@ true
         else
             (ys...) -> begin
                 inner_rule = get_inner_rrule(for_rule)
-                zeroed = tuple_map(set_to_zero!!, grad_cache.tangents)
+                zeroed = tuple_map(set_to_zero!!, tangents)
                 coduals = tuple_map(CoDual, (f, ys...), zeroed)
                 val, grad = __value_and_gradient!!(inner_rule, coduals...)
                 # Drop the gradient w.r.t. f itself (always index 1).

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2242,19 +2242,53 @@ true
     f::F, x::Vararg{Any,N}; config=Config()
 ) where {F,N}
     N == 0 && throw(ArgumentError("prepare_hvp_cache requires at least one x argument"))
-    # Pre-build the reverse-mode gradient cache so forward-over-reverse differentiates
-    # only through gradient evaluation, not through repeated rule construction.
+    # `prepare_gradient_cache` runs the inner rule once so captured `LazyDerivedRule`s
+    # get their `.rule` field initialised; otherwise `zero_tangent` over the captures
+    # would produce uninitialised `PossiblyUninitTangent`s that crash forward AD.
     grad_cache = prepare_gradient_cache(f, x...; config)
+
+    # `DerivedFoRRule` wraps a pre-built `Dual(rule, rule_tangent)` so forward AD reuses
+    # the rule's forward-mode-compiled dual callables instead of `zero_tangent`
+    # re-deriving them and leaking reverse-mode primitives (e.g. inlined `IdDict()`)
+    # into the forward IR. The second type parameter `D` discriminates derived
+    # (`D <: Dual`) from primitive (`D === Nothing`) rrules — primitive rrules have
+    # no MistyClosure IR and keep using `grad_cache`'s rule directly.
+    for_rule = compile_for_rule(f, x...; debug_mode=config.debug_mode)
+
     grad_f = if N == 1
-        y -> begin
-            val_and_grad = value_and_gradient!!(grad_cache, f, y)
-            (val_and_grad[1], val_and_grad[2][2])
+        if for_rule isa DerivedFoRRule{Nothing}
+            y -> begin
+                val_and_grad = value_and_gradient!!(grad_cache, f, y)
+                (val_and_grad[1], val_and_grad[2][2])
+            end
+        else
+            y -> begin
+                inner_rule = get_inner_rrule(for_rule)
+                t_f, t_y = grad_cache.tangents
+                t_f = set_to_zero!!(t_f)
+                t_y = set_to_zero!!(t_y)
+                val, grad = __value_and_gradient!!(
+                    inner_rule, CoDual(f, t_f), CoDual(y, t_y)
+                )
+                (val, grad[2])
+            end
         end
     else
-        function (ys...)
-            val_and_grad = value_and_gradient!!(grad_cache, f, ys...)
-            # Drop the gradient w.r.t. f itself (always index 1); return only x-arg gradients.
-            (val_and_grad[1], Base.tail(val_and_grad[2]))
+        if for_rule isa DerivedFoRRule{Nothing}
+            (ys...) -> begin
+                val_and_grad = value_and_gradient!!(grad_cache, f, ys...)
+                # Drop the gradient w.r.t. f itself (always index 1).
+                (val_and_grad[1], Base.tail(val_and_grad[2]))
+            end
+        else
+            (ys...) -> begin
+                inner_rule = get_inner_rrule(for_rule)
+                zeroed = tuple_map(set_to_zero!!, grad_cache.tangents)
+                coduals = tuple_map(CoDual, (f, ys...), zeroed)
+                val, grad = __value_and_gradient!!(inner_rule, coduals...)
+                # Drop the gradient w.r.t. f itself (always index 1).
+                (val, Base.tail(grad))
+            end
         end
     end
     fwd_cache = prepare_derivative_cache(grad_f, x...; config)

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -8,13 +8,25 @@
     typeof(build_derived_rrule),MooncakeInterpreter{C},Any,Any,Bool
 } where {C}
 
-# LazyFoRRule and DynamicFoRRule are the frule for `build_derived_rrule` in
-# forward-over-reverse mode.  In HVPCache, grad_f calls
-# prepare_gradient_cache → build_rrule → build_derived_rrule on every
-# value_and_hvp!! call, so caching is essential: the first call compiles the
-# inner DerivedRule and dual callables; subsequent calls reuse them via _copy (cheap).
+# This file defines three forward-over-reverse (FoR) types organised into two layers.
+# Big-picture context: reverse mode has `DerivedRule` / `LazyDerivedRule` /
+# `DynamicDerivedRule` (`src/interpreter/reverse_mode.jl`); forward mode has
+# `DerivedFRule` / `LazyFRule` / `DynamicFRule` (`src/interpreter/forward_mode.jl`).
+# The FoR triplet below mirrors them — with the layer caveat described at the end
+# of this block.
 #
-# build_primitive_frule selects between the two via __build_primitive_frule (@generated):
+# Value layer — `DerivedFoRRule{D}` (defined below, near `compile_for_rule`): a FoR
+# rule (or its absence) held as a value and reused across many calls. `D <: Dual`
+# carries a pre-built `Dual(rule, rule_tangent)` for HVP / Hessian; `D === Nothing`
+# is the primitive-passthrough sentinel. Reuse is safe because the rule's Stacks
+# self-reset within each forward+reverse pass.
+#
+# Frule layer — `LazyFoRRule` / `DynamicFoRRule` (this section): callable caches
+# dispatched as the frule for `build_derived_rrule`. Each call returns a fresh
+# `Dual(rule, rule_tangent)`, with Stacks cloned via `_for_rule_cached_dual` —
+# defensive against nested AD where the rule may be re-entered before the
+# previous call's Stacks have self-reset. `build_primitive_frule` selects between
+# the two via `__build_primitive_frule` (@generated):
 #
 #   • Concrete Trule → LazyFoRRule{Trule,Tfwd,Trvs}: fully-typed single-slot cache.
 #     Zero virtual dispatch on cache hits. Safe because each instance lives at exactly
@@ -22,9 +34,27 @@
 #
 #   • Non-concrete Trule (Trule = Any) → DynamicFoRRule: Dict-keyed cache. Arises
 #     when build_rrule's @nospecialize sig_or_mi causes the forward-mode compiler to
-#     see SMI=Any/S=Any, yielding Trule=Any.  The single frule call site is then
+#     see SMI=Any/S=Any, yielding Trule=Any. The single frule call site is then
 #     shared by multiple LazyDerivedRule instances (different inner functions), so a
 #     single-slot cache would serve the wrong rule — see DynamicFoRRule for key design.
+#
+# The trio mirrors reverse-mode `DerivedRule` / `LazyDerivedRule` / `DynamicDerivedRule`
+# at a slight angle: reverse mode's three types are all *rule-callable*
+# (`(rule)(args...)` with primal args, returning AD output). None of the three
+# FoR types here is rule-callable in that sense:
+#   • `DerivedFoRRule` is a *carrier* of a pre-built `Dual(rule, rule_tangent)`;
+#     callers extract via `get_inner_rrule`, they do not invoke it directly.
+#   • `LazyFoRRule` / `DynamicFoRRule` are *constructors* — their call shape is
+#     `(::Dual{typeof(build_derived_rrule)}, …)`, returning a fresh Dual rule
+#     per invocation (the frule for `build_derived_rrule`, not for user code).
+# Mooncake has no top-level "FoR rule" type — the user entry point
+# `value_and_hvp!!` dispatches through a regular `DerivedFRule`. The shared
+# `FoRRule` suffix is a family label (= "lives in the FoR machinery"), not a
+# contract suffix.
+#
+# TODO: rename to make the role honest — e.g. carrier → `FoRRuleDual` /
+# `RRuleDualBox`, constructors → `Lazy` / `DynamicBuildRRuleFRule`. Kept as-is
+# for now to minimise diff while wiring HVP through `DerivedFoRRule`.
 mutable struct LazyFoRRule{Trule,Tfwd,Trvs}
     rule::Trule
     fwd_dual_callable::Tfwd
@@ -270,6 +300,43 @@ function rrule!!(
         ArgumentError(
             "Reverse-over-reverse differentiation is not supported. " *
             "Encountered attempt to differentiate build_derived_rrule in reverse mode.",
+        ),
+    )
+end
+
+# Wrapper around a pre-built `Dual(rule, rule_tangent)` so forward AD sees the
+# rule with its forward-mode-compiled dual callables instead of `zero_tangent`
+# re-deriving them over the reverse-mode-optimised primal IR (which would
+# reintroduce the bug `_compile_for_rule` exists to avoid). `tangent_type` is
+# `NoTangent`; the tangent rides inside the cached `Dual`. The type parameter
+# `D` discriminates: `D <: Dual` for derived rrules, `D === Nothing` for
+# primitives — callers branch via `for_rule isa DerivedFoRRule{Nothing}`.
+# Stale-rule caveat: the cached `Dual` is pinned to world age at prep; rebuild
+# the `HVPCache` if methods change after prep.
+struct DerivedFoRRule{D}
+    rule_dual::D
+end
+function compile_for_rule(f, x...; debug_mode::Bool=false)
+    sig = _typeof((f, x...))
+    interp = get_interpreter(ReverseMode)
+    if is_primitive(DefaultCtx, ReverseMode, sig, interp.world)
+        return DerivedFoRRule{Nothing}(nothing)
+    end
+    rule, _, _, rule_tangent = _compile_for_rule(interp, sig, sig, debug_mode)
+    return DerivedFoRRule(Dual(rule, rule_tangent))
+end
+tangent_type(::Type{<:DerivedFoRRule}) = NoTangent
+
+get_inner_rrule(r::DerivedFoRRule{<:Dual}) = primal(r.rule_dual)
+@is_primitive MinimalCtx Tuple{typeof(get_inner_rrule),<:DerivedFoRRule{<:Dual}}
+function frule!!(::Dual{typeof(get_inner_rrule)}, r::Dual{<:DerivedFoRRule{<:Dual}})
+    return primal(r).rule_dual
+end
+function rrule!!(::CoDual{typeof(get_inner_rrule)}, ::CoDual{<:DerivedFoRRule{<:Dual}})
+    throw(
+        ArgumentError(
+            "DerivedFoRRule is forward-over-reverse only; reverse-mode " *
+            "differentiation through it is not supported.",
         ),
     )
 end

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -200,8 +200,9 @@ end
     end
 
     @testset "cache reuse across multiple HVP calls" begin
-        # The LazyFoRRule should compile the inner rule only once; verify the cache
-        # produces consistent results when called repeatedly with different directions.
+        # The `DerivedFoRRule`'s cached `Dual` is reused across calls without copying;
+        # verify the cache produces consistent results when called repeatedly with
+        # different directions.
         f(x) = sum(x .* x)  # H = 2I
         x = [1.0, 2.0, 3.0]
         cache = prepare_hvp_cache(f, x)

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -1,3 +1,8 @@
+struct _RefCaptureWrap{F}
+    f::F
+end
+(w::_RefCaptureWrap)(x) = w.f(x)
+Mooncake.tangent_type(::Type{<:_RefCaptureWrap}) = Mooncake.NoTangent
 function _compute_grad(rule, f, x::Vector{Float64}, x_fdata::Vector{Float64})
     fill!(x_fdata, 0.0)
     _, pb!! = rule(zero_fcodual(f), CoDual(x, x_fdata))
@@ -223,5 +228,19 @@ end
         @test grad_y ≈ [6.0] rtol = 1e-10
         @test hvp_x ≈ [2.0, 0.0] rtol = 1e-10
         @test hvp_y ≈ [0.0] rtol = 1e-10
+    end
+
+    # Regression for https://github.com/chalk-lab/Mooncake.jl/issues/1193.
+    @testset "Ref-capture under NoTangent wrapper (issue #1193)" begin
+        f = _RefCaptureWrap(
+            let r = Ref(3.0);
+                x -> r[] * sum(abs2, x);
+            end,
+        )
+        x = [1.0, 2.0]
+        _, _, hvp = value_and_hvp!!(prepare_hvp_cache(f, x), f, [1.0, 0.0], x)
+        @test hvp ≈ [6.0, 0.0]
+        _, _, H = value_gradient_and_hessian!!(prepare_hessian_cache(f, x), f, x)
+        @test H ≈ [6.0 0.0; 0.0 6.0]
     end
 end

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -182,6 +182,13 @@ end
     end
 end
 
+@testset "get_inner_rrule is forward-over-reverse only" begin
+    for_rule = Mooncake.compile_for_rule(x -> sum(x .* x), [1.0, 2.0])
+    @test_throws "forward-over-reverse only" Mooncake.rrule!!(
+        zero_fcodual(Mooncake.get_inner_rrule), zero_fcodual(for_rule)
+    )
+end
+
 @testset "native HVP interface (prepare_hvp_cache + value_and_hvp!!)" begin
     @testset "gradient correctness for x^4" begin
         f(x) = x[1]^4.0
@@ -229,6 +236,34 @@ end
         @test grad_y ≈ [6.0] rtol = 1e-10
         @test hvp_x ≈ [2.0, 0.0] rtol = 1e-10
         @test hvp_y ≈ [0.0] rtol = 1e-10
+    end
+
+    @testset "primitive f (DerivedFoRRule{Nothing} path)" begin
+        # When `f` is itself a reverse-mode primitive, `compile_for_rule` returns
+        # `DerivedFoRRule{Nothing}` and `grad_f` routes through `value_and_gradient!!`
+        # rather than an inner derived rrule.
+        @testset "single argument" begin
+            f = sum  # linear ⇒ zero Hessian
+            x = [1.0, 2.0, 3.0]
+            fval, grad, hvp = value_and_hvp!!(
+                prepare_hvp_cache(f, x), f, [1.0, 0.0, 0.0], x
+            )
+            @test fval ≈ 6.0
+            @test grad ≈ [1.0, 1.0, 1.0]
+            @test hvp ≈ [0.0, 0.0, 0.0]
+        end
+        @testset "multiple arguments" begin
+            f = hypot  # r = √(a²+b²); H = [b² -ab; -ab a²]/r³
+            a, b = 3.0, 4.0
+            fval, grads, hvps = value_and_hvp!!(
+                prepare_hvp_cache(f, a, b), f, (1.0, 0.0), a, b
+            )
+            @test fval ≈ 5.0
+            @test grads[1] ≈ 0.6 rtol = 1e-10
+            @test grads[2] ≈ 0.8 rtol = 1e-10
+            @test hvps[1] ≈ 0.128 rtol = 1e-10
+            @test hvps[2] ≈ -0.096 rtol = 1e-10
+        end
     end
 
     # Regression for https://github.com/chalk-lab/Mooncake.jl/issues/1193.


### PR DESCRIPTION
Forward-over-reverse on a closure capturing a `Ref` wrapped in a `NoTangent`-typed aggregate previously threw `UndefRefError`: the inner `IdDict()` cache construction on the `zero_tangent_internal` path was inlined to `_new_` (or, on 1.11, `jl_alloc_genericmemory`), bypassing Mooncake's existing `Type{IdDict}()` constructor rule.

Fix the root cause in `prepare_hvp_cache` rather than patching each inlined call: compile the inner rrule together with its forward-mode dual callables (`compile_for_rule`), wrap them in a new `FoRRuleDual` lifting primitive, and route the outer forward AD pass through that so the rrule body is differentiated via dual callables whose IR was optimised with a `ForwardMode` interpreter — exactly the mechanism PR #990 added for `LazyFoRRule`, applied here.

Fix #1193

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1202 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1202/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 181.0 ns │      1.6 │        1.61 │   0.718 │        3.54 │   6.97 │
│             _sum_1000 │  1.09 μs │     5.97 │        1.03 │  1630.0 │        39.6 │   1.06 │
│          sum_sin_1000 │  7.43 μs │     2.66 │        1.18 │    1.67 │        11.2 │   1.74 │
│         _sum_sin_1000 │  4.66 μs │     3.77 │        2.63 │   369.0 │        17.5 │   3.06 │
│              kron_sum │ 198.0 μs │     13.3 │         3.3 │    12.2 │       576.0 │   22.8 │
│         kron_view_sum │ 261.0 μs │     13.0 │        5.32 │    29.0 │       517.0 │   13.6 │
│ naive_map_sin_cos_exp │  2.19 μs │     2.83 │        1.53 │ missing │        8.88 │   2.16 │
│       map_sin_cos_exp │   2.1 μs │      3.5 │        1.65 │    1.65 │        7.59 │   2.79 │
│ broadcast_sin_cos_exp │  2.25 μs │     3.02 │        1.56 │    4.37 │        1.47 │   2.16 │
│            simple_mlp │ 344.0 μs │     5.07 │        2.95 │     2.0 │        9.61 │   3.22 │
│                gp_lml │ 368.0 μs │     6.36 │        1.72 │    2.75 │     missing │    3.1 │
│    large_single_block │ 521.0 ns │     5.29 │        1.77 │  3580.0 │        32.7 │   1.87 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->