### PR TITLE
Fix Lazy/Dynamic rules rebuilding at the current world instead of the prediction world (#1218)

### DIFF
--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -336,18 +336,24 @@ const GLOBAL_INTERPRETERS = Dict(
 )
 
 """
-    get_interpreter(mode::Type{<:Mode})
+    get_interpreter(mode::Type{<:Mode}; world::UInt=Base.get_world_counter())
 
-Returns a `MooncakeInterpreter` appropriate for the current world age. Will use a cached
-interpreter if one already exists for the current world age, otherwise creates a new one.
+Returns a `MooncakeInterpreter` for `mode` at `world`, defaulting to the current world age and
+served from a process-wide cache. A non-current `world` (e.g. when a Lazy/Dynamic rule rebuilds
+at its stored prediction world) yields a fresh, uncached interpreter, leaving the shared
+current-world cache untouched.
 
 This should be prefered over constructing a `MooncakeInterpreter` directly.
 """
-function get_interpreter(mode::Type{<:Mode})
-    if GLOBAL_INTERPRETERS[mode].world != Base.get_world_counter()
-        GLOBAL_INTERPRETERS[mode] = MooncakeInterpreter(DefaultCtx, mode)
+function get_interpreter(mode::Type{<:Mode}; world::UInt=Base.get_world_counter())
+    return if world != Base.get_world_counter()
+        # Pinned older world (Lazy/Dynamic rule rebuild): fresh, never cached.
+        MooncakeInterpreter(DefaultCtx, mode; world)
+    elseif GLOBAL_INTERPRETERS[mode].world == world
+        GLOBAL_INTERPRETERS[mode]
+    else
+        GLOBAL_INTERPRETERS[mode] = MooncakeInterpreter(DefaultCtx, mode; world)
     end
-    return GLOBAL_INTERPRETERS[mode]
 end
 
 """

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -336,24 +336,32 @@ const GLOBAL_INTERPRETERS = Dict(
 )
 
 """
-    get_interpreter(mode::Type{<:Mode}; world::UInt=Base.get_world_counter())
+    get_interpreter(mode::Type{<:Mode})
 
-Returns a `MooncakeInterpreter` for `mode` at `world`, defaulting to the current world age and
-served from a process-wide cache. A non-current `world` (e.g. when a Lazy/Dynamic rule rebuilds
-at its stored prediction world) yields a fresh, uncached interpreter, leaving the shared
-current-world cache untouched.
+Returns a `MooncakeInterpreter` appropriate for the current world age. Will use a cached
+interpreter if one already exists for the current world age, otherwise creates a new one.
 
 This should be prefered over constructing a `MooncakeInterpreter` directly.
 """
-function get_interpreter(mode::Type{<:Mode}; world::UInt=Base.get_world_counter())
-    return if world != Base.get_world_counter()
-        # Pinned older world (Lazy/Dynamic rule rebuild): fresh, never cached.
-        MooncakeInterpreter(DefaultCtx, mode; world)
-    elseif GLOBAL_INTERPRETERS[mode].world == world
-        GLOBAL_INTERPRETERS[mode]
-    else
-        GLOBAL_INTERPRETERS[mode] = MooncakeInterpreter(DefaultCtx, mode; world)
+function get_interpreter(mode::Type{<:Mode})
+    if GLOBAL_INTERPRETERS[mode].world != Base.get_world_counter()
+        GLOBAL_INTERPRETERS[mode] = MooncakeInterpreter(DefaultCtx, mode)
     end
+    return GLOBAL_INTERPRETERS[mode]
+end
+
+"""
+    get_interpreter(mode::Type{<:Mode}, world::UInt)
+
+Returns a `MooncakeInterpreter` for `mode` pinned to `world`. When `world` is the current
+world age this is equivalent to `get_interpreter(mode)` (served from the process-wide cache).
+A non-current `world` (e.g. when a Lazy/Dynamic rule rebuilds at its stored prediction world)
+yields a fresh, uncached interpreter, leaving the shared current-world cache untouched.
+"""
+function get_interpreter(mode::Type{<:Mode}, world::UInt)
+    world == Base.get_world_counter() && return get_interpreter(mode)
+    # Pinned older world (Lazy/Dynamic rule rebuild): fresh, never cached.
+    return MooncakeInterpreter(DefaultCtx, mode; world)
 end
 
 """

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -52,7 +52,7 @@ Returns a function which performs forward-mode AD for `sig_or_mi`. Will derive a
 
 Set `skip_world_age_check=true` when the interpreter's world age is intentionally older
 than the current world (e.g. when building rules for a MistyClosure, which uses its own
-world, or when a Lazy/Dynamic rule rebuilds at its stored prediction world; see issue #1209).
+world, or when a Lazy/Dynamic rule rebuilds at its stored prediction world; see issue #1218).
 """
 function build_frule(
     interp::MooncakeInterpreter{C},
@@ -553,8 +553,8 @@ end
 
 # Build at the world `Trule` was predicted at, not the current world: a world advance since
 # prediction can re-tighten `mi`'s inferred return type, yielding a rule that no longer
-# matches `Trule` and fails to `convert` on assignment below. Handles the world-advance
-# trigger of issue #1209 (not the inference-complexity-widening case in its headline MWE).
+# matches `Trule` and fails to `convert` on assignment below. Fixes the world-advance bug
+# #1218 (not the inference-complexity-widening case in #1209's headline MWE).
 @noinline function _build_rule!(rule::LazyFRule{sig,Trule}, args) where {sig,Trule}
     interp = get_interpreter(ForwardMode, rule.world)
     rule.rule = build_frule(
@@ -609,7 +609,7 @@ function (dynamic_rule::DynamicFRule)(args::Vararg{Dual,N}) where {N}
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
         # Build at the world this rule was created at (matching the enclosing rule), not the
-        # current world. See _build_rule! and issue #1209.
+        # current world. See _build_rule! and issue #1218.
         interp = get_interpreter(ForwardMode, dynamic_rule.world)
         rule = build_frule(
             interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -53,7 +53,6 @@ Returns a function which performs forward-mode AD for `sig_or_mi`. Will derive a
 Set `skip_world_age_check=true` when the interpreter's world age is intentionally older
 than the current world (e.g. when building rules for a MistyClosure, which uses its own
 world, or when a Lazy/Dynamic rule rebuilds at its stored prediction world; see issue #1209).
-Otherwise the check guards general callers against passing a stale interpreter.
 """
 function build_frule(
     interp::MooncakeInterpreter{C},

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -51,7 +51,9 @@ Returns a function which performs forward-mode AD for `sig_or_mi`. Will derive a
 `sig_or_mi` is not a primitive.
 
 Set `skip_world_age_check=true` when the interpreter's world age is intentionally older
-than the current world (e.g., when building rules for MistyClosure which uses its own world).
+than the current world (e.g. when building rules for a MistyClosure, which uses its own
+world, or when a Lazy/Dynamic rule rebuilds at its stored prediction world; see issue #1209).
+Otherwise the check guards general callers against passing a stale interpreter.
 """
 function build_frule(
     interp::MooncakeInterpreter{C},
@@ -507,20 +509,23 @@ end
 mutable struct LazyFRule{primal_sig,Trule}
     debug_mode::Bool
     mi::Core.MethodInstance
+    world::UInt
     rule::Trule
     function LazyFRule(mi::Core.MethodInstance, debug_mode::Bool)
         interp = get_interpreter(ForwardMode)
-        return new{mi.specTypes,frule_type(interp, mi;debug_mode)}(debug_mode, mi)
+        return new{mi.specTypes,frule_type(interp, mi;debug_mode)}(
+            debug_mode, mi, interp.world
+        )
     end
     function LazyFRule{Tprimal_sig,Trule}(
-        mi::Core.MethodInstance, debug_mode::Bool
+        mi::Core.MethodInstance, debug_mode::Bool, world::UInt
     ) where {Tprimal_sig,Trule}
-        return new{Tprimal_sig,Trule}(debug_mode, mi)
+        return new{Tprimal_sig,Trule}(debug_mode, mi, world)
     end
 end
 
-# Create new lazy rule with same method instance and debug mode
-_copy(x::P) where {P<:LazyFRule} = P(x.mi, x.debug_mode)
+# Create new lazy rule with same method instance, debug mode, and prediction world
+_copy(x::P) where {P<:LazyFRule} = P(x.mi, x.debug_mode, x.world)
 
 # On Julia 1.10, the generic __call_rule fallback is @stable-checked and returns Any for
 # LazyFRule, triggering TypeInstabilityError when dispatch_doctor_mode = "error".
@@ -547,9 +552,14 @@ end
     return isdefined(rule, :rule) ? __call_rule(rule.rule, args) : _build_rule!(rule, args)
 end
 
+# Build at the world `Trule` was predicted at, not the current world: a world advance since
+# prediction can re-tighten `mi`'s inferred return type, yielding a rule that no longer
+# matches `Trule` and fails to `convert` on assignment below. See issue #1209.
 @noinline function _build_rule!(rule::LazyFRule{sig,Trule}, args) where {sig,Trule}
-    interp = get_interpreter(ForwardMode)
-    rule.rule = build_frule(interp, rule.mi; debug_mode=rule.debug_mode)
+    interp = get_interpreter(ForwardMode; world=rule.world)
+    rule.rule = build_frule(
+        interp, rule.mi; debug_mode=rule.debug_mode, skip_world_age_check=true
+    )
     return __call_rule(rule.rule, args)
 end
 
@@ -582,12 +592,15 @@ end
 struct DynamicFRule{V}
     cache::V
     debug_mode::Bool
+    world::UInt
 end
 
-DynamicFRule(debug_mode::Bool) = DynamicFRule(Dict{Any,Any}(), debug_mode)
+function DynamicFRule(debug_mode::Bool)
+    return DynamicFRule(Dict{Any,Any}(), debug_mode, get_interpreter(ForwardMode).world)
+end
 
-# Create new dynamic rule with empty cache and same debug mode  
-_copy(x::P) where {P<:DynamicFRule} = P(Dict{Any,Any}(), x.debug_mode)
+# Create new dynamic rule with empty cache and same debug mode and build world
+_copy(x::P) where {P<:DynamicFRule} = P(Dict{Any,Any}(), x.debug_mode, x.world)
 
 function (dynamic_rule::DynamicFRule)(args::Vararg{Dual,N}) where {N}
     # `Base._stable_typeof` must be used here, rather than `typeof` or `Mooncake._typeof`.
@@ -595,8 +608,12 @@ function (dynamic_rule::DynamicFRule)(args::Vararg{Dual,N}) where {N}
     sig = Tuple{map(Base._stable_typeof ∘ primal, args)...}
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
-        interp = get_interpreter(ForwardMode)
-        rule = build_frule(interp, sig; debug_mode=dynamic_rule.debug_mode)
+        # Build at the world this rule was created at (matching the enclosing rule), not the
+        # current world. See _build_rule! and issue #1209.
+        interp = get_interpreter(ForwardMode; world=dynamic_rule.world)
+        rule = build_frule(
+            interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true
+        )
         dynamic_rule.cache[sig] = rule
     end
     return __call_rule(rule, args)

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -556,7 +556,7 @@ end
 # prediction can re-tighten `mi`'s inferred return type, yielding a rule that no longer
 # matches `Trule` and fails to `convert` on assignment below. See issue #1209.
 @noinline function _build_rule!(rule::LazyFRule{sig,Trule}, args) where {sig,Trule}
-    interp = get_interpreter(ForwardMode; world=rule.world)
+    interp = get_interpreter(ForwardMode, rule.world)
     rule.rule = build_frule(
         interp, rule.mi; debug_mode=rule.debug_mode, skip_world_age_check=true
     )
@@ -610,7 +610,7 @@ function (dynamic_rule::DynamicFRule)(args::Vararg{Dual,N}) where {N}
     if rule === nothing
         # Build at the world this rule was created at (matching the enclosing rule), not the
         # current world. See _build_rule! and issue #1209.
-        interp = get_interpreter(ForwardMode; world=dynamic_rule.world)
+        interp = get_interpreter(ForwardMode, dynamic_rule.world)
         rule = build_frule(
             interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true
         )

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -554,7 +554,8 @@ end
 
 # Build at the world `Trule` was predicted at, not the current world: a world advance since
 # prediction can re-tighten `mi`'s inferred return type, yielding a rule that no longer
-# matches `Trule` and fails to `convert` on assignment below. See issue #1209.
+# matches `Trule` and fails to `convert` on assignment below. Handles the world-advance
+# trigger of issue #1209 (not the inference-complexity-widening case in its headline MWE).
 @noinline function _build_rule!(rule::LazyFRule{sig,Trule}, args) where {sig,Trule}
     interp = get_interpreter(ForwardMode, rule.world)
     rule.rule = build_frule(

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1182,7 +1182,7 @@ If `debug_mode` is `true`, then all calls to rules are replaced with calls to `D
 
 Set `skip_world_age_check=true` when the interpreter's world age is intentionally older than
 the current world (e.g. when a Lazy/Dynamic rule rebuilds at its stored prediction world; see
-issue #1209).
+issue #1218).
 """
 function build_rrule(
     interp::MooncakeInterpreter{C},
@@ -1959,7 +1959,7 @@ function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
         # Build at the world this rule was created at (matching the enclosing rule), not the
-        # current world. See _build_rule! and issue #1209.
+        # current world. See _build_rule! and issue #1218.
         interp = get_interpreter(ReverseMode, dynamic_rule.world)
         rule = build_rrule(
             interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true
@@ -2079,7 +2079,7 @@ end
 end
 
 # Build at the world `Trule` was predicted at, not the current world. See the LazyFRule
-# analogue in forward_mode.jl and the world-advance trigger of issue #1209.
+# analogue in forward_mode.jl and the world-advance bug #1218.
 @noinline function _build_rule!(rule::LazyDerivedRule{sig,Trule}, args) where {sig,Trule}
     interp = get_interpreter(ReverseMode, rule.world)
     rule.rule = build_rrule(

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1182,7 +1182,7 @@ If `debug_mode` is `true`, then all calls to rules are replaced with calls to `D
 
 Set `skip_world_age_check=true` when the interpreter's world age is intentionally older than
 the current world (e.g. when a Lazy/Dynamic rule rebuilds at its stored prediction world; see
-issue #1209). Otherwise the check guards general callers against passing a stale interpreter.
+issue #1209).
 """
 function build_rrule(
     interp::MooncakeInterpreter{C},

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -2079,7 +2079,7 @@ end
 end
 
 # Build at the world `Trule` was predicted at, not the current world. See the LazyFRule
-# analogue in forward_mode.jl and issue #1209.
+# analogue in forward_mode.jl and the world-advance trigger of issue #1209.
 @noinline function _build_rule!(rule::LazyDerivedRule{sig,Trule}, args) where {sig,Trule}
     interp = get_interpreter(ReverseMode, rule.world)
     rule.rule = build_rrule(

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1960,7 +1960,7 @@ function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
     if rule === nothing
         # Build at the world this rule was created at (matching the enclosing rule), not the
         # current world. See _build_rule! and issue #1209.
-        interp = get_interpreter(ReverseMode; world=dynamic_rule.world)
+        interp = get_interpreter(ReverseMode, dynamic_rule.world)
         rule = build_rrule(
             interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true
         )
@@ -2081,7 +2081,7 @@ end
 # Build at the world `Trule` was predicted at, not the current world. See the LazyFRule
 # analogue in forward_mode.jl and issue #1209.
 @noinline function _build_rule!(rule::LazyDerivedRule{sig,Trule}, args) where {sig,Trule}
-    interp = get_interpreter(ReverseMode; world=rule.world)
+    interp = get_interpreter(ReverseMode, rule.world)
     rule.rule = build_rrule(
         interp, rule.mi; debug_mode=rule.debug_mode, skip_world_age_check=true
     )

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1179,13 +1179,23 @@ Returns a `DerivedRule` which is an `rrule!!` for `sig_or_mi` in context `C`. Se
 docstring for `rrule!!` for more info.
 
 If `debug_mode` is `true`, then all calls to rules are replaced with calls to `DebugRRule`s.
+
+Set `skip_world_age_check=true` when the interpreter's world age is intentionally older than
+the current world (e.g. when a Lazy/Dynamic rule rebuilds at its stored prediction world; see
+issue #1209). Otherwise the check guards general callers against passing a stale interpreter.
 """
 function build_rrule(
-    interp::MooncakeInterpreter{C}, sig_or_mi; debug_mode=false, silence_debug_messages=true
+    interp::MooncakeInterpreter{C},
+    sig_or_mi;
+    debug_mode=false,
+    silence_debug_messages=true,
+    skip_world_age_check=false,
 ) where {C}
     @nospecialize sig_or_mi
 
-    build_rrule_checks(interp, sig_or_mi, debug_mode, silence_debug_messages)
+    build_rrule_checks(
+        interp, sig_or_mi, debug_mode, silence_debug_messages, skip_world_age_check
+    )
 
     # If we have a hand-coded rule, just use that.
     sig = _get_sig(sig_or_mi)
@@ -1199,13 +1209,17 @@ end
 
 # Separated out so we can make an frule!! for it, for forward-over-reverse.
 function build_rrule_checks(
-    interp::MooncakeInterpreter, sig_or_mi, debug_mode::Bool, silence_debug_messages::Bool
+    interp::MooncakeInterpreter,
+    sig_or_mi,
+    debug_mode::Bool,
+    silence_debug_messages::Bool,
+    skip_world_age_check::Bool=false,
 )
     @nospecialize sig_or_mi
 
     # To avoid segfaults, ensure that we bail out if the interpreter's world age is greater
     # than the current world age.
-    if Base.get_world_counter() > interp.world
+    if !skip_world_age_check && Base.get_world_counter() > interp.world
         throw(
             ArgumentError(
                 "World age associated to interp is behind current world age. Please " *
@@ -1921,12 +1935,17 @@ This is used to implement dynamic dispatch.
 struct DynamicDerivedRule{V}
     cache::V
     debug_mode::Bool
+    world::UInt
 end
 
-DynamicDerivedRule(debug_mode::Bool) = DynamicDerivedRule(Dict{Any,Any}(), debug_mode)
+function DynamicDerivedRule(debug_mode::Bool)
+    return DynamicDerivedRule(
+        Dict{Any,Any}(), debug_mode, get_interpreter(ReverseMode).world
+    )
+end
 
-# Create new dynamic rule with empty cache and same debug mode
-_copy(x::P) where {P<:DynamicDerivedRule} = P(Dict{Any,Any}(), x.debug_mode)
+# Create new dynamic rule with empty cache and same debug mode and build world
+_copy(x::P) where {P<:DynamicDerivedRule} = P(Dict{Any,Any}(), x.debug_mode, x.world)
 
 function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
 
@@ -1939,8 +1958,12 @@ function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
 
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
-        interp = get_interpreter(ReverseMode)
-        rule = build_rrule(interp, sig; debug_mode=dynamic_rule.debug_mode)
+        # Build at the world this rule was created at (matching the enclosing rule), not the
+        # current world. See _build_rule! and issue #1209.
+        interp = get_interpreter(ReverseMode; world=dynamic_rule.world)
+        rule = build_rrule(
+            interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true
+        )
         dynamic_rule.cache[sig] = rule
     end
     return __call_rule(rule, args)
@@ -2011,20 +2034,23 @@ the rule for A, we would be unable to complete the derivation of the rule for A.
 mutable struct LazyDerivedRule{primal_sig,Trule}
     debug_mode::Bool
     mi::Core.MethodInstance
+    world::UInt
     rule::Trule
     function LazyDerivedRule(mi::Core.MethodInstance, debug_mode::Bool)
         interp = get_interpreter(ReverseMode)
-        return new{mi.specTypes,rule_type(interp, mi;debug_mode)}(debug_mode, mi)
+        return new{mi.specTypes,rule_type(interp, mi;debug_mode)}(
+            debug_mode, mi, interp.world
+        )
     end
     function LazyDerivedRule{Tprimal_sig,Trule}(
-        mi::Core.MethodInstance, debug_mode::Bool
+        mi::Core.MethodInstance, debug_mode::Bool, world::UInt
     ) where {Tprimal_sig,Trule}
-        return new{Tprimal_sig,Trule}(debug_mode, mi)
+        return new{Tprimal_sig,Trule}(debug_mode, mi, world)
     end
 end
 
-# Create new lazy rule with same method instance and debug mode
-_copy(x::P) where {P<:LazyDerivedRule} = P(x.mi, x.debug_mode)
+# Create new lazy rule with same method instance, debug mode, and prediction world
+_copy(x::P) where {P<:LazyDerivedRule} = P(x.mi, x.debug_mode, x.world)
 
 # On Julia 1.10, the generic __call_rule fallback is @stable-checked and returns Any for
 # LazyDerivedRule, triggering TypeInstabilityError when dispatch_doctor_mode = "error".
@@ -2052,9 +2078,13 @@ end
     return isdefined(rule, :rule) ? __call_rule(rule.rule, args) : _build_rule!(rule, args)
 end
 
+# Build at the world `Trule` was predicted at, not the current world. See the LazyFRule
+# analogue in forward_mode.jl and issue #1209.
 @noinline function _build_rule!(rule::LazyDerivedRule{sig,Trule}, args) where {sig,Trule}
-    interp = get_interpreter(ReverseMode)
-    rule.rule = build_rrule(interp, rule.mi; debug_mode=rule.debug_mode)
+    interp = get_interpreter(ReverseMode; world=rule.world)
+    rule.rule = build_rrule(
+        interp, rule.mi; debug_mode=rule.debug_mode, skip_world_age_check=true
+    )
     return __call_rule(rule.rule, args)
 end
 

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -1,6 +1,6 @@
 @zero_derivative MinimalCtx Tuple{typeof(get_interpreter),Type{<:Mode}}
 @zero_derivative MinimalCtx Tuple{
-    typeof(build_rrule_checks),MooncakeInterpreter,Any,Bool,Bool
+    typeof(build_rrule_checks),MooncakeInterpreter,Any,Bool,Bool,Bool
 }
 @zero_derivative MinimalCtx Tuple{typeof(is_primitive),Type,Type{<:Mode},Type,UInt}
 

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -1,4 +1,5 @@
 @zero_derivative MinimalCtx Tuple{typeof(get_interpreter),Type{<:Mode}}
+@zero_derivative MinimalCtx Tuple{typeof(get_interpreter),Type{<:Mode},UInt}
 @zero_derivative MinimalCtx Tuple{
     typeof(build_rrule_checks),MooncakeInterpreter,Any,Bool,Bool,Bool
 }

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -11,15 +11,15 @@ function foo(x)
     return y
 end
 
-# Helpers for the world-advance rule-staleness regression test (one trigger from issue #1209;
-# see `_build_rule!` in forward_mode.jl for the scope caveat). Defining `issue1209_inner(::Float64)`
-# later tightens `issue1209_callee`'s return type Float32->Float64 via a mid-pass world advance.
-# `issue1209_lazy` reaches the callee statically (LazyFRule), `issue1209_dyn` dynamically (DynamicFRule).
-issue1209_inner(x) = Float32(x) * 2.0f0
-@noinline issue1209_callee(x) = issue1209_inner(x)
-issue1209_lazy(x) = issue1209_callee(x)
-const ISSUE1209_FNS = Function[issue1209_callee]
-issue1209_dyn(x) = (ISSUE1209_FNS[1])(x)
+# Helpers for the world-advance rule-staleness regression test (issue #1218;
+# see `_build_rule!` in forward_mode.jl for the scope caveat). Defining `stale_fwd_inner(::Float64)`
+# later tightens `stale_fwd_callee`'s return type Float32->Float64 via a mid-pass world advance.
+# `stale_fwd_lazy` reaches the callee statically (LazyFRule), `stale_fwd_dyn` dynamically (DynamicFRule).
+stale_fwd_inner(x) = Float32(x) * 2.0f0
+@noinline stale_fwd_callee(x) = stale_fwd_inner(x)
+stale_fwd_lazy(x) = stale_fwd_callee(x)
+const STALE_FWD_FNS = Function[stale_fwd_callee]
+stale_fwd_dyn(x) = (STALE_FWD_FNS[1])(x)
 
 @testset "s2s_forward_mode_ad" begin
     test_cases = collect(enumerate(TestResources.generate_test_functions()))
@@ -65,15 +65,15 @@ issue1209_dyn(x) = (ISSUE1209_FNS[1])(x)
     # Without the fix the lazy path throws a `convert` MethodError in _build_rule! after the
     # world advance; both lazy and dynamic must return the build-world result (Float32), not
     # the post-advance world's (Float64).
-    @testset "stale rule build-world after world advance (issue #1209 trigger)" begin
-        lazy = Mooncake.build_frule(issue1209_lazy, 1.5)
-        dyn = Mooncake.build_frule(issue1209_dyn, 1.5)
-        @eval issue1209_inner(x::Float64) = x * 2.0  # advance world; tightens callee's type
+    @testset "stale rule build-world after world advance (issue #1218)" begin
+        lazy = Mooncake.build_frule(stale_fwd_lazy, 1.5)
+        dyn = Mooncake.build_frule(stale_fwd_dyn, 1.5)
+        @eval stale_fwd_inner(x::Float64) = x * 2.0  # advance world; tightens callee's type
         lazy_out = Base.invokelatest(
-            lazy, Mooncake.zero_dual(issue1209_lazy), Mooncake.Dual(1.5, 1.0)
+            lazy, Mooncake.zero_dual(stale_fwd_lazy), Mooncake.Dual(1.5, 1.0)
         )
         dyn_out = Base.invokelatest(
-            dyn, Mooncake.zero_dual(issue1209_dyn), Mooncake.Dual(1.5, 1.0)
+            dyn, Mooncake.zero_dual(stale_fwd_dyn), Mooncake.Dual(1.5, 1.0)
         )
         @test Mooncake.primal(lazy_out) === 3.0f0
         @test Mooncake.primal(dyn_out) === 3.0f0

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -11,13 +11,10 @@ function foo(x)
     return y
 end
 
-# Helpers for the world-advance rule-staleness regression test (one trigger from issue
-# #1209). Defining `issue1209_inner(::Float64)` later tightens `issue1209_callee`'s return
-# type Float32->Float64 via a mid-pass world advance. `issue1209_lazy` reaches the callee
-# statically (LazyFRule), `issue1209_dyn` dynamically (DynamicFRule). NOTE: this covers only
-# the world-advance trigger; the issue's headline MWE, where `frule_type` widens the
-# predicted return type by inference type-complexity (not a world advance), is a distinct
-# failure mode that this fix does not address.
+# Helpers for the world-advance rule-staleness regression test (one trigger from issue #1209;
+# see `_build_rule!` in forward_mode.jl for the scope caveat). Defining `issue1209_inner(::Float64)`
+# later tightens `issue1209_callee`'s return type Float32->Float64 via a mid-pass world advance.
+# `issue1209_lazy` reaches the callee statically (LazyFRule), `issue1209_dyn` dynamically (DynamicFRule).
 issue1209_inner(x) = Float32(x) * 2.0f0
 @noinline issue1209_callee(x) = issue1209_inner(x)
 issue1209_lazy(x) = issue1209_callee(x)

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -11,6 +11,16 @@ function foo(x)
     return y
 end
 
+# Helpers for the issue #1209 regression test. Defining `issue1209_inner(::Float64)` later
+# tightens `issue1209_callee`'s return type Float32->Float64, mimicking a mid-pass world
+# advance. `issue1209_lazy` reaches the callee statically (LazyFRule), `issue1209_dyn`
+# dynamically (DynamicFRule).
+issue1209_inner(x) = Float32(x) * 2.0f0
+@noinline issue1209_callee(x) = issue1209_inner(x)
+issue1209_lazy(x) = issue1209_callee(x)
+const ISSUE1209_FNS = Function[issue1209_callee]
+issue1209_dyn(x) = (ISSUE1209_FNS[1])(x)
+
 @testset "s2s_forward_mode_ad" begin
     test_cases = collect(enumerate(TestResources.generate_test_functions()))
     @testset "$n - $(_typeof((fx)))" for (n, (int_only, pf, _, fx...)) in test_cases
@@ -50,5 +60,22 @@ end
         TestUtils.test_rule(
             StableRNG(123), f, 1.0; perf_flag=:none, is_primitive=false, mode=ForwardMode
         )
+    end
+
+    # Without the fix the lazy path throws a `convert` MethodError in _build_rule! after the
+    # world advance; both lazy and dynamic must return the build-world result (Float32), not
+    # the post-advance world's (Float64).
+    @testset "stale rule world (issue #1209)" begin
+        lazy = Mooncake.build_frule(issue1209_lazy, 1.5)
+        dyn = Mooncake.build_frule(issue1209_dyn, 1.5)
+        @eval issue1209_inner(x::Float64) = x * 2.0  # advance world; tightens callee's type
+        lazy_out = Base.invokelatest(
+            lazy, Mooncake.zero_dual(issue1209_lazy), Mooncake.Dual(1.5, 1.0)
+        )
+        dyn_out = Base.invokelatest(
+            dyn, Mooncake.zero_dual(issue1209_dyn), Mooncake.Dual(1.5, 1.0)
+        )
+        @test Mooncake.primal(lazy_out) === 3.0f0
+        @test Mooncake.primal(dyn_out) === 3.0f0
     end
 end;

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -11,10 +11,13 @@ function foo(x)
     return y
 end
 
-# Helpers for the issue #1209 regression test. Defining `issue1209_inner(::Float64)` later
-# tightens `issue1209_callee`'s return type Float32->Float64, mimicking a mid-pass world
-# advance. `issue1209_lazy` reaches the callee statically (LazyFRule), `issue1209_dyn`
-# dynamically (DynamicFRule).
+# Helpers for the world-advance rule-staleness regression test (one trigger from issue
+# #1209). Defining `issue1209_inner(::Float64)` later tightens `issue1209_callee`'s return
+# type Float32->Float64 via a mid-pass world advance. `issue1209_lazy` reaches the callee
+# statically (LazyFRule), `issue1209_dyn` dynamically (DynamicFRule). NOTE: this covers only
+# the world-advance trigger; the issue's headline MWE, where `frule_type` widens the
+# predicted return type by inference type-complexity (not a world advance), is a distinct
+# failure mode that this fix does not address.
 issue1209_inner(x) = Float32(x) * 2.0f0
 @noinline issue1209_callee(x) = issue1209_inner(x)
 issue1209_lazy(x) = issue1209_callee(x)
@@ -65,7 +68,7 @@ issue1209_dyn(x) = (ISSUE1209_FNS[1])(x)
     # Without the fix the lazy path throws a `convert` MethodError in _build_rule! after the
     # world advance; both lazy and dynamic must return the build-world result (Float32), not
     # the post-advance world's (Float64).
-    @testset "stale rule world (issue #1209)" begin
+    @testset "stale rule build-world after world advance (issue #1209 trigger)" begin
         lazy = Mooncake.build_frule(issue1209_lazy, 1.5)
         dyn = Mooncake.build_frule(issue1209_dyn, 1.5)
         @eval issue1209_inner(x::Float64) = x * 2.0  # advance world; tightens callee's type

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -24,6 +24,15 @@ end
 # (PR #1099).
 rule_type_nonreturning(e::Exception) = throw(e)
 
+# Helpers for the issue #1209 regression test (reverse mode); see the forward-mode analogue.
+# `issue1209r_lazy` reaches the callee statically (LazyDerivedRule), `issue1209r_dyn`
+# dynamically (DynamicDerivedRule).
+issue1209r_inner(x) = Float32(x) * 2.0f0
+@noinline issue1209r_callee(x) = issue1209r_inner(x)
+issue1209r_lazy(x) = issue1209r_callee(x)
+const ISSUE1209R_FNS = Function[issue1209r_callee]
+issue1209r_dyn(x) = (ISSUE1209R_FNS[1])(x)
+
 @testset "s2s_reverse_mode_ad" begin
     @testset "SharedDataPairs" begin
         m = SharedDataPairs()
@@ -507,5 +516,22 @@ rule_type_nonreturning(e::Exception) = throw(e)
         @test rule_debug_sig isa Mooncake.DebugRRule
         rule_debug_args = build_rrule(args...; debug_mode=true, silence_debug_messages=true)
         @test rule_debug_args == rule_debug_sig
+    end
+
+    # Without the fix the lazy path throws a `convert` MethodError in _build_rule! after the
+    # world advance; both lazy and dynamic must return the build-world result (Float32), not
+    # the post-advance world's (Float64).
+    @testset "stale rule world (issue #1209)" begin
+        lazy = Mooncake.build_rrule(issue1209r_lazy, 1.5)
+        dyn = Mooncake.build_rrule(issue1209r_dyn, 1.5)
+        @eval issue1209r_inner(x::Float64) = x * 2.0  # advance world; tightens callee's type
+        lazy_y, _ = Base.invokelatest(
+            lazy, Mooncake.zero_fcodual(issue1209r_lazy), Mooncake.zero_fcodual(1.5)
+        )
+        dyn_y, _ = Base.invokelatest(
+            dyn, Mooncake.zero_fcodual(issue1209r_dyn), Mooncake.zero_fcodual(1.5)
+        )
+        @test Mooncake.primal(lazy_y) === 3.0f0
+        @test Mooncake.primal(dyn_y) === 3.0f0
     end
 end

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -24,9 +24,9 @@ end
 # (PR #1099).
 rule_type_nonreturning(e::Exception) = throw(e)
 
-# Helpers for the issue #1209 regression test (reverse mode); see the forward-mode analogue.
-# `issue1209r_lazy` reaches the callee statically (LazyDerivedRule), `issue1209r_dyn`
-# dynamically (DynamicDerivedRule).
+# Helpers for the world-advance rule-staleness regression test (reverse mode); see the
+# forward-mode analogue for the scope note. `issue1209r_lazy` reaches the callee statically
+# (LazyDerivedRule), `issue1209r_dyn` dynamically (DynamicDerivedRule).
 issue1209r_inner(x) = Float32(x) * 2.0f0
 @noinline issue1209r_callee(x) = issue1209r_inner(x)
 issue1209r_lazy(x) = issue1209r_callee(x)
@@ -521,7 +521,7 @@ issue1209r_dyn(x) = (ISSUE1209R_FNS[1])(x)
     # Without the fix the lazy path throws a `convert` MethodError in _build_rule! after the
     # world advance; both lazy and dynamic must return the build-world result (Float32), not
     # the post-advance world's (Float64).
-    @testset "stale rule world (issue #1209)" begin
+    @testset "stale rule build-world after world advance (issue #1209 trigger)" begin
         lazy = Mooncake.build_rrule(issue1209r_lazy, 1.5)
         dyn = Mooncake.build_rrule(issue1209r_dyn, 1.5)
         @eval issue1209r_inner(x::Float64) = x * 2.0  # advance world; tightens callee's type

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -25,13 +25,13 @@ end
 rule_type_nonreturning(e::Exception) = throw(e)
 
 # Helpers for the world-advance rule-staleness regression test (reverse mode); see the
-# forward-mode analogue for the scope note. `issue1209r_lazy` reaches the callee statically
-# (LazyDerivedRule), `issue1209r_dyn` dynamically (DynamicDerivedRule).
-issue1209r_inner(x) = Float32(x) * 2.0f0
-@noinline issue1209r_callee(x) = issue1209r_inner(x)
-issue1209r_lazy(x) = issue1209r_callee(x)
-const ISSUE1209R_FNS = Function[issue1209r_callee]
-issue1209r_dyn(x) = (ISSUE1209R_FNS[1])(x)
+# forward-mode analogue for the scope note. `stale_rvs_lazy` reaches the callee statically
+# (LazyDerivedRule), `stale_rvs_dyn` dynamically (DynamicDerivedRule).
+stale_rvs_inner(x) = Float32(x) * 2.0f0
+@noinline stale_rvs_callee(x) = stale_rvs_inner(x)
+stale_rvs_lazy(x) = stale_rvs_callee(x)
+const STALE_RVS_FNS = Function[stale_rvs_callee]
+stale_rvs_dyn(x) = (STALE_RVS_FNS[1])(x)
 
 @testset "s2s_reverse_mode_ad" begin
     @testset "SharedDataPairs" begin
@@ -521,15 +521,15 @@ issue1209r_dyn(x) = (ISSUE1209R_FNS[1])(x)
     # Without the fix the lazy path throws a `convert` MethodError in _build_rule! after the
     # world advance; both lazy and dynamic must return the build-world result (Float32), not
     # the post-advance world's (Float64).
-    @testset "stale rule build-world after world advance (issue #1209 trigger)" begin
-        lazy = Mooncake.build_rrule(issue1209r_lazy, 1.5)
-        dyn = Mooncake.build_rrule(issue1209r_dyn, 1.5)
-        @eval issue1209r_inner(x::Float64) = x * 2.0  # advance world; tightens callee's type
+    @testset "stale rule build-world after world advance (issue #1218)" begin
+        lazy = Mooncake.build_rrule(stale_rvs_lazy, 1.5)
+        dyn = Mooncake.build_rrule(stale_rvs_dyn, 1.5)
+        @eval stale_rvs_inner(x::Float64) = x * 2.0  # advance world; tightens callee's type
         lazy_y, _ = Base.invokelatest(
-            lazy, Mooncake.zero_fcodual(issue1209r_lazy), Mooncake.zero_fcodual(1.5)
+            lazy, Mooncake.zero_fcodual(stale_rvs_lazy), Mooncake.zero_fcodual(1.5)
         )
         dyn_y, _ = Base.invokelatest(
-            dyn, Mooncake.zero_fcodual(issue1209r_dyn), Mooncake.zero_fcodual(1.5)
+            dyn, Mooncake.zero_fcodual(stale_rvs_dyn), Mooncake.zero_fcodual(1.5)
         )
         @test Mooncake.primal(lazy_y) === 3.0f0
         @test Mooncake.primal(dyn_y) === 3.0f0


### PR DESCRIPTION
Fixes #1218.

`LazyFRule` / `DynamicFRule` / `LazyDerivedRule` / `DynamicDerivedRule` predict their rule type
in the enclosing rule's derivation world but rebuilt it lazily in the *current* world. A mid-pass
world advance can re-tighten the callee's inferred return type, so the rebuilt rule no longer
matches the predicted `Trule` and `setfield!` fails to `convert` (Lazy), or the Dynamic rebuild
silently reflects the post-advance world. Pin the rebuild to the prediction world (stored per
rule) via `get_interpreter(mode, world)` + `skip_world_age_check`, for all four rule types in
forward and reverse mode. Includes a `@zero_derivative` for the new two-arg `get_interpreter`.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1213 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1213/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 181.0 ns │     1.55 │        1.61 │   0.718 │        3.49 │   6.97 │
│             _sum_1000 │  1.09 μs │      6.2 │        1.04 │  1560.0 │        35.3 │   1.07 │
│          sum_sin_1000 │  7.43 μs │      2.6 │        1.11 │    1.65 │        11.1 │   1.71 │
│         _sum_sin_1000 │  4.69 μs │     3.74 │         2.6 │   324.0 │        17.3 │   3.04 │
│              kron_sum │ 198.0 μs │     13.1 │        3.28 │    10.7 │       503.0 │   14.6 │
│         kron_view_sum │ 261.0 μs │     12.8 │        5.32 │    24.1 │       435.0 │   10.4 │
│ naive_map_sin_cos_exp │  2.21 μs │     2.83 │        1.53 │ missing │        8.73 │   2.16 │
│       map_sin_cos_exp │  2.23 μs │     3.35 │        1.63 │    1.52 │        7.33 │   2.68 │
│ broadcast_sin_cos_exp │  2.22 μs │      3.1 │        1.57 │    4.52 │        1.46 │   2.17 │
│            simple_mlp │ 340.0 μs │     5.23 │        2.94 │    1.66 │        10.7 │   3.25 │
│                gp_lml │ 369.0 μs │     5.99 │        1.72 │    2.88 │     missing │   3.22 │
│    large_single_block │ 471.0 ns │     5.57 │        1.96 │  4040.0 │        32.2 │   2.08 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->

