### PR TITLE
fix `setindex!` `frule`, `rrule!`.

### DIFF
--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -135,13 +135,16 @@ end
 @is_primitive MinimalCtx Tuple{typeof(setindex!),IdDict,Any,Any}
 function frule!!(::Dual{typeof(setindex!)}, d::Dual{IdDict{K,V}}, val, key) where {K,V}
     setindex!(primal(d), primal(val), primal(key))
-    # Coerce via V so the tangent slot gets tangent_type(V), not tangent_type(typeof(val)).
-    tv = if tangent_type(V) == tangent_type(typeof(primal(val)))
-        tangent(val)
+    # `setindex!` above stored `convert(V, val)`, so the tangent slot is `tangent_type(V)`, not
+    # `tangent_type(typeof(val))`: NoTangent slot, zero for a non-diff value, else `tangent(val)`.
+    dslot = if tangent_type(V) == NoTangent
+        NoTangent()
+    elseif tangent_type(typeof(primal(val))) == NoTangent
+        zero_tangent(primal(d)[primal(key)])
     else
-        zero_tangent(convert(V, primal(val)))
+        tangent(val)
     end
-    setindex!(tangent(d), tv, primal(key))
+    setindex!(tangent(d), dslot, primal(key))
     return d
 end
 function rrule!!(::CoDual{typeof(setindex!)}, d::CoDual{IdDict{K,V}}, val, key) where {K,V}
@@ -153,20 +156,32 @@ function rrule!!(::CoDual{typeof(setindex!)}, d::CoDual{IdDict{K,V}}, val, key) 
     end
 
     setindex!(primal(d), primal(val), k)
-    # Coerce via V so the tangent slot gets tangent_type(V), not tangent_type(typeof(val)).
-    setindex!(tangent(d), zero_tangent(convert(V, primal(val))), k)
+    # `setindex!` above stored `convert(V, val)`, so the slot is `tangent_type(V)`. For a
+    # matched/abstract `V` the two-argument `zero_tangent` reuses `val`'s fdata to preserve
+    # aliasing for mutable values; a non-diff slot/value takes a fresh slot-typed zero.
+    dslot = if tangent_type(V) == NoTangent
+        NoTangent()
+    elseif tangent_type(typeof(primal(val))) == NoTangent
+        zero_tangent(primal(d)[k])
+    else
+        zero_tangent(primal(val), tangent(val))
+    end
+    setindex!(tangent(d), dslot, k)
 
     dval = lazy_zero_rdata(primal(val))
     dkey = lazy_zero_rdata(primal(key))
     function setindex_pb!!(::NoRData)
 
-        # If V and typeof(val) differ in differentiability, their rdata types don't match; val gets zero gradient.
-        _dval =
-            if rdata_type(tangent_type(V)) == rdata_type(tangent_type(typeof(primal(val))))
-                increment!!(instantiate(dval), rdata(tangent(d)[k]))
-            else
-                zero_rdata(primal(val))
-            end
+        # Map the slot cotangent back to `val`: zero if either side is non-diff, a direct
+        # increment for matched/abstract `V`, else undo the widening (`fptrunc` for floats).
+        S = tangent_type(typeof(primal(val)))
+        _dval = if tangent_type(V) == NoTangent || S == NoTangent
+            instantiate(dval)
+        elseif S <: tangent_type(V)
+            increment!!(instantiate(dval), rdata(tangent(d)[k]))
+        else
+            increment!!(instantiate(dval), convert(rdata_type(S), rdata(tangent(d)[k])))
+        end
 
         # Restore previous state if necessary.
         if restore_state
@@ -205,7 +220,8 @@ function rrule!!(
             dd[k] = increment_rdata!!(dd[k], dy)
             _rdefault = instantiate(rdefault)
         else
-            _rdefault = increment_rdata!!(instantiate(rdefault), dy)
+            # Key absent: `y === default`, so `dy` is exactly `default`'s cotangent.
+            _rdefault = dy
         end
         return NoRData(), NoRData(), instantiate(dkey), _rdefault
     end
@@ -253,11 +269,21 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:iddict})
         (false, :stability, nothing, Base.rehash!, IdDict(true => 5.0, false => 4.0), 10),
         (false, :none, nothing, setindex!, IdDict(true => 5.0, false => 4.0), 3.0, false),
         (false, :none, nothing, setindex!, IdDict(true => 5.0), 3.0, false),
-        # type-mismatched stores (typeof(val) ≠ V)
+        # type-mismatched stores (typeof(val) ≠ V): non-diff/diff slots, mutable & abstract
+        # values (aliasing), and a floating-point width change (fpext/fptrunc).
         (false, :none, nothing, setindex!, IdDict(:a => 1.0), 2, :b),
+        # interface_only: the finite-difference perturbation would break `convert(Int, ...)`.
         (true, :none, nothing, setindex!, IdDict(:a => 1), 3.0, :b),
