### PR TITLE
Retry noisy perf benchmarks before failing

### DIFF
--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -176,14 +176,18 @@ function generate_inter_framework_tests()
 end
 
 function benchmark_rules!!(
-    test_case_data, default_ratios, include_other_frameworks::Bool, seconds=nothing
+    test_case_data,
+    default_ratios,
+    include_other_frameworks::Bool,
+    seconds=nothing;
+    retries=0,
 )
     test_cases = reduce(vcat, map(first, test_case_data))
     memory = map(x -> x[2], test_case_data)
     ranges = reduce(vcat, map(x -> x[3], test_case_data))
     tags = reduce(vcat, map(x -> x[4], test_case_data))
     GC.@preserve memory begin
-        return map(enumerate(test_cases)) do (n, args)
+        function run_case(n, args)
             @info "$n / $(length(test_cases))", _typeof(args)
             suite = Dict()
 
@@ -286,6 +290,18 @@ function benchmark_rules!!(
 
             return combine_results((args, suite), tags[n], ranges[n], default_ratios)
         end
+
+        # Perf ratios can spike spuriously on noisy CI runners, so retry an out-of-range
+        # result up to `retries` times; only a persistent failure counts as a regression.
+        return map(enumerate(test_cases)) do (n, args)
+            ratio = run_case(n, args)
+            for _ in 1:retries
+                (ratio.range.lb < ratio.Mooncake < ratio.range.ub) && break
+                @info "perf ratio $(ratio.Mooncake) outside $(ratio.range); retrying" n
+                ratio = run_case(n, args)
+            end
+            return ratio
+        end
     end
 end
 
@@ -333,7 +349,7 @@ function benchmark_hand_written_rrules!!(rng_ctor)
         tags = fill(nothing, length(test_cases))
         return map(x -> x[4:end], test_cases), memory, ranges, tags
     end
-    return benchmark_rules!!(test_case_data, (lb=1e-3, ub=50.0), false, 0.03)
+    return benchmark_rules!!(test_case_data, (lb=1e-3, ub=50.0), false, 0.03; retries=5)
 end
 
 function benchmark_derived_rrules!!(rng_ctor)
@@ -343,7 +359,7 @@ function benchmark_derived_rrules!!(rng_ctor)
         tags = fill(nothing, length(test_cases))
         return map(x -> x[4:end], test_cases), memory, ranges, tags
     end
-    return benchmark_rules!!(test_case_data, (lb=1e-3, ub=200), false, 0.1)
+    return benchmark_rules!!(test_case_data, (lb=1e-3, ub=200), false, 0.1; retries=5)
 end
 
 function benchmark_inter_framework_rules()


### PR DESCRIPTION
Perf-ratio assertions sometimes fail on CI-runner noise (e.g. the recent
`getfield(::StructFoo, ::Symbol)` at 389 vs. a 350 ceiling on a ~60 ns primal).

`benchmark_rules!!` now retries an out-of-range ratio up to `retries` times, passing on
the first in-range result; only a persistent failure counts as a regression. Set to 5
for the `hand_written`/`derived` groups; `comparison` keeps `0`. The bound is unchanged.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1233 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1233/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 211.0 ns │     1.47 │        1.47 │   0.569 │        2.75 │   5.32 │
│             _sum_1000 │ 971.0 ns │     6.93 │        1.01 │  3230.0 │        37.0 │   1.06 │
│          sum_sin_1000 │  7.23 μs │     3.37 │         1.3 │    1.47 │        11.0 │   1.72 │
│         _sum_sin_1000 │  5.85 μs │     3.67 │        1.94 │   240.0 │        13.6 │   2.26 │
│              kron_sum │ 216.0 μs │     13.1 │        3.34 │    18.3 │       381.0 │   18.9 │
│         kron_view_sum │ 301.0 μs │     10.9 │        5.09 │    24.3 │       336.0 │   12.1 │
│ naive_map_sin_cos_exp │  2.48 μs │     2.98 │        1.49 │ missing │        7.18 │   1.98 │
│       map_sin_cos_exp │   2.4 μs │     3.33 │        1.57 │     1.4 │        6.42 │   2.52 │
│ broadcast_sin_cos_exp │  2.47 μs │     3.05 │        1.53 │    3.67 │        1.38 │   2.01 │
│            simple_mlp │ 342.0 μs │     4.98 │        2.76 │    1.78 │        9.01 │   3.01 │
│                gp_lml │ 169.0 μs │     13.0 │        3.93 │    10.9 │     missing │   7.99 │
│    large_single_block │ 411.0 ns │      5.9 │        1.98 │  4910.0 │        33.6 │    2.1 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->