### PR TITLE
Document differentiating through another AD library as out of scope

### DIFF
--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -175,10 +175,11 @@ If you observe unexpected performance regressions in differentiated code that is
 
 ## Differentiating Through Another Automatic Differentiation Library
 
-Mooncake.jl differentiates ordinary Julia code; it is not meant to differentiate *through* another automatic differentiation library.
-If the function you hand to Mooncake itself calls a second autograd tool — for example by building and replaying a tape — you are asking Mooncake to differentiate that tool's internals rather than your underlying mathematical function.
-This is outside Mooncake's scope and is not supported.
+Mooncake.jl is designed to differentiate ordinary Julia code, rather than to differentiate *through* another automatic differentiation library.
+If the function you hand to Mooncake itself calls a second autograd tool — for example by building and replaying a tape — you are effectively asking Mooncake to differentiate that tool's internals rather than your underlying mathematical function.
 
+Because such a library is itself Julia code, Mooncake will not refuse to differentiate it, and in some cases it may even work.
+This use is, however, *not officially supported*, so treat it as use-at-your-own-risk: if something goes wrong, fixing it is not something we are obligated to maintain.
 Such code leans on exactly the features that make AD hard, such as runtime code generation and world-age changes that happen mid-run, so it may fail loudly or, worse, return a plausible but incorrect gradient.
 See [issue #1209](https://github.com/chalk-lab/Mooncake.jl/issues/1209) for an example.
 

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -177,7 +177,7 @@ If you observe unexpected performance regressions in differentiated code that is
 
 Mooncake.jl differentiates ordinary Julia code; it is not meant to differentiate *through* another automatic differentiation library.
 If the function you hand to Mooncake itself calls a second autograd tool — for example by building and replaying a tape — you are asking Mooncake to differentiate that tool's internals rather than your underlying mathematical function.
-This is not officially supported.
+This is outside Mooncake's scope and is not officially supported.
 
 Such code leans on exactly the features that make AD hard, such as runtime code generation and world-age changes that happen mid-run, so it may fail loudly or, worse, return a plausible but incorrect gradient.
 See [issue #1209](https://github.com/chalk-lab/Mooncake.jl/issues/1209) for an example.

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -173,6 +173,18 @@ Consequently, code that performs well in its primal form may suffer substantial 
 
 If you observe unexpected performance regressions in differentiated code that is known to vectorise effectively in its primal form, consider implementing custom rules for the relevant operations. For example, a customised performance-oriented rule is added for `kron` in Mooncake ([PR #886](https://github.com/chalk-lab/Mooncake.jl/pull/886)) to address the loss of SIMD vectorisation that arises when differentiating the SIMD-friendly primal implementation of `kron` in Julia's standard library ([LinearAlgebra implementation](https://github.com/JuliaLang/LinearAlgebra.jl/blob/b1f48a442ba5f41479d4fb6f3e931b1ac2f21059/src/dense.jl#L499-L531)).
 
+## Differentiating Through Another Automatic Differentiation Library
+
+Mooncake.jl differentiates ordinary Julia code; it is not meant to differentiate *through* another automatic differentiation library.
+If the function you hand to Mooncake itself calls a second autograd tool — for example by building and replaying a tape — you are asking Mooncake to differentiate that tool's internals rather than your underlying mathematical function.
+This is outside Mooncake's scope and is not supported.
+
+Such code leans on exactly the features that make AD hard, such as runtime code generation and world-age changes that happen mid-run, so it may fail loudly or, worse, return a plausible but incorrect gradient.
+See [issue #1209](https://github.com/chalk-lab/Mooncake.jl/issues/1209) for an example.
+
+Instead, differentiate the underlying function directly with Mooncake.
+If part of your computation genuinely needs another AD tool, wrap that part in a custom rule so Mooncake treats it as a primitive and never looks inside; see [Defining Rules](@ref).
+
 ## Circular References in Type Declarations
 
 Mooncake.jl's default `tangent_type` implementation cannot support types which refer to themselves either directly or indirectly in their definition.

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -177,7 +177,7 @@ If you observe unexpected performance regressions in differentiated code that is
 
 Mooncake.jl differentiates ordinary Julia code; it is not meant to differentiate *through* another automatic differentiation library.
 If the function you hand to Mooncake itself calls a second autograd tool — for example by building and replaying a tape — you are asking Mooncake to differentiate that tool's internals rather than your underlying mathematical function.
-This is not *officially* supported, so use it at your own risk.
+This is not officially supported.
 
 Such code leans on exactly the features that make AD hard, such as runtime code generation and world-age changes that happen mid-run, so it may fail loudly or, worse, return a plausible but incorrect gradient.
 See [issue #1209](https://github.com/chalk-lab/Mooncake.jl/issues/1209) for an example.

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -175,11 +175,10 @@ If you observe unexpected performance regressions in differentiated code that is
 
 ## Differentiating Through Another Automatic Differentiation Library
 
-Mooncake.jl is designed to differentiate ordinary Julia code, rather than to differentiate *through* another automatic differentiation library.
-If the function you hand to Mooncake itself calls a second autograd tool — for example by building and replaying a tape — you are effectively asking Mooncake to differentiate that tool's internals rather than your underlying mathematical function.
+Mooncake.jl differentiates ordinary Julia code; it is not meant to differentiate *through* another automatic differentiation library.
+If the function you hand to Mooncake itself calls a second autograd tool — for example by building and replaying a tape — you are asking Mooncake to differentiate that tool's internals rather than your underlying mathematical function.
+This is not *officially* supported, so use it at your own risk.
 
-Because such a library is itself Julia code, Mooncake will not refuse to differentiate it, and in some cases it may even work.
-This use is, however, *not officially supported*, so treat it as use-at-your-own-risk: if something goes wrong, fixing it is not something we are obligated to maintain.
 Such code leans on exactly the features that make AD hard, such as runtime code generation and world-age changes that happen mid-run, so it may fail loudly or, worse, return a plausible but incorrect gradient.
 See [issue #1209](https://github.com/chalk-lab/Mooncake.jl/issues/1209) for an example.
 


### PR DESCRIPTION
Adds a new section to the known-limitations page explaining that Mooncake should not be used to differentiate *through* another automatic differentiation library — doing so asks Mooncake to differentiate that tool's internals rather than the underlying mathematical function, which is outside its scope.

The section:
- States the limitation plainly.
- Notes such code leans on the features that make AD hard (runtime codegen, mid-run world-age changes), so it may fail loudly or return a silently incorrect gradient.
- Links to [#1209](https://github.com/chalk-lab/Mooncake.jl/issues/1209) as an example.
- Points users to differentiate the underlying function directly, or wrap the foreign AD call in a custom rule (see Defining Rules).

Self-contained and doctest-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1217 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1217/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 181.0 ns │     1.55 │        1.55 │   0.663 │        3.27 │    6.2 │
│             _sum_1000 │ 962.0 ns │     6.89 │        1.02 │  3290.0 │        42.3 │   1.07 │
│          sum_sin_1000 │  7.17 μs │     3.53 │        1.34 │     1.5 │        11.3 │   1.79 │
│         _sum_sin_1000 │  5.96 μs │     3.52 │        1.92 │   259.0 │        13.4 │   2.19 │
│              kron_sum │ 212.0 μs │     13.2 │        3.27 │    17.2 │       381.0 │   20.1 │
│         kron_view_sum │ 295.0 μs │     11.2 │        5.12 │    25.0 │       329.0 │   12.5 │
│ naive_map_sin_cos_exp │  2.45 μs │     2.86 │        1.52 │ missing │        7.26 │   2.04 │
│       map_sin_cos_exp │  2.18 μs │     3.67 │         1.7 │    1.65 │         7.0 │    2.8 │
│ broadcast_sin_cos_exp │  2.43 μs │     3.01 │        1.59 │    3.82 │         1.4 │   2.02 │
│            simple_mlp │ 373.0 μs │     4.86 │        2.55 │    1.68 │        9.35 │   2.79 │
│                gp_lml │ 403.0 μs │     5.53 │        1.69 │    4.82 │     missing │   3.35 │
│    large_single_block │ 421.0 ns │     5.52 │        1.93 │  4720.0 │        35.5 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->