### PR TITLE
Fix StackOverflow in _copy_output for compiled callables

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -521,6 +521,14 @@ For types with custom copy semantics, overload this function (see `Core.SimpleVe
 _copy_output(x::Core.TypeName) = x
 _copy_output(x::Module) = x
 
+# Compiled callables retain reflection/IR objects whose reference graph is cyclic
+# (e.g. Method.specializations <-> MethodInstance.def), so field-by-field descent
+# never terminates. They are never differentiable, so return them as-is — this lets
+# the friendly `prepare_hvp_cache` path copy a gradient closure that captures a
+# compiled rule without overflowing.
+_copy_output(x::Core.OpaqueClosure) = x
+_copy_output(x::MistyClosure) = x
+
 _copy_output(x::SimpleVector) = Core.svec([map(_copy_output, x_sub) for x_sub in x]...)
 
 # Array, Memory

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -580,6 +580,21 @@ end
             @test ds_copy2._n == ds2._n
             @test ds_copy2._data == ds2._data
         end
+
+        # Fix for #1242: compiled callables retain reflection/IR objects with cyclic
+        # reference graphs, so descending into their fields never terminates.
+        @testset "_copy_output compiled callables" begin
+            oc = Base.Experimental.@opaque x -> x + 1
+            @test Mooncake._copy_output(oc) === oc
+
+            # End-to-end: friendly forward-over-reverse over an array function builds
+            # a gradient closure that captures the compiled reverse rule. Copying it
+            # must not StackOverflow at prepare time.
+            f = x -> sum(abs2, x)
+            @test Mooncake.prepare_hvp_cache(
+                f, [1.0, 2.0, 3.0]; config=Mooncake.Config(; friendly_tangents=true)
+            ) isa Mooncake.HVPCache
+        end
     end
     @testset "forwards mode ($kwargs)" for kwargs in [
         (;),


### PR DESCRIPTION
Closes #1242.

`prepare_hvp_cache(f, x; config = Config(friendly_tangents = true))` StackOverflows at prepare time for array `x`: the friendly path `_copy_output`s the gradient closure, which recursively deep-copies the captured compiled rule's cyclic reflection/IR graph (`Method.specializations` ⇄ `MethodInstance.def`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1243 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1243/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 211.0 ns │     1.47 │        1.52 │   0.616 │        2.94 │   5.93 │
│                  _sum_1000 │  1.09 μs │     6.13 │        1.02 │  3960.0 │        41.8 │   1.07 │
│               sum_sin_1000 │  7.43 μs │     2.49 │         1.1 │    1.63 │        10.9 │   1.72 │
│              _sum_sin_1000 │  4.74 μs │     3.69 │        2.59 │   384.0 │        17.2 │   2.98 │
│                   kron_sum │ 193.0 μs │     13.0 │        3.29 │    7.28 │       556.0 │   19.8 │
│              kron_view_sum │ 262.0 μs │     12.9 │        5.32 │    28.4 │       477.0 │   14.0 │
│      naive_map_sin_cos_exp │   2.2 μs │     2.85 │        1.49 │ missing │        8.57 │   2.17 │
│            map_sin_cos_exp │  2.18 μs │      3.3 │        1.66 │    1.53 │        7.31 │    2.7 │
│      broadcast_sin_cos_exp │  2.29 μs │     2.96 │        1.55 │    4.57 │        1.41 │   2.11 │
│                 simple_mlp │ 342.0 μs │     5.19 │        2.97 │    2.13 │        9.71 │   3.29 │
│                     gp_lml │ 370.0 μs │     5.93 │        1.74 │    2.88 │     missing │   3.08 │
│ turing_broadcast_benchmark │  1.62 ms │     7.69 │         4.1 │ missing │        43.7 │    2.2 │
│         large_single_block │ 471.0 ns │     6.51 │        1.96 │  4020.0 │        32.3 │   2.06 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->