### PR TITLE
Drop AllocCheck get_pgcstack_static monkeypatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -55,7 +55,7 @@ MooncakeSpecialFunctionsExt = "SpecialFunctions"
 
 [compat]
 ADTypes = "1.9"
-AllocCheck = "0.2"
+AllocCheck = "0.2.5"
 Aqua = "0.8.9"
 BFloat16s = "0.6"
 BenchmarkTools = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,7 +10,7 @@ LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 
 [compat]
-AllocCheck = "0.2.0"
+AllocCheck = "0.2.5"
 ChainRulesCore = "1"
 Documenter = "1"
 JET = "0.9, 0.10, 0.11"

--- a/ext/MooncakeAllocCheckExt.jl
+++ b/ext/MooncakeAllocCheckExt.jl
@@ -7,23 +7,4 @@ import Mooncake.TestUtils: check_allocs_internal, Shim
 @check_allocs check_allocs_internal(::Shim, f::F, x, y) where {F} = f(x, y)
 @check_allocs check_allocs_internal(::Shim, f::F, x, y, z) where {F} = f(x, y, z)
 
-# TODO: remove the fix below after https://github.com/JuliaLang/AllocCheck.jl/pull/100 is merged
-function __init__()
-    # AllocCheck's allowlist includes "get_pgcstack" but not "get_pgcstack_static",
-    # which is the arm64-specific variant used on Apple Silicon. Patch fn_may_allocate
-    # to recognise it as non-allocating. See: AllocCheck.jl/src/classify.jl
-    #
-    # MWE reproducing the false positive on arm64:
-    #   using Mooncake, AllocCheck
-    #   T = Tuple{Vector{Float64}, Vector{Float64}}
-    #   AllocCheck.compile_callable(Mooncake.fdata_type, Tuple{Type{T}}; ignore_throw=true).analysis
-    #   # => ["Allocating runtime call to \"jl_get_pgcstack_static\" in unknown location"]
-    orig = AllocCheck.fn_may_allocate
-    orig_world = Base.get_world_counter()
-    @eval AllocCheck function fn_may_allocate(name::AbstractString; ignore_throw::Bool)
-        name == "get_pgcstack_static" && return false
-        return Base.invoke_in_world($orig_world, $orig, name; ignore_throw)
-    end
-end
-
 end


### PR DESCRIPTION
[AllocCheck.jl PR #100](https://github.com/JuliaLang/AllocCheck.jl/pull/100) added "get_pgcstack_static" to the non-allocating allowlist, shipped in AllocCheck 0.2.5. The __init__ patch in MooncakeAllocCheckExt that redefined fn_may_allocate to work around the arm64 false positive is now redundant, so remove it and tighten the AllocCheck compat bound to 0.2.5.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1210 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1210/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 200.0 ns │     1.45 │        1.55 │    0.65 │        3.26 │   6.36 │
│             _sum_1000 │   1.1 μs │     5.98 │        1.02 │  3690.0 │        40.2 │   1.06 │
│          sum_sin_1000 │  7.42 μs │     2.48 │        1.12 │    1.65 │        10.8 │   1.71 │
│         _sum_sin_1000 │  4.61 μs │     3.82 │        2.67 │   394.0 │        17.6 │   3.09 │
│              kron_sum │ 198.0 μs │     13.1 │        3.24 │     7.3 │       527.0 │   21.6 │
│         kron_view_sum │ 264.0 μs │     12.8 │        5.32 │    28.6 │       494.0 │   13.8 │
│ naive_map_sin_cos_exp │  2.24 μs │     2.78 │        1.54 │ missing │        8.29 │   2.12 │
│       map_sin_cos_exp │  2.15 μs │     3.39 │        1.65 │    1.53 │        7.48 │   2.73 │
│ broadcast_sin_cos_exp │  2.23 μs │     3.02 │        1.58 │     4.4 │        1.44 │   2.13 │
│            simple_mlp │ 343.0 μs │     5.07 │        2.95 │    2.15 │        10.7 │   3.22 │
│                gp_lml │ 168.0 μs │     11.5 │        2.55 │    5.08 │     missing │   5.42 │
│    large_single_block │ 471.0 ns │     5.34 │        1.93 │  4020.0 │        32.2 │   2.08 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->