### PR TITLE
Re-enable CI groups and benchmark disabled in #1155 and #1144

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         test_group: [
-          # {test_type: 'ext', label: 'differentiation_interface'},
+          {test_type: 'ext', label: 'differentiation_interface'},
           {test_type: 'ext', label: 'dynamic_expressions'},
           {test_type: 'ext', label: 'flux'},
           {test_type: 'ext', label: 'function_wrappers'},
@@ -100,10 +100,10 @@ jobs:
           {test_type: 'integration_testing', label: 'array'},
           {test_type: 'integration_testing', label: 'bijectors'},
           {test_type: 'integration_testing', label: 'diff_tests'},
-          # {test_type: 'integration_testing', label: 'diffeq'},
+          {test_type: 'integration_testing', label: 'diffeq'},
           {test_type: 'integration_testing', label: 'dispatch_doctor'},
           {test_type: 'integration_testing', label: 'distributions'},
-          # {test_type: 'integration_testing', label: 'dynamicppl'},
+          {test_type: 'integration_testing', label: 'dynamicppl'},
           {test_type: 'integration_testing', label: 'gp'},
           {test_type: 'integration_testing', label: 'logexpfunctions'},
           {test_type: 'integration_testing', label: 'battery_tests'},

--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -169,8 +169,7 @@ function generate_inter_framework_tests()
             (_simple_mlp, randn(128, 256), randn(256, 128), randn(128, 70), randn(128, 70)),
         ),
         ("gp_lml", (_gp_lml, _generate_gp_inputs()...)),
-        # TODO: re-enable when DI is removed from DynamicPPL hard deps. 
-        # ("turing_broadcast_benchmark", build_dynamicppl_problem()),
+        ("turing_broadcast_benchmark", build_dynamicppl_problem()),
         ("large_single_block", (large_single_block, [0.9, 0.99])),
     ]
 end


### PR DESCRIPTION
Uncomments the differentiation_interface, diffeq, and dynamicppl CI matrix entries and restores the turing_broadcast_benchmark. 

Fix #1156

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1239 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1239/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 191.0 ns │     1.58 │        1.58 │   0.628 │        3.15 │   5.87 │
│                  _sum_1000 │ 992.0 ns │     6.78 │       0.999 │  4300.0 │        41.7 │   1.04 │
│               sum_sin_1000 │  7.02 μs │     3.58 │        1.37 │    1.52 │        11.3 │   1.84 │
│              _sum_sin_1000 │  6.03 μs │     3.42 │        1.87 │   240.0 │        13.1 │   2.16 │
│                   kron_sum │ 211.0 μs │     12.3 │        3.17 │    7.87 │       340.0 │   18.8 │
│              kron_view_sum │ 292.0 μs │     10.8 │        5.03 │    25.0 │       302.0 │   12.4 │
│      naive_map_sin_cos_exp │  2.44 μs │      2.9 │        1.48 │ missing │        7.34 │   2.04 │
│            map_sin_cos_exp │  2.21 μs │     3.61 │        1.67 │    1.53 │        6.96 │   2.79 │
│      broadcast_sin_cos_exp │  2.43 μs │     3.06 │        1.62 │    3.88 │        1.39 │   2.03 │
│                 simple_mlp │ 362.0 μs │      4.8 │        2.65 │    1.95 │        8.53 │   2.83 │
│                     gp_lml │ 168.0 μs │     11.4 │        2.63 │    5.44 │     missing │    5.4 │
│ turing_broadcast_benchmark │  1.66 ms │     6.89 │        3.51 │ missing │        36.4 │   2.38 │
│         large_single_block │ 421.0 ns │      5.4 │        1.93 │  4810.0 │        31.9 │   2.05 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->