### PR TITLE
Add rrule!! for NNlib.gather

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.39"
+version = "0.5.40"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -270,6 +270,31 @@ end
     } where {P,N,M},
     true,
 )
+
+# ChainRules defines an `rrule` only for the in-place `gather!`, not `gather`, so without
+# this AD would trace `gather`'s scalar per-index loop (see
+# https://github.com/chalk-lab/Mooncake.jl/issues/1234). The pullback is `∇gather_src`
+# accumulating straight into `src`'s fdata, avoiding its intermediate allocation.
+@is_primitive(
+    MinimalCtx,
+    Tuple{
+        typeof(NNlib.gather),SupportedArray{P,N},SupportedArray{<:Union{Integer,Tuple},M}
+    } where {P<:IEEEFloat,N,M},
+)
+function Mooncake.rrule!!(
+    ::CoDual{typeof(NNlib.gather)},
+    src::CoDual{<:SupportedArray{P,N}},
+    idx::CoDual{<:SupportedArray{<:Union{Integer,Tuple},M}},
+) where {P<:IEEEFloat,N,M}
+    pidx = primal(idx)
+    res = zero_fcodual(NNlib.gather(primal(src), pidx))
+    function gather_pb!!(::NoRData)
+        _, dsrc = arrayify(src)
+        NNlib.scatter!(+, dsrc, tangent(res), pidx)
+        return NoRData(), NoRData(), NoRData()
+    end
+    return res, gather_pb!!
+end
 for conv in [:conv, :depthwiseconv]
     local ∇conv_data, ∇conv_filter = Symbol.(:∇, conv, [:_data, :_filter])
 

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -305,6 +305,9 @@ dropout_tester_3(Trng, x, p) = dropout(Trng(1), x, p; dims=(1, 2))
         (false, :none, true, NNlib.scatter, +, _rand(rng, 2), [1, 3]),
         (false, :none, true, Core.kwcall, (;), NNlib.scatter, +, _rand(rng, 2), [1, 3]),
 
+        # gather
+        (false, :none, true, NNlib.gather, _rand(rng, 2, 4), [1, 3, 1]),
+
         # conv
         (false, :none, true, Core.kwcall, (;), conv, x, w, dense_cdims),
         (false, :none, true, conv, x, w, dense_cdims),


### PR DESCRIPTION
gather is the adjoint of scatter, but ChainRules defines an rrule only for the in-place gather!, so Mooncake had no primitive for gather and differentiated its scalar per-index loop instruction-by-instruction (~96x slower than Zygote on the issue's GNN benchmark).

Register gather as a primitive with a hand-written pullback that scatters the output cotangent straight into src's fdata via scatter!(+, ...) — the exact adjoint, and equal to NNlib's ∇gather_src without its intermediate allocation. Reverse-mode gather now matches Zygote (~1.1x) and the pullback is zero-allocation.

Fixes #1234

<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1252 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1252/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 181.0 ns │     1.55 │         1.6 │   0.663 │        3.21 │   6.25 │
│                  _sum_1000 │ 962.0 ns │     6.86 │        1.03 │  4470.0 │        37.1 │   1.07 │
│               sum_sin_1000 │  7.08 μs │     3.38 │        1.34 │     1.5 │        11.0 │   1.74 │
│              _sum_sin_1000 │  5.94 μs │     3.57 │         1.9 │   246.0 │        13.2 │   2.19 │
│                   kron_sum │ 211.0 μs │     12.6 │        3.24 │    21.4 │       370.0 │   19.1 │
│              kron_view_sum │ 293.0 μs │     11.8 │        5.27 │    22.0 │       312.0 │   10.1 │
│      naive_map_sin_cos_exp │  2.38 μs │     2.91 │        1.49 │ missing │        7.35 │   2.06 │
│            map_sin_cos_exp │  2.17 μs │     3.79 │        1.68 │    1.58 │        7.06 │   2.86 │
│      broadcast_sin_cos_exp │  2.34 μs │     3.22 │        1.59 │    4.09 │        1.44 │   2.09 │
│                 simple_mlp │ 370.0 μs │     4.97 │        2.57 │    1.65 │        8.61 │   2.77 │
│                     gp_lml │ 415.0 μs │     5.22 │        1.62 │    2.65 │     missing │   2.84 │
│ turing_broadcast_benchmark │  1.67 ms │      6.8 │        3.54 │ missing │        41.3 │    2.4 │
│         large_single_block │ 431.0 ns │     6.53 │        2.06 │  4770.0 │        31.7 │    2.0 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->