### PR TITLE
fix `debuginfo` copy & `line` padding for final `IRCode`.

### DIFF
--- a/docs/src/developer_documentation/ir_representation.md
+++ b/docs/src/developer_documentation/ir_representation.md
@@ -231,7 +231,7 @@ For example, consider
 julia> using Mooncake.BasicBlockCode: ID # to improve printing
 
 julia> bb_ir.blocks[3].insts[1]
-Compiler.NewInstruction(:(Base.add_int(ID(2), 1)), Int64, Compiler.NoCallInfo(), (0, 0, 0), 0x00002478)
+Compiler.NewInstruction(:(Base.add_int(ID(2), 1)), Int64, Compiler.NoCallInfo(), (9, 2, 1), 0x00002478)
 ```
 This is the first instruction of the third basic block.
 The first field is a call to `Base.add_int`, the second field is `Int64` (we promise that the other fields are just copies of the corresponding data from the `Core.Compiler.InstructionStream` in the original `IRCode` representation of this IR).
@@ -319,7 +319,7 @@ The same transformation can be performed on `BBCode`:
 julia> bb_ir_copy = copy(bb_ir);
 
 julia> old_inst = bb_ir_copy.blocks[3].insts[2]
-Compiler.NewInstruction(:(Base.mul_int(ID(1), ID(5))), Int64, Compiler.NoCallInfo(), (3, 0, 0), 0x00002478)
+Compiler.NewInstruction(:(Base.mul_int(ID(1), ID(5))), Int64, Compiler.NoCallInfo(), (13, 3, 1), 0x00002478)
 
 julia> new_stmt = Expr(:call, Base.add_int, old_inst.stmt.args[2:end]...)
 :((Core.Intrinsics.add_int)(ID(1), ID(5)))

--- a/docs/src/developer_documentation/ir_representation.md
+++ b/docs/src/developer_documentation/ir_representation.md
@@ -432,11 +432,11 @@ julia> CC.IRCode(bb_ir_copy)
   │   %3 = φ (#1 => 0, #3 => %7)::Int64
   │   %4 = intrinsic Base.slt_int(%3, _2)::Bool
   └──      goto #4 if not %4
-5 3 ─ %6 = intrinsic (Core.Intrinsics.mul_int)(%3, 2)::Int64
-6 │   %7 = intrinsic Base.add_int(%6, 1)::Int64
-7 │   %8 = intrinsic (Core.Intrinsics.add_int)(%2, %7)::Int64
-8 └──      goto #2
-  4 ─      return %2
+2 3 ─ %6 = intrinsic (Core.Intrinsics.mul_int)(%3, 2)::Int64
+5 │   %7 = intrinsic Base.add_int(%6, 1)::Int64
+6 │   %8 = intrinsic (Core.Intrinsics.add_int)(%2, %7)::Int64
+7 └──      goto #2
+8 4 ─      return %2
 ```
 We see here that `IRCode` and `BBCode` involve similar levels of complexity to insert an instruction.
 
