### PR TITLE
Document cache size constraints and wordarounds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,5 @@ val, grad, H = MC.value_gradient_and_hessian!!(hess_cache, f, x)
 ```
 
 You should expect that `MC.prepare_*_cache` take a little time to run, but that subsequent gradient and hessian calls using the prepared caches are fast. For details, see the [interface docs](https://chalk-lab.github.io/Mooncake.jl/stable/interface/). 
+
+The gradient interface `prepare_gradient_cache` / `value_and_gradient!!` requires `f` to return a real scalar (`Union{Float16, Float32, Float64}`); for other outputs, such as arrays, use `prepare_pullback_cache` / `value_and_pullback!!`, which accept any output if you supply the seed cotangent yourself. Any prepared cache fixes the type and size of each input (calls error if a later `x` differs) and reuses its pre-allocated gradient buffers in place, so copy any gradient you need to keep before calling again. For varying input sizes, skip the cache and call `value_and_pullback!!(rule, ȳ, f, x...)` on a `rule` from `build_rrule`: it re-allocates tangents each call, requiring only the input types to stay fixed. Since that `rule` is reusable, you can also build your own cache on top of it that resizes on demand.


### PR DESCRIPTION
Explain that value_and_gradient!! requires a scalar output while value_and_pullback!! accepts any output, that prepared caches fix input type/size and reuse gradient buffers in place, and that the rule-based value_and_pullback!! supports varying input sizes.

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1236 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1236/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌───────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                 Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                String │   String │   String │      String │  String │      String │ String │
├───────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│              sum_1000 │ 171.0 ns │     1.64 │        1.64 │   0.702 │        3.34 │   6.56 │
│             _sum_1000 │ 972.0 ns │     6.87 │        1.02 │  4020.0 │        41.9 │   1.06 │
│          sum_sin_1000 │   7.1 μs │     3.51 │        1.38 │    1.53 │        11.4 │   1.84 │
│         _sum_sin_1000 │  5.98 μs │     3.69 │         1.9 │   266.0 │        13.3 │   2.19 │
│              kron_sum │ 249.0 μs │     11.5 │        3.06 │     8.4 │       317.0 │   17.3 │
│         kron_view_sum │ 314.0 μs │     10.6 │        5.19 │    23.9 │       313.0 │   11.7 │
│ naive_map_sin_cos_exp │  2.39 μs │     3.01 │        1.48 │ missing │        7.35 │   2.06 │
│       map_sin_cos_exp │  2.39 μs │     3.38 │         1.6 │    1.51 │        6.37 │   2.64 │
│ broadcast_sin_cos_exp │  2.41 μs │     3.11 │        1.57 │     3.9 │         1.4 │   2.08 │
│            simple_mlp │ 407.0 μs │     4.66 │        2.77 │    1.75 │        8.74 │    2.6 │
│                gp_lml │ 428.0 μs │     5.75 │        1.71 │    2.88 │     missing │   3.21 │
│    large_single_block │ 421.0 ns │     5.97 │        1.93 │  4810.0 │        35.6 │   2.05 │
└───────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->