### PR TITLE
CI: track in-dev Julia 1.12.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,6 +75,17 @@ jobs:
           arch: ${{ matrix.arch }}
           include-all-prereleases: false
       - uses: julia-actions/cache@v3
+      # On in-development Julia ('-DEV' builds) JET refuses to load and ships an empty
+      # stub whose `test_opt`/`report_opt` just error. Set `JET_DEV_MODE` so the real
+      # JET loads and the JET-based checks actually run on 1.12-nightly. Scoped to that
+      # job so released-version jobs (and JET's `use_fixed_world` default) are untouched.
+      - name: Enable JET on in-dev Julia
+        if: matrix.version == '1.12-nightly'
+        run: |
+          cat > LocalPreferences.toml <<'EOF'
+          [JET]
+          JET_DEV_MODE = true
+          EOF
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,9 @@ jobs:
     name: ${{ matrix.test_group }}-${{ matrix.version }}-${{ matrix.arch }}
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
+    # '1.12-nightly' tracks the in-development Julia 1.12.7 (release-1.12 branch).
+    # Allowed to fail so upstream breakage is tracked without blocking PRs/merges.
+    continue-on-error: ${{ matrix.version == '1.12-nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +57,7 @@ jobs:
         version:
           - 'lts'
           - '1.12'
+          - '1.12-nightly'  # in-dev Julia 1.12.7 (release-1.12); non-blocking, see continue-on-error above
         arch:
           - x64
         include:


### PR DESCRIPTION
<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1211 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1211/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.62 │        1.62 │   0.722 │        3.62 │   7.01 │
│             _sum_1000 │   1.1 μs │     6.73 │        1.01 │  1690.0 │        35.1 │   1.06 │
│          sum_sin_1000 │  7.52 μs │     2.54 │        1.11 │    1.64 │        10.9 │   1.74 │
│         _sum_sin_1000 │  4.58 μs │     3.86 │        2.68 │   362.0 │        17.7 │    3.1 │
│              kron_sum │ 239.0 μs │     11.0 │         3.1 │    9.56 │       457.0 │   15.2 │
│         kron_view_sum │ 297.0 μs │     12.1 │        5.31 │    26.1 │       450.0 │   12.8 │
│ naive_map_sin_cos_exp │   2.4 μs │     3.08 │        1.79 │ missing │        7.77 │   2.02 │
│       map_sin_cos_exp │   2.7 μs │      3.0 │        1.44 │    1.26 │        5.97 │   2.16 │
│ broadcast_sin_cos_exp │   2.9 μs │     2.55 │        1.29 │    4.08 │        1.14 │   1.69 │
│            simple_mlp │ 367.0 μs │      4.8 │        2.83 │    2.03 │        9.05 │   3.09 │
│                gp_lml │ 165.0 μs │     12.1 │        2.62 │     5.0 │     missing │   5.74 │
│    large_single_block │ 471.0 ns │     11.3 │         2.1 │  4080.0 │        32.5 │   2.08 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->