### PR TITLE
Update HISTORY.md for 0.5.32 and backfill 0.5.27-0.5.31

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,39 @@
+# 0.5.32
+
+- Fix forward-over-reverse Hessian-vector products on closures that capture a `Ref` wrapped in a `NoTangent`-typed aggregate, which previously threw `UndefRefError`. `prepare_hvp_cache` now eagerly compiles the inner `rrule!!` together with its forward-mode dual callables and routes the outer forward pass through a new `DerivedFoRRule`, so the inner `IdDict` constructor is no longer inlined past Mooncake's rule ([#1193](https://github.com/chalk-lab/Mooncake.jl/pull/1193), [#1202](https://github.com/chalk-lab/Mooncake.jl/pull/1202)).
+- Fix the gradient of `copysign(x, y)` with respect to `x`: the derivative is `sign(x) * sign(y)`, and the missing `sign(x)` factor previously gave the wrong gradient sign when `x < 0` ([#1196](https://github.com/chalk-lab/Mooncake.jl/pull/1196)).
+- Handle mutation of non-`const` globals (`setglobal!`) in forward mode on Julia 1.12+ ([#1194](https://github.com/chalk-lab/Mooncake.jl/pull/1194)).
+- Version-bound the `Core._call_latest(CoreLogging.handle_message, ...)` rule (and its keyword-argument variant) to Julia below 1.12 ([#1200](https://github.com/chalk-lab/Mooncake.jl/pull/1200)).
+
+# 0.5.31
+
+- Guard `codual_type` / `fcodual_type` against unbound `TypeVar`s ([#1191](https://github.com/chalk-lab/Mooncake.jl/pull/1191), [#1192](https://github.com/chalk-lab/Mooncake.jl/pull/1192)).
+
+# 0.5.30
+
+- Bump the `LogExpFunctions` compat bound to 1 ([#1186](https://github.com/chalk-lab/Mooncake.jl/pull/1186)).
+
+# 0.5.29
+
+- Add a `max_fd_step` keyword to `TestUtils.test_rule` that caps the finite-difference step sizes, keeping perturbations of domain-restricted functions (`log`, `sqrt`, `cholesky`) inside their domains ([#1173](https://github.com/chalk-lab/Mooncake.jl/pull/1173)).
+- Pre-allocate and reuse the Hessian, gradient, and basis-direction buffers in the Hessian cache so that repeated `value_gradient_and_hessian!!` calls avoid allocation ([#1178](https://github.com/chalk-lab/Mooncake.jl/pull/1178)).
+- Add consistency checks for rule reuse ([#1172](https://github.com/chalk-lab/Mooncake.jl/pull/1172)).
+- Mark `CUDACore.cudaError_enum` as having no tangent ([#1175](https://github.com/chalk-lab/Mooncake.jl/pull/1175)).
+
+# 0.5.28
+
+- Throw a clear `UnhandledLanguageFeatureException` for `try` / `catch` blocks in reverse-mode AD instead of an opaque IR-verification failure ([#1161](https://github.com/chalk-lab/Mooncake.jl/pull/1161)).
+- Import the ChainRules `svd` rule via `@from_rrule` ([#1163](https://github.com/chalk-lab/Mooncake.jl/pull/1163), closes [#670](https://github.com/chalk-lab/Mooncake.jl/issues/670)).
+- Guard the `friendly_tangent_cache` array branch against `NoTangent` element types (e.g. `SparseMatrixCSC{Int}`) ([#1150](https://github.com/chalk-lab/Mooncake.jl/pull/1150)).
+
+# 0.5.27
+
+- Add a cached `value_and_jacobian!!` interface for both forward-mode (chunked) and reverse-mode (row-by-row) caches ([#1153](https://github.com/chalk-lab/Mooncake.jl/pull/1153)).
+- Fix `tangent_type` for `Union{NoRData, RData{...}}` ([#1133](https://github.com/chalk-lab/Mooncake.jl/pull/1133)).
+- Add foreigncall zero-derivative rules for `jl_get_world_counter` and `jl_matching_methods`, supporting forward-over-reverse over those calls ([#1143](https://github.com/chalk-lab/Mooncake.jl/pull/1143)).
+- Handle `Ptr` in `zero_tangent` by delegating to `uninit_tangent` ([#1139](https://github.com/chalk-lab/Mooncake.jl/pull/1139)).
+- Update the CUDA extension for CUDA + cuDNN 6 ([#1148](https://github.com/chalk-lab/Mooncake.jl/pull/1148)).
+
 # 0.5.26
 
 - Add `Config(empty_cache=true)` to free internal caches before rebuilding rules.


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1214 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1214/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 180.0 ns │     1.56 │        1.62 │   0.667 │        3.23 │   6.23 │
│             _sum_1000 │ 962.0 ns │     7.31 │        1.03 │  3760.0 │        42.7 │   1.07 │
│          sum_sin_1000 │  7.36 μs │     3.48 │        1.33 │    1.47 │        10.7 │   1.69 │
│         _sum_sin_1000 │  5.96 μs │     3.75 │        1.93 │   250.0 │        13.8 │   2.19 │
│              kron_sum │ 235.0 μs │     12.8 │        3.33 │    21.1 │       305.0 │   19.4 │
│         kron_view_sum │ 305.0 μs │     11.5 │        5.02 │    24.2 │       321.0 │   12.2 │
│ naive_map_sin_cos_exp │  2.78 μs │     2.66 │        1.38 │ missing │        6.38 │   1.78 │
│       map_sin_cos_exp │  2.51 μs │     3.37 │        1.57 │    1.37 │        6.19 │   2.46 │
│ broadcast_sin_cos_exp │  2.54 μs │     3.03 │        1.57 │    3.94 │        1.34 │   1.97 │
│            simple_mlp │ 420.0 μs │     4.53 │        2.47 │    1.87 │        8.35 │   2.59 │
│                gp_lml │ 183.0 μs │     11.6 │        2.64 │    5.03 │     missing │   5.87 │
│    large_single_block │ 421.0 ns │     5.33 │         1.9 │  4670.0 │        36.7 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->