### PR TITLE
Preserve the copy rule boundary in the trtrs! pullback

### DIFF
--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -153,7 +153,9 @@ function rrule!!(
     uplo, trans, diag = primal(_uplo), primal(_trans), primal(_diag)
     A, dA = arrayify(_A)
     B, dB = arrayify(_B)
-    B_copy = copy(B)
+    # Preserve the typed copy call when this rrule is differentiated in forward mode.
+    # Otherwise native inlining lowers it to the unruleable memmove foreigncall.
+    B_copy = Base.@noinline copy(B)
 
     # Run primal.
     trtrs!(uplo, trans, diag, A, B)

--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -153,7 +153,7 @@ function rrule!!(
     uplo, trans, diag = primal(_uplo), primal(_trans), primal(_diag)
     A, dA = arrayify(_A)
     B, dB = arrayify(_B)
-    # Keep the copy call visible to the forward-over-reverse transform.
+    # Preserve the copy primitive during forward-over-reverse AD.
     B_copy = Base.@noinline copy(B)
 
     # Run primal.

--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -153,7 +153,7 @@ function rrule!!(
     uplo, trans, diag = primal(_uplo), primal(_trans), primal(_diag)
     A, dA = arrayify(_A)
     B, dB = arrayify(_B)
-    # Keep `copy` uninlined so forward-over-reverse AD can use its forward rule.
+    # Keep `copy` in the IR so forward-over-reverse AD can dispatch to its `frule!!`.
     B_copy = Base.@noinline copy(B)
 
     # Run primal.

--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -153,7 +153,7 @@ function rrule!!(
     uplo, trans, diag = primal(_uplo), primal(_trans), primal(_diag)
     A, dA = arrayify(_A)
     B, dB = arrayify(_B)
-    # Keep the copy call visible to forward mode.
+    # Keep the copy call visible to the forward-over-reverse transform.
     B_copy = Base.@noinline copy(B)
 
     # Run primal.

--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -153,7 +153,7 @@ function rrule!!(
     uplo, trans, diag = primal(_uplo), primal(_trans), primal(_diag)
     A, dA = arrayify(_A)
     B, dB = arrayify(_B)
-    # Preserve the copy primitive during forward-over-reverse AD.
+    # Keep `copy` uninlined so forward-over-reverse AD can use its forward rule.
     B_copy = Base.@noinline copy(B)
 
     # Run primal.

--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -153,8 +153,6 @@ function rrule!!(
     uplo, trans, diag = primal(_uplo), primal(_trans), primal(_diag)
     A, dA = arrayify(_A)
     B, dB = arrayify(_B)
-    # Preserve the typed copy call when this rrule is differentiated in forward mode.
-    # Otherwise native inlining lowers it to the unruleable memmove foreigncall.
     B_copy = Base.@noinline copy(B)
 
     # Run primal.

--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -153,6 +153,7 @@ function rrule!!(
     uplo, trans, diag = primal(_uplo), primal(_trans), primal(_diag)
     A, dA = arrayify(_A)
     B, dB = arrayify(_B)
+    # Keep the copy call visible to forward mode.
     B_copy = Base.@noinline copy(B)
 
     # Run primal.

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -207,15 +207,11 @@ end
     end
 
     @testset "triangular solve" begin
-        # The trtrs! rrule snapshots its right-hand side with copy. That typed call must
-        # survive optimisation so forward-over-reverse does not encounter raw memmove.
         L = LowerTriangular([2.0 0.0; 1.0 3.0])
         f(x) = sum(abs2, L \ x)
         x = [1.0, 2.0]
 
-        value, grad, H = value_gradient_and_hessian!!(
-            prepare_hessian_cache(f, x), f, x
-        )
+        value, grad, H = value_gradient_and_hessian!!(prepare_hessian_cache(f, x), f, x)
 
         @test value ≈ 1 / 2
         @test grad ≈ [1 / 3, 1 / 3]

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -206,6 +206,22 @@ end
         @test hvp ≈ [48.0]
     end
 
+    @testset "triangular solve" begin
+        # The trtrs! rrule snapshots its right-hand side with copy. That typed call must
+        # survive optimisation so forward-over-reverse does not encounter raw memmove.
+        L = LowerTriangular([2.0 0.0; 1.0 3.0])
+        f(x) = sum(abs2, L \ x)
+        x = [1.0, 2.0]
+
+        value, grad, H = value_gradient_and_hessian!!(
+            prepare_hessian_cache(f, x), f, x
+        )
+
+        @test value ≈ 1 / 2
+        @test grad ≈ [1 / 3, 1 / 3]
+        @test H ≈ [5 / 9 -1 / 9; -1 / 9 2 / 9]
+    end
+
     @testset "cache reuse across multiple HVP calls" begin
         # The `DerivedFoRRule`'s cached `Dual` is reused across calls without copying;
         # verify the cache produces consistent results when called repeatedly with

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -206,6 +206,7 @@ end
         @test hvp ≈ [48.0]
     end
 
+    # Regression test for #1246.
     @testset "triangular solve" begin
         L = LowerTriangular([2.0 0.0; 1.0 3.0])
         f(x) = sum(abs2, L \ x)


### PR DESCRIPTION
Closes #1246.

Forward-over-reverse through a triangular solve failed because pre-forward optimisation inlined the `copy(B)` snapshot in the `trtrs!` reverse rule through `unsafe_copyto!` to raw `memmove`. At that point the element type and copy count needed for differentiation have been erased, so Mooncake intentionally has no rule for the foreign call.

Mark this snapshot call `Base.@noinline` so the typed `copy` primitive remains visible to forward mode, and add a focused Hessian regression. This remains necessary with #1215: its width-generic `Lifted`/`NDualArray` copy rule handles every tangent lane once the call boundary survives, while the earlier inlining phase and unsupported raw `memmove` boundary are unchanged.

Validated with the `rules/high_order_derivative_patches` and `rules/lapack` test groups, plus the focused reproducer on Julia 1.10–1.12.

Prepared with Codex.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1247 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1247/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 160.0 ns │     1.69 │        1.81 │    0.75 │        3.69 │   7.14 │
│                  _sum_1000 │ 962.0 ns │     7.01 │        1.04 │  3140.0 │        44.9 │   1.07 │
│               sum_sin_1000 │  6.96 μs │     3.35 │        1.35 │    1.53 │        11.4 │   1.83 │
│              _sum_sin_1000 │  6.13 μs │     3.42 │        1.85 │   237.0 │        12.7 │   2.13 │
│                   kron_sum │ 198.0 μs │     13.6 │        3.24 │    9.12 │       381.0 │   20.1 │
│              kron_view_sum │ 287.0 μs │     11.2 │        5.01 │    13.7 │       332.0 │    8.8 │
│      naive_map_sin_cos_exp │  2.42 μs │      2.9 │        1.52 │ missing │        7.31 │   2.06 │
│            map_sin_cos_exp │  2.24 μs │     3.59 │        1.66 │    1.51 │        6.75 │   2.75 │
│      broadcast_sin_cos_exp │  2.28 μs │     3.22 │        1.58 │    4.35 │        1.48 │   2.14 │
│                 simple_mlp │ 369.0 μs │     4.69 │        2.53 │     2.5 │        8.55 │   2.72 │
│                     gp_lml │ 380.0 μs │     5.72 │        1.76 │    3.01 │     missing │    3.0 │
│ turing_broadcast_benchmark │  1.67 ms │      6.9 │        3.51 │ missing │        37.4 │   2.38 │
│         large_single_block │ 410.0 ns │     5.57 │         2.0 │  4850.0 │        34.4 │    2.1 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->