### PR TITLE
Cap LoweredCodeUtils below 3.6 to unblock Julia 1.12 CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -76,6 +76,8 @@ JET = "0.9, 0.10, 0.11"
 LinearAlgebra = "1"
 LogExpFunctions = "0.3, 1"
 Logging = "1"
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"
 LuxLib = "1.11"
 MLDataDevices = "1.10.0"
 MistyClosures = "2"
@@ -100,6 +102,7 @@ DiffTests = "de460e47-3fe3-5279-bb4a-814414816d5d"
 DynamicExpressions = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -114,6 +117,7 @@ test = [
     "DiffTests",
     "JET",
     "Logging",
+    "LoweredCodeUtils",
     "Pkg",
     "Revise",
     "StableRNGs",

--- a/Project.toml
+++ b/Project.toml
@@ -76,7 +76,6 @@ JET = "0.9, 0.10, 0.11"
 LinearAlgebra = "1"
 LogExpFunctions = "0.3, 1"
 Logging = "1"
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"
 LuxLib = "1.11"
 MLDataDevices = "1.10.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,6 +6,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 
 [compat]
@@ -13,4 +14,6 @@ AllocCheck = "0.2.0"
 ChainRulesCore = "1"
 Documenter = "1"
 JET = "0.9, 0.10, 0.11"
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"
 Mooncake = "0.5, 0.6"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,6 +14,5 @@ AllocCheck = "0.2.0"
 ChainRulesCore = "1"
 Documenter = "1"
 JET = "0.9, 0.10, 0.11"
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"
 Mooncake = "0.5, 0.6"

--- a/test/ext/bfloat16s/Project.toml
+++ b/test/ext/bfloat16s/Project.toml
@@ -2,6 +2,7 @@
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -11,4 +12,6 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 BFloat16s = "0.6"
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"
 Revise = "3.0 - 3.12"

--- a/test/ext/bfloat16s/Project.toml
+++ b/test/ext/bfloat16s/Project.toml
@@ -12,6 +12,5 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 BFloat16s = "0.6"
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"
 Revise = "3.0 - 3.12"

--- a/test/ext/cuda/Project.toml
+++ b/test/ext/cuda/Project.toml
@@ -2,6 +2,11 @@
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"

--- a/test/ext/cuda/Project.toml
+++ b/test/ext/cuda/Project.toml
@@ -8,5 +8,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"

--- a/test/ext/dynamic_expressions/Project.toml
+++ b/test/ext/dynamic_expressions/Project.toml
@@ -9,5 +9,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"

--- a/test/ext/dynamic_expressions/Project.toml
+++ b/test/ext/dynamic_expressions/Project.toml
@@ -2,7 +2,12 @@
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 DynamicExpressions = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"

--- a/test/ext/function_wrappers/Project.toml
+++ b/test/ext/function_wrappers/Project.toml
@@ -2,6 +2,11 @@
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"

--- a/test/ext/function_wrappers/Project.toml
+++ b/test/ext/function_wrappers/Project.toml
@@ -8,5 +8,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"

--- a/test/ext/luxlib/Project.toml
+++ b/test/ext/luxlib/Project.toml
@@ -13,6 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"
 Revise = "3.0 - 3.12"

--- a/test/ext/luxlib/Project.toml
+++ b/test/ext/luxlib/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxLib = "82251201-b29d-42c6-8e01-566dec8acb11"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
@@ -12,4 +13,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"
 Revise = "3.0 - 3.12"

--- a/test/ext/nnlib/Project.toml
+++ b/test/ext/nnlib/Project.toml
@@ -1,9 +1,14 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 LuxLib = "82251201-b29d-42c6-8e01-566dec8acb11"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
+
+[compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"

--- a/test/ext/nnlib/Project.toml
+++ b/test/ext/nnlib/Project.toml
@@ -10,5 +10,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"

--- a/test/ext/special_functions/Project.toml
+++ b/test/ext/special_functions/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -10,4 +11,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"
 Revise = "3.0 - 3.12"

--- a/test/ext/special_functions/Project.toml
+++ b/test/ext/special_functions/Project.toml
@@ -11,6 +11,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"
 Revise = "3.0 - 3.12"

--- a/test/integration_testing/battery_tests/Project.toml
+++ b/test/integration_testing/battery_tests/Project.toml
@@ -2,7 +2,12 @@
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"

--- a/test/integration_testing/battery_tests/Project.toml
+++ b/test/integration_testing/battery_tests/Project.toml
@@ -9,5 +9,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"

--- a/test/integration_testing/dispatch_doctor/Project.toml
+++ b/test/integration_testing/dispatch_doctor/Project.toml
@@ -8,6 +8,7 @@ DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -15,3 +16,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [preferences.Mooncake]
 dispatch_doctor_mode = "error"
+
+[compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"

--- a/test/integration_testing/dispatch_doctor/Project.toml
+++ b/test/integration_testing/dispatch_doctor/Project.toml
@@ -18,5 +18,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 dispatch_doctor_mode = "error"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"

--- a/test/integration_testing/distributions/Project.toml
+++ b/test/integration_testing/distributions/Project.toml
@@ -14,6 +14,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
-# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
 LoweredCodeUtils = "<3.6"
 Revise = "3.0 - 3.12"

--- a/test/integration_testing/distributions/Project.toml
+++ b/test/integration_testing/distributions/Project.toml
@@ -4,6 +4,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -13,4 +14,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
+# TODO: remove cap once JET is compatible with LoweredCodeUtils 3.6 (aviatesk/JET.jl#823).
+LoweredCodeUtils = "<3.6"
 Revise = "3.0 - 3.12"


### PR DESCRIPTION
LoweredCodeUtils 3.6.0 (registered 2026-06-11) changed the signature of add_active_gotos!, which JET (0.11.2 and 0.11.3) still calls with the old four-argument form. On Julia 1.12, every environment that includes JET therefore fails while precompiling JET and MooncakeJETExt:

```
  MethodError: no method matching add_active_gotos!(::BitVector,
  ::Core.CodeInfo, ::Compiler.CFG, ::Compiler.GenericDomTree{true})
```

This broke all Julia 1.12 CI jobs and the docs build on main (the same commit went green at 08:10 and red at 13:46 UTC on 2026-06-11) and on every open PR. Upstream issue: https://github.com/aviatesk/JET.jl/issues/823

Add LoweredCodeUtils with compat "<3.6" to every environment that depends on JET: the root test target, docs, and the ext / integration test envs. No lower bound is imposed, so Julia 1.10 resolution is unaffected. Verified locally on 1.12.6: the function_wrappers env resolves JET 0.11.3 + LoweredCodeUtils 3.5.3, and JET / MooncakeJETExt precompile cleanly.

Remove the cap once a JET release supports LoweredCodeUtils 3.6.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1203 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1203/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 190.0 ns │     1.53 │        1.53 │   0.684 │        3.43 │   6.75 │
│             _sum_1000 │   1.1 μs │     6.14 │        1.01 │  1660.0 │        41.4 │   1.05 │
│          sum_sin_1000 │  7.44 μs │     2.53 │        1.11 │    1.63 │        10.9 │   1.74 │
│         _sum_sin_1000 │  4.68 μs │     3.78 │        2.61 │   353.0 │        17.6 │   3.03 │
│              kron_sum │ 199.0 μs │     13.6 │        3.21 │    7.05 │       548.0 │   19.0 │
│         kron_view_sum │ 268.0 μs │     12.6 │        5.26 │    28.5 │       451.0 │   14.5 │
│ naive_map_sin_cos_exp │  2.21 μs │     2.86 │        1.55 │ missing │        8.42 │   2.16 │
│       map_sin_cos_exp │  2.19 μs │     3.31 │         1.6 │    1.57 │        7.36 │   2.67 │
│ broadcast_sin_cos_exp │  2.28 μs │     3.06 │        1.57 │    4.49 │        1.41 │   2.09 │
│            simple_mlp │ 358.0 μs │      5.1 │        2.89 │    1.63 │        9.36 │   3.15 │
│                gp_lml │ 163.0 μs │     12.0 │        3.95 │    11.8 │     missing │   7.83 │
│    large_single_block │ 471.0 ns │      5.3 │        1.96 │  4150.0 │        31.8 │   2.08 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->