### PR TITLE
fix `has_equal_data_internal` usage clarity

### DIFF
--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -276,7 +276,7 @@ end
 # Method, CodeInstance, and MethodInstance form circular reference chains
 # (Method.specializations → MethodInstance, MethodInstance.def → Method,
 # MethodInstance.cache → CodeInstance, CodeInstance.def → MethodInstance).
-# Recursing into their fields would loop forever, so delegate to == instead.
+# Generic `has_equal_data_internal` will lead to infinite recursion.
 for T in (:(Core.Method), :(Core.CodeInstance), :(Core.MethodInstance))
     @eval function has_equal_data_internal(
         x::$T, y::$T, equal_undefs::Bool, d::IdDict{Any,Bool}

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -273,9 +273,11 @@ function has_equal_data_internal(
     return all(map((a, b) -> has_equal_data_internal(a, b, equal_undefs, d), x, y))
 end
 
-# Method, CodeInstance, and MethodInstance form circular reference chains
-# (Method.specializations → MethodInstance, MethodInstance.def → Method,
-# MethodInstance.cache → CodeInstance, CodeInstance.def → MethodInstance).
+# `Method`, `CodeInstance`, and `MethodInstance` have mutually recursive fields:
+# `Method.specializations` → `MethodInstance`
+# `MethodInstance.def` → `Method`
+# `MethodInstance.cache` → `CodeInstance`
+# `CodeInstance.def` → `MethodInstance`
 # Generic `has_equal_data_internal` will lead to infinite recursion.
 for T in (:(Core.Method), :(Core.CodeInstance), :(Core.MethodInstance))
     @eval function has_equal_data_internal(

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -273,12 +273,8 @@ function has_equal_data_internal(
     return all(map((a, b) -> has_equal_data_internal(a, b, equal_undefs, d), x, y))
 end
 
-# `Method`, `CodeInstance`, and `MethodInstance` have mutually recursive fields:
-# `Method.specializations` → `MethodInstance`
-# `MethodInstance.def` → `Method`
-# `MethodInstance.cache` → `CodeInstance`
-# `CodeInstance.def` → `MethodInstance`
-# Generic `has_equal_data_internal` will lead to infinite recursion.
+# `Method`, `CodeInstance`, and `MethodInstance` reference one another; recursing
+# into their fields traverses the runtime's method graph and overflows the stack.
 for T in (:(Core.Method), :(Core.CodeInstance), :(Core.MethodInstance))
     @eval function has_equal_data_internal(
         x::$T, y::$T, equal_undefs::Bool, d::IdDict{Any,Bool}

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -273,6 +273,10 @@ function has_equal_data_internal(
     return all(map((a, b) -> has_equal_data_internal(a, b, equal_undefs, d), x, y))
 end
 
+# Method, CodeInstance, and MethodInstance form circular reference chains
+# (Method.specializations → MethodInstance, MethodInstance.def → Method,
+# MethodInstance.cache → CodeInstance, CodeInstance.def → MethodInstance).
+# Recursing into their fields would loop forever, so delegate to == instead.
 for T in (:(Core.Method), :(Core.CodeInstance), :(Core.MethodInstance))
     @eval function has_equal_data_internal(
         x::$T, y::$T, equal_undefs::Bool, d::IdDict{Any,Bool}


### PR DESCRIPTION
Closes Item 4 of #847.

`Method` / `CodeInstance` / `MethodInstance` types form true object-level circular reference chains:
  - `Method.specializations` contains `MethodInstance` objects
  - `MethodInstance.def` points back to the same `Method` object
  - `MethodInstance.cache` contains a `CodeInstance`
  - `CodeInstance.def` points back to the same `MethodInstance`
  - `CodeInstance.next` is of type `CodeInstance` (self-referential chain)
  
**MWE :** 

```
m = only(methods(sin, (Float64,)))
mi = m.specializations[1]
ci = mi.cache

mi.def === m   # true as MethodInstance.def is the same Method object
ci.def === mi  # true as CodeInstance.def is the same MethodInstance object
```

Without the short-circuit, `has_equal_data_internal`'s generic fallback recurses into struct fields. Following these cycles would loop forever and cause a stack overflow. The return `x== y` breaks the cycle by using Julia's built-in equality.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1219 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1219/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 190.0 ns │     1.58 │        1.58 │   0.684 │        3.32 │   6.59 │
│             _sum_1000 │  1.09 μs │     6.03 │        1.03 │  3400.0 │        64.4 │   1.06 │
│          sum_sin_1000 │  7.42 μs │     2.55 │        1.12 │    1.66 │        14.0 │   1.79 │
│         _sum_sin_1000 │  4.68 μs │     3.78 │        4.67 │   379.0 │        30.2 │   3.04 │
│              kron_sum │ 190.0 μs │     13.1 │        3.28 │    7.39 │       522.0 │   23.9 │
│         kron_view_sum │ 264.0 μs │     12.7 │        5.27 │    28.5 │       501.0 │   14.2 │
│ naive_map_sin_cos_exp │  2.33 μs │     2.99 │        1.46 │ missing │        8.37 │   2.05 │
│       map_sin_cos_exp │  2.16 μs │     3.38 │        1.62 │    1.61 │        13.5 │   2.71 │
│ broadcast_sin_cos_exp │  2.27 μs │     3.07 │        1.58 │     4.4 │        1.49 │   2.13 │
│            simple_mlp │ 350.0 μs │     4.96 │        2.87 │    2.86 │        9.35 │   3.19 │
│                gp_lml │ 177.0 μs │     11.1 │        2.39 │    6.52 │     missing │   5.88 │
│    large_single_block │ 471.0 ns │     8.74 │        1.93 │  4190.0 │        63.7 │   2.08 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->