### PR TITLE
Stop is_primitive specialising per call-signature

### DIFF
--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -109,7 +109,7 @@ callable `struct` with type parameters which are the result of this computation.
 context, the motivation for using this function is the same as that of using staged
 programming (e.g. via `@generated` functions) more generally.
 """
-build_primitive_frule(::Type{<:Tuple}) = frule!!
+build_primitive_frule(@nospecialize(sig::Type)) = frule!!
 
 """
     rrule!!(f::CoDual, x::CoDual...)
@@ -166,7 +166,7 @@ callable `struct` with type parameters which are the result of this computation.
 context, the motivation for using this function is the same as that of using staged
 programming (e.g. via `@generated` functions) more generally.
 """
-build_primitive_rrule(::Type{<:Tuple}) = rrule!!
+build_primitive_rrule(@nospecialize(sig::Type)) = rrule!!
 
 #! format: off
 @stable default_mode = "disable" default_union_limit = 2 begin

--- a/src/interpreter/contexts.jl
+++ b/src/interpreter/contexts.jl
@@ -154,9 +154,7 @@ Observe that `is_primitive` returns `false` for the world age prior to declaring
 primitive, but `true` afterwards. For more information on Julia's world age mechanism, see
 https://docs.julialang.org/en/v1/manual/methods/#Redefining-Methods .
 """
-function is_primitive(
-    ctx::Type{MinimalCtx}, mode::Type{<:Mode}, sig::Type{Tsig}, world::UInt
-) where {Tsig<:Tuple}
+function is_primitive(ctx::Type{MinimalCtx}, mode::Type{<:Mode}, sig, world::UInt)
     @nospecialize sig
     try
         Base.invoke_in_world(world, _is_primitive, ctx, mode, sig)::Bool
@@ -170,9 +168,7 @@ function is_primitive(
     end
 end
 
-function is_primitive(
-    ctx::Type{DefaultCtx}, mode::Type{<:Mode}, sig::Type{Tsig}, world::UInt
-) where {Tsig<:Tuple}
+function is_primitive(ctx::Type{DefaultCtx}, mode::Type{<:Mode}, sig, world::UInt)
     @nospecialize sig
     # This function returns `true` if the method is a primitive in either 
     # `DefaultCtx` _or_ `MinimalCtx`.

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -3,7 +3,7 @@
 @zero_derivative MinimalCtx Tuple{
     typeof(build_rrule_checks),MooncakeInterpreter,Any,Bool,Bool,Bool
 }
-@zero_derivative MinimalCtx Tuple{typeof(is_primitive),Type,Type{<:Mode},Type,UInt}
+@zero_derivative MinimalCtx Tuple{typeof(is_primitive),Type,Type{<:Mode},Any,UInt}
 
 @is_primitive MinimalCtx Tuple{
     typeof(build_derived_rrule),MooncakeInterpreter{C},Any,Any,Bool

--- a/test/interpreter/contexts.jl
+++ b/test/interpreter/contexts.jl
@@ -34,4 +34,24 @@ end
         @test !Mooncake.is_primitive(DefaultCtx, mode, Tuple{Tf,Real}, world)
         @test !Mooncake.is_primitive(MinimalCtx, mode, Tuple{Tf,Real}, world)
     end
+
+    # `is_primitive` must not specialise per signature: it is called once per call-node
+    # signature during the AD transform, so specialising would make compile time scale with
+    # the number of distinct signatures (issue #1222). Distinct signatures must add no new
+    # specialisation.
+    @testset "no per-signature specialisation" begin
+        nspecialisations(f) =
+            sum(methods(f); init=0) do m
+                specs = m.specializations
+                specs isa Core.MethodInstance ? 1 : count(!isnothing, specs)
+            end
+        Tf = typeof(ContextsTestModule.foo)
+        world = Base.get_world_counter()
+        Mooncake.is_primitive(DefaultCtx, Mooncake.ReverseMode, Tuple{Tf,Bool}, world)
+        n = nspecialisations(Mooncake.is_primitive)
+        for T in (Int8, Int16, Int32, Int64)
+            Mooncake.is_primitive(DefaultCtx, Mooncake.ReverseMode, Tuple{Tf,T}, world)
+        end
+        @test nspecialisations(Mooncake.is_primitive) == n
+    end
 end


### PR DESCRIPTION
`is_primitive` is called once per call-node signature during the AD transform, so specialising it makes compile time scale with the number of distinct signatures in the typed primal IR. On deeply composed DynamicPPL models, this dominates: its specialisation count grows into the thousands.

The `where {Tsig<:Tuple}` static parameter defeated the existing `@nospecialize sig`. Drop it (untyped `@nospecialize sig`) so the method is genuinely despecialised. Two supporting changes keep behaviour identical:

- Broaden the `build_primitive_frule`/`build_primitive_rrule` fallbacks from `::Type{<:Tuple}` to `@nospecialize(sig::Type)`, so signatures containing a free type variable (e.g. the `jl_type_unionall` foreigncall sig) still match once `is_primitive` no longer normalises them via the static parameter.
- Broaden the `is_primitive` zero-derivative declaration's `sig` argument from `Type` to `Any`. `is_primitive` is a forward-mode primitive so that nested forward-over-reverse AD does not differentiate through its `try`/`catch`; with a despecialised (statically `Any`) `sig` argument, the previous `Type` bound no longer matched, which would otherwise re-expose the `catch` to the forward-mode transform.

Specialisations collapse to a small constant (no growth with model size); warmed-marginal rule-build cost drops ~30% (from 5x to 3.5x primal compile time). Reverse/forward dispatch, gradients, and forward-over-reverse HVP/Hessian type-stability and allocations are unchanged.

Fix https://github.com/chalk-lab/Mooncake.jl/issues/1222

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1223 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1223/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 190.0 ns │     1.43 │        1.37 │   0.632 │        3.16 │   5.91 │
│             _sum_1000 │ 962.0 ns │     6.76 │        1.03 │  3610.0 │        37.0 │   1.07 │
│          sum_sin_1000 │   7.4 μs │     3.78 │        1.35 │    1.44 │        10.7 │   1.74 │
│         _sum_sin_1000 │  6.17 μs │     3.66 │        1.87 │   249.0 │        12.8 │   2.11 │
│              kron_sum │ 223.0 μs │     12.4 │        3.16 │    22.0 │       306.0 │   18.5 │
│         kron_view_sum │ 296.0 μs │     11.7 │        5.09 │    24.4 │       311.0 │   12.5 │
│ naive_map_sin_cos_exp │  2.35 μs │     3.03 │        1.52 │ missing │        7.52 │   2.14 │
│       map_sin_cos_exp │  2.29 μs │     3.61 │        1.66 │    1.52 │        6.69 │    2.7 │
│ broadcast_sin_cos_exp │  2.45 μs │     3.04 │        1.58 │    3.87 │        1.38 │   2.05 │
│            simple_mlp │ 379.0 μs │     4.62 │        2.62 │    2.04 │        8.55 │   2.73 │
│                gp_lml │ 394.0 μs │     5.74 │        1.75 │    2.89 │     missing │   3.03 │
│    large_single_block │ 421.0 ns │     5.24 │        1.93 │  4630.0 │        32.7 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->