@@ -474,13 +474,13 @@ julia> CC.IRCode(bb_ir_copy)
   │   %3 = φ (#1 => 0, #3 => %7)::Int64
   │   %4 = intrinsic Base.slt_int(%3, _2)::Bool
   └──      goto #5 if not %4
-5 3 ─ %6 = intrinsic (Core.Intrinsics.mul_int)(%3, 2)::Int64
-6 │   %7 = intrinsic Base.add_int(%6, 1)::Int64
-7 │   %8 = intrinsic (Core.Intrinsics.add_int)(%2, %7)::Int64
-8 └──      goto #2
-  4 ─        dynamic (println)(%2)::Any
+2 3 ─ %6 = intrinsic (Core.Intrinsics.mul_int)(%3, 2)::Int64
+5 │   %7 = intrinsic Base.add_int(%6, 1)::Int64
+6 │   %8 = intrinsic (Core.Intrinsics.add_int)(%2, %7)::Int64
+7 └──      goto #2
+2 4 ─        dynamic (println)(%2)::Any
   └──      goto #2
-  5 ─      return %2
+8 5 ─      return %2
 ```
 Observe that, in this case, rather than creating `new_bb` and then inserting instructions into it, we simply create the block _with_ the instructions.
 This programming style is often more convenient.
@@ -513,14 +513,14 @@ julia> new_ir = CC.IRCode(bb_ir_copy)
   │   %3 = φ (#1 => 0, #3 => %7)::Int64
   │   %4 = intrinsic Base.slt_int(%3, _2)::Bool
   └──      goto #5 if not %4
-5 3 ─ %6 = intrinsic (Core.Intrinsics.mul_int)(%3, 2)::Int64
-6 │   %7 = intrinsic Base.add_int(%6, 1)::Int64
-7 │   %8 = intrinsic (Core.Intrinsics.add_int)(%2, %7)::Int64
-8 │   %9 =   dynamic (iseven)(%2)::Any
+2 3 ─ %6 = intrinsic (Core.Intrinsics.mul_int)(%3, 2)::Int64
+5 │   %7 = intrinsic Base.add_int(%6, 1)::Int64
+6 │   %8 = intrinsic (Core.Intrinsics.add_int)(%2, %7)::Int64
+2 │   %9 =   dynamic (iseven)(%2)::Any
   └──      goto #2 if not %9
   4 ─        dynamic (println)(%2)::Any
   └──      goto #2
-  5 ─      return %2
+8 5 ─      return %2
 ```
 Observe that in order to tie the conditional to the goto-if-not, we simply ensure that the `ID` associated to the instruction which computes the conditional appears in the `IDGotoIfNot` instruction.
 

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -571,7 +571,22 @@ Convert an `Compiler.InstructionStream` into a list of `Compiler.NewInstruction`
 """
 function new_inst_vec(x::CC.InstructionStream)
     stmt = @static VERSION < v"1.11.0-rc4" ? x.inst : x.stmt
-    return map((v...,) -> NewInstruction(v...), stmt, x.type, x.info, x.line, x.flag)
+    @static if VERSION > v"1.12-"
+        # In Julia 1.12+, x.line is a flat Vector{Int32} of length 3n (3 codeloc values per
+        # instruction). Extract the proper Tuple{Int32,Int32,Int32} for each instruction.
+        n = length(stmt)
+        return [
+            NewInstruction(
+                stmt[i],
+                x.type[i],
+                x.info[i],
+                (x.line[3i - 2], x.line[3i - 1], x.line[3i]),
+                x.flag[i],
+            ) for i in 1:n
+        ]
+    else
+        return map((v...,) -> NewInstruction(v...), stmt, x.type, x.info, x.line, x.flag)
+    end
 end
 
 # Maps from positional names (SSAValues for nodes, Integers for basic blocks) to IDs.

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -666,15 +666,17 @@ function CC.IRCode(bb_code::BBCode)
     cfg = control_flow_graph(bb_code)
     insts = _lines_to_blocks(insts, cfg)
     @static if VERSION > v"1.12-"
-        lines = CC.copy(bb_code.debuginfo.codelocs)
-        n = length(insts)
-        if length(lines) > 3n
-            resize!(lines, 3n)
-        elseif length(lines) < 3n
-            for _ in (length(lines) + 1):3n
-                push!(lines, 0)
-            end
-        end
+        # Reconstruct codelocs from each instruction's own line field (a Tuple{Int32,Int32,Int32}
+        # in Julia 1.12+). This is now always 3n entries by construction, regardless of how
+        # many instructions were added or removed during BBCode transforms. The old approach of
+        # copying debuginfo.codelocs and resizing was a defensive workaround: instructions added
+        # or removed during transforms don't update codelocs, causing a size mismatch and
+        # misalignment between debug info and line numbers, potentially affecting added, removed,
+        # and already-present instructions depending on where the changes occurred.
+        lines = Int32[v for inst in insts for v in inst.line]
+        debuginfo = CC.copy(bb_code.debuginfo)
+        resize!(debuginfo.codelocs, length(lines))
+        copyto!(debuginfo.codelocs, lines)
         return IRCode(
             CC.InstructionStream(
                 Any[x.stmt for x in insts],
@@ -684,7 +686,7 @@ function CC.IRCode(bb_code::BBCode)
                 UInt32[x.flag for x in insts],
             ),
             cfg,
-            CC.copy(bb_code.debuginfo),
+            debuginfo,
             CC.copy(bb_code.argtypes),
             CC.copy(bb_code.meta),
             CC.copy(bb_code.sptypes),

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -691,8 +691,7 @@ function CC.IRCode(bb_code::BBCode)
         # and already-present instructions depending on where the changes occurred.
         lines = Int32[v for inst in insts for v in inst.line]
         debuginfo = CC.copy(bb_code.debuginfo)
-        resize!(debuginfo.codelocs, length(lines))
-        copyto!(debuginfo.codelocs, lines)
+        debuginfo.codelocs = lines
         return IRCode(
             CC.InstructionStream(
                 Any[x.stmt for x in insts],

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -573,7 +573,8 @@ function new_inst_vec(x::CC.InstructionStream)
     stmt = @static VERSION < v"1.11.0-rc4" ? x.inst : x.stmt
     @static if VERSION > v"1.12-"
         # In Julia 1.12+, x.line is a flat Vector{Int32} of length 3n (3 codeloc values per
-        # instruction). Extract the proper Tuple{Int32,Int32,Int32} for each instruction.
+        # instruction). Construct each NewInstruction with its proper Tuple{Int32,Int32,Int32}
+        # line field by reading the 3 entries for instruction i at positions 3i-2, 3i-1, 3i.
         n = length(stmt)
         return [
             NewInstruction(

--- a/test/interpreter/bbcode.jl
+++ b/test/interpreter/bbcode.jl
@@ -67,9 +67,9 @@ end
 
     @static if VERSION > v"1.12-"
         @testset "codelocs consistent after instruction insertion" begin
-            # Regression test: adding instructions during BBCode transforms used to leave
-            # debuginfo.codelocs at its original size, causing a mismatch with the new
-            # instruction count and wrong/misaligned debug info on BBCode -> IRCode conversion.
+            # Adding instructions during BBCode transforms does not update debuginfo.codelocs.
+            # Check that BBCode -> IRCode produces consistent stmts.line and debuginfo.codelocs
+            # of the correct size after an instruction is inserted.
             ir = Base.code_ircode(sin, Tuple{Float64})[1][1]
             bb = BBCode(ir)
             # Insert an instruction into the first block

--- a/test/interpreter/bbcode.jl
+++ b/test/interpreter/bbcode.jl
@@ -64,6 +64,25 @@ end
         @test length(Mooncake.collect_stmts(bb_code)) == length(stmt(ir.stmts))
         @test Mooncake.BasicBlockCode.id_to_line_map(bb_code) isa Dict{ID,Int}
     end
+
+    @static if VERSION > v"1.12-"
+        @testset "codelocs consistent after instruction insertion" begin
+            # Regression test: adding instructions during BBCode transforms used to leave
+            # debuginfo.codelocs at its original size, causing a mismatch with the new
+            # instruction count and wrong/misaligned debug info on BBCode -> IRCode conversion.
+            ir = Base.code_ircode(sin, Tuple{Float64})[1][1]
+            bb = BBCode(ir)
+            # Insert an instruction into the first block
+            push!(bb.blocks[1].inst_ids, ID())
+            push!(bb.blocks[1].insts, new_inst(nothing))
+            new_ir = CC.IRCode(bb)
+            n = length(new_ir.stmts)
+            @test length(new_ir.stmts.line) == 3n
+            @test length(new_ir.debuginfo.codelocs) == 3n
+            @test new_ir.stmts.line == new_ir.debuginfo.codelocs
+        end
+    end
+
     @testset "control_flow_graph" begin
         ir = Base.code_ircode_by_type(Tuple{typeof(sin),Float64})[1][1]
         bb = BBCode(ir)

--- a/test/interpreter/bbcode.jl
+++ b/test/interpreter/bbcode.jl
@@ -67,19 +67,39 @@ end
 
     @static if VERSION > v"1.12-"
         @testset "codelocs consistent after instruction insertion" begin
-            # Adding instructions during BBCode transforms does not update debuginfo.codelocs.
-            # Check that BBCode -> IRCode produces new_ir with stmts.line and debuginfo.codelocs of the
-            # correct size (3n) after an instruction is inserted.
+            # In 1.12+, codelocs (and stmts.line) pack 3 Int32 per instruction, so an
+            # n-instruction IRCode has 3n entries that must stay aligned across the round-trip.
             ir = Base.code_ircode(sin, Tuple{Float64})[1][1]
             n_orig = length(ir.stmts)
+            orig_ir_codelocs = copy(ir.debuginfo.codelocs)
             bb = BBCode(ir)
-            push!(bb.blocks[1].inst_ids, ID())
-            push!(bb.blocks[1].insts, new_inst(nothing))
+
+            # Mirror insert_before_terminator! to predict where the new instruction lands.
+            blk = bb.blocks[1]
+            insert_idx = if isnothing(Mooncake.terminator(blk))
+                length(blk.insts) + 1
+            else
+                length(blk.insts)
+            end
+            # Recognisable codeloc to check it lands at the right offset, not just that sizes match.
+            sentinel = (Int32(123), Int32(45), Int32(6))
+            inst = CC.NewInstruction(
+                nothing, Any, CC.NoCallInfo(), sentinel, CC.IR_FLAG_REFINED
+            )
+            Mooncake.insert_before_terminator!(blk, ID(), inst)
+            orig_bb_codelocs = copy(bb.debuginfo.codelocs)
             new_ir = CC.IRCode(bb)
             n = length(new_ir.stmts)
+            insert_range = (3insert_idx - 2):(3insert_idx)
+
             @test n == n_orig + 1
             @test length(new_ir.stmts.line) == 3n
             @test length(new_ir.debuginfo.codelocs) == 3n
+            @test Tuple(new_ir.stmts.line[insert_range]) == sentinel
+            @test new_ir.debuginfo.codelocs !== bb.debuginfo.codelocs
+            # Conversion must not mutate the source; bb and ir share the same codelocs array.
+            @test bb.debuginfo.codelocs == orig_bb_codelocs
+            @test ir.debuginfo.codelocs == orig_ir_codelocs
         end
     end
 

--- a/test/interpreter/bbcode.jl
+++ b/test/interpreter/bbcode.jl
@@ -68,18 +68,18 @@ end
     @static if VERSION > v"1.12-"
         @testset "codelocs consistent after instruction insertion" begin
             # Adding instructions during BBCode transforms does not update debuginfo.codelocs.
-            # Check that BBCode -> IRCode produces consistent stmts.line and debuginfo.codelocs
-            # of the correct size after an instruction is inserted.
+            # Check that BBCode -> IRCode produces new_ir with stmts.line and debuginfo.codelocs of the
+            # correct size (3n) after an instruction is inserted.
             ir = Base.code_ircode(sin, Tuple{Float64})[1][1]
+            n_orig = length(ir.stmts)
             bb = BBCode(ir)
-            # Insert an instruction into the first block
             push!(bb.blocks[1].inst_ids, ID())
             push!(bb.blocks[1].insts, new_inst(nothing))
             new_ir = CC.IRCode(bb)
             n = length(new_ir.stmts)
+            @test n == n_orig + 1
             @test length(new_ir.stmts.line) == 3n
             @test length(new_ir.debuginfo.codelocs) == 3n
-            @test new_ir.stmts.line == new_ir.debuginfo.codelocs
         end
     end
 


### PR DESCRIPTION
**PR Issue description :**

Fixes part 1 of #847 .

In Julia `1.12+`, every `IRCode` has a `debuginfo.codelocs` array storing exactly `3` `Int32` values per instruction (file index, line number, column) - `3n` total for `n` instructions. When Mooncake converts `IRCode` to `BBCode`, it copies `debuginfo`. During AD transforms, instructions are added or removed from the `BBCode` blocks but `debuginfo.codelocs` is never updated. When converting back `BBCode` to `IRCode`, the sizes disagree, and depending on where instructions were added or removed, the debug info can be misaligned or wrong for added, removed, and already-present instructions.

The current code handles this with a defensive resize where it pads with zeros if too short, truncate if too long. This is a workaround that hides the root cause rather than fixing it.

**Note :**
1. Currently internal helper `new_inst_vec` also reads `stmts.line` incorrectly in Julia `1.12+`. `stmts.line` is a flat `Vector{Int32}` of length `3n`, map was called on it - treating it as length n. So each NewInstruction got a single Int32 instead of the proper `Tuple{Int32,Int32,Int32}`. This meant all `inst.line` fields in `BBCode` had wrong values also. Also fixed by indexing `x.line[3i-2]`, `x.line[3i-1]`, `x.line[3i]` for each instruction `i` access in `new_inst_vec`. 

2. PR also updates `ir_representation.md` doctests to reflect the new correct behaviour :  `NewInstruction` line fields now show proper `Tuple{Int32,Int32,Int32}` values, and `IR` display line numbers for inserted instructions now reflect their actual source location from the `linetable` (doctests run on latest Julia version only)

**MWE :** 

```  
  using Mooncake
  import Mooncake: BBCode, new_inst, ID
  import Core.Compiler as CC

  # for any function
  ir = Base.code_ircode(sin, Tuple{Float64})[1][1]
  bb = BBCode(ir)

  # Simulating what the AD transform does: add an instruction
  push!(bb.blocks[1].inst_ids, ID())
  push!(bb.blocks[1].insts, new_inst(nothing))

  new_ir = CC.IRCode(bb)
  n = length(new_ir.stmts) 

  # Before the fix: debuginfo.codelocs has wrong size (stmts.line was resized but
  # debuginfo.codelocs was copied from the unmodified BBCode debuginfo)

  # After the fix:
  @assert length(new_ir.stmts.line) == 3n
  @assert length(new_ir.debuginfo.codelocs) == 3n

```

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1216 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1216/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 110.0 ns │     1.82 │        1.91 │   0.909 │        4.65 │    9.1 │
│             _sum_1000 │ 851.0 ns │     6.12 │        1.01 │  3950.0 │        40.4 │   1.13 │
│          sum_sin_1000 │  5.78 μs │     2.45 │        1.16 │    1.71 │        11.4 │   1.76 │
│         _sum_sin_1000 │  3.59 μs │     3.77 │        2.74 │   402.0 │        18.2 │   3.15 │
│              kron_sum │ 151.0 μs │     12.9 │        3.51 │    8.23 │       529.0 │   24.9 │
│         kron_view_sum │ 167.0 μs │     16.3 │        6.31 │    35.5 │       600.0 │   18.8 │
│ naive_map_sin_cos_exp │  1.75 μs │     2.75 │         1.5 │ missing │        8.94 │   2.19 │
│       map_sin_cos_exp │   1.7 μs │      3.3 │        1.65 │    1.69 │        7.62 │   2.77 │
│ broadcast_sin_cos_exp │  1.82 μs │     2.85 │        1.47 │    4.63 │        1.47 │   2.09 │
│            simple_mlp │ 240.0 μs │     5.35 │        2.94 │    2.35 │        10.9 │    3.5 │
│                gp_lml │ 146.0 μs │     11.1 │        2.82 │     4.6 │     missing │   5.79 │
│    large_single_block │ 370.0 ns │     5.44 │        1.92 │  4210.0 │        37.8 │   2.03 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->