+        (false, :none, nothing, setindex!, IdDict{Symbol,Vector{Float64}}(:a => [1.0, 2.0]), [3.0, 4.0], :b),
+        (false, :none, nothing, setindex!, IdDict{Symbol,Any}(:a => 1.0), 2.0, :b),
+        (false, :none, nothing, setindex!, IdDict{Symbol,Any}(:a => [1.0]), [2.0, 3.0], :b),
+        (false, :none, nothing, setindex!, IdDict{Symbol,Float64}(:a => 1.0), 2.0f0, :b),
         (false, :none, nothing, get, IdDict(true => 5.0, false => 4.0), false, 2.0),
         (false, :none, nothing, get, IdDict(true => 5.0), false, 2.0),
+        # `get` returning a default (absent key) whose rdata type differs from its tangent type.
+        (false, :none, nothing, get, IdDict{Symbol,Vector{Float64}}(:a => [1.0]), :b, [2.0, 3.0]),
+        # interface_only: the non-differentiable default carries no derivative.
+        (true, :none, nothing, get, IdDict{Symbol,Float64}(:a => 1.0), :b, 2),
         (false, :none, nothing, getindex, IdDict(true => 5.0, false => 4.0), true),
         (false, :none, nothing, IdDict{Any,Any}),
     ]

--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -255,7 +255,7 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:iddict})
         (false, :none, nothing, setindex!, IdDict(true => 5.0), 3.0, false),
         # type-mismatched stores (typeof(val) ≠ V)
         (false, :none, nothing, setindex!, IdDict(:a => 1.0), 2, :b),
-        (false, :none, nothing, setindex!, IdDict(:a => 1), 3.0, :b),
+        (true, :none, nothing, setindex!, IdDict(:a => 1), 3.0, :b),
         (false, :none, nothing, get, IdDict(true => 5.0, false => 4.0), false, 2.0),
         (false, :none, nothing, get, IdDict(true => 5.0), false, 2.0),
         (false, :none, nothing, getindex, IdDict(true => 5.0, false => 4.0), true),

--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -165,7 +165,7 @@ function rrule!!(::CoDual{typeof(setindex!)}, d::CoDual{IdDict{K,V}}, val, key) 
             if rdata_type(tangent_type(V)) == rdata_type(tangent_type(typeof(primal(val))))
                 increment!!(instantiate(dval), rdata(tangent(d)[k]))
             else
-                instantiate(dval)
+                zero_rdata(primal(val))
             end
 
         # Restore previous state if necessary.

--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -274,14 +274,30 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:iddict})
         (false, :none, nothing, setindex!, IdDict(:a => 1.0), 2, :b),
         # interface_only: the finite-difference perturbation would break `convert(Int, ...)`.
         (true, :none, nothing, setindex!, IdDict(:a => 1), 3.0, :b),
-        (false, :none, nothing, setindex!, IdDict{Symbol,Vector{Float64}}(:a => [1.0, 2.0]), [3.0, 4.0], :b),
+        (
+            false,
+            :none,
+            nothing,
+            setindex!,
+            IdDict{Symbol,Vector{Float64}}(:a => [1.0, 2.0]),
+            [3.0, 4.0],
+            :b,
+        ),
         (false, :none, nothing, setindex!, IdDict{Symbol,Any}(:a => 1.0), 2.0, :b),
         (false, :none, nothing, setindex!, IdDict{Symbol,Any}(:a => [1.0]), [2.0, 3.0], :b),
         (false, :none, nothing, setindex!, IdDict{Symbol,Float64}(:a => 1.0), 2.0f0, :b),
         (false, :none, nothing, get, IdDict(true => 5.0, false => 4.0), false, 2.0),
         (false, :none, nothing, get, IdDict(true => 5.0), false, 2.0),
         # `get` returning a default (absent key) whose rdata type differs from its tangent type.
-        (false, :none, nothing, get, IdDict{Symbol,Vector{Float64}}(:a => [1.0]), :b, [2.0, 3.0]),
+        (
+            false,
+            :none,
+            nothing,
+            get,
+            IdDict{Symbol,Vector{Float64}}(:a => [1.0]),
+            :b,
+            [2.0, 3.0],
+        ),
         # interface_only: the non-differentiable default carries no derivative.
         (true, :none, nothing, get, IdDict{Symbol,Float64}(:a => 1.0), :b, 2),
         (false, :none, nothing, getindex, IdDict(true => 5.0, false => 4.0), true),

--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -135,7 +135,13 @@ end
 @is_primitive MinimalCtx Tuple{typeof(setindex!),IdDict,Any,Any}
 function frule!!(::Dual{typeof(setindex!)}, d::Dual{IdDict{K,V}}, val, key) where {K,V}
     setindex!(primal(d), primal(val), primal(key))
-    setindex!(tangent(d), tangent(val), primal(key))
+    # Coerce via V so the tangent slot gets tangent_type(V), not tangent_type(typeof(val)).
+    tv = if tangent_type(V) == tangent_type(typeof(primal(val)))
+        tangent(val)
+    else
+        zero_tangent(convert(V, primal(val)))
+    end
+    setindex!(tangent(d), tv, primal(key))
     return d
 end
 function rrule!!(::CoDual{typeof(setindex!)}, d::CoDual{IdDict{K,V}}, val, key) where {K,V}
@@ -147,14 +153,20 @@ function rrule!!(::CoDual{typeof(setindex!)}, d::CoDual{IdDict{K,V}}, val, key) 
     end
 
     setindex!(primal(d), primal(val), k)
-    setindex!(tangent(d), zero_tangent(primal(val), tangent(val)), k)
+    # Coerce via V so the tangent slot gets tangent_type(V), not tangent_type(typeof(val)).
+    setindex!(tangent(d), zero_tangent(convert(V, primal(val))), k)
 
     dval = lazy_zero_rdata(primal(val))
     dkey = lazy_zero_rdata(primal(key))
     function setindex_pb!!(::NoRData)
 
-        # Increment tangent.
-        _dval = increment!!(instantiate(dval), rdata(tangent(d)[k]))
+        # If V and typeof(val) differ in differentiability, their rdata types don't match; val gets zero gradient.
+        _dval =
+            if rdata_type(tangent_type(V)) == rdata_type(tangent_type(typeof(primal(val))))
+                increment!!(instantiate(dval), rdata(tangent(d)[k]))
+            else
+                instantiate(dval)
+            end
 
         # Restore previous state if necessary.
         if restore_state
@@ -241,6 +253,9 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:iddict})
         (false, :stability, nothing, Base.rehash!, IdDict(true => 5.0, false => 4.0), 10),
         (false, :none, nothing, setindex!, IdDict(true => 5.0, false => 4.0), 3.0, false),
         (false, :none, nothing, setindex!, IdDict(true => 5.0), 3.0, false),
+        # type-mismatched stores (typeof(val) ≠ V)
+        (false, :none, nothing, setindex!, IdDict(:a => 1.0), 2, :b),
+        (false, :none, nothing, setindex!, IdDict(:a => 1), 3.0, :b),
         (false, :none, nothing, get, IdDict(true => 5.0, false => 4.0), false, 2.0),
         (false, :none, nothing, get, IdDict(true => 5.0), false, 2.0),
         (false, :none, nothing, getindex, IdDict(true => 5.0, false => 4.0), true),


### PR DESCRIPTION
closes #1201 

Julia allows storing a value whose type differs from `V` into an `IdDict{K,V}` via implicit `convert(V, val)`. Mooncake's rules for `setindex!` crashed in this case because the tangent was derived from `typeof(val)` rather than `V`, causing a type mismatch when writing into the tangent dict (whose slots have type `tangent_type(V)`).

**MWE :** 
```
  using Mooncake: rrule!!, zero_fcodual

  rrule!!(zero_fcodual(setindex!), zero_fcodual(IdDict(:a => 1.0)), zero_fcodual(2), zero_fcodual(:b))
  # ERROR: MethodError: Cannot `convert` an object of type NoTangent to an object of type Float64

  rrule!!(zero_fcodual(setindex!), zero_fcodual(IdDict(:a => 1)), zero_fcodual(3.0), zero_fcodual(:b))
  # ERROR: MethodError: Cannot `convert` an object of type Float64 to an object of type NoTangent
```

**Note :** 
The Float64-into-Int test case uses `interface_only=true` since perturbing a `Float64` for finite-difference checking produces a non-integer that breaks `convert(Int64, ...)` (the slot is non-differentiable anyways)

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1220 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1220/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 190.0 ns │     1.47 │        1.53 │   0.684 │        3.43 │   6.64 │
│             _sum_1000 │  1.07 μs │     6.64 │        1.06 │  4250.0 │        38.6 │   1.09 │
│          sum_sin_1000 │  7.47 μs │     2.45 │        1.11 │    1.65 │        10.9 │   1.71 │
│         _sum_sin_1000 │  4.58 μs │     3.85 │        2.66 │   409.0 │        18.0 │   3.11 │
│              kron_sum │ 193.0 μs │     13.2 │        3.23 │    7.73 │       570.0 │   23.1 │
│         kron_view_sum │ 263.0 μs │     12.8 │         5.3 │    21.2 │       455.0 │   11.0 │
│ naive_map_sin_cos_exp │  2.13 μs │     3.09 │        1.53 │ missing │        8.71 │   2.21 │
│       map_sin_cos_exp │  2.12 μs │     3.48 │        1.66 │    1.58 │         7.5 │   2.76 │
│ broadcast_sin_cos_exp │  2.29 μs │     2.96 │        1.57 │    4.39 │        1.44 │    2.1 │
│            simple_mlp │ 375.0 μs │     4.67 │        2.66 │     1.5 │        8.76 │   2.94 │
│                gp_lml │ 382.0 μs │     5.71 │        1.66 │    2.77 │     missing │   3.02 │
│    large_single_block │ 471.0 ns │     5.44 │        1.96 │  4370.0 │        32.4 │   2.08 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->