### PR TITLE
Enable Flux BatchNorm GPU test

### DIFF
--- a/test/integration_testing/flux/flux.jl
+++ b/test/integration_testing/flux/flux.jl
@@ -170,7 +170,7 @@ const TEST_MODELS = [
     # LayerNorm calls varm via LuxLib.Impl.mean_var → var → varm. Enabled by the
     # Statistics.varm GPU rrule!! in MooncakeCUDAExt.
     (_gpu_enabled, LayerNorm(2), randn(Float32, 2, 10), "LayerNorm(2)"),
-    (_gpu_disabled, BatchNorm(2), randn(Float32, 2, 10), "BatchNorm(2)"),  # batchnorm_cudnn! not yet differentiable
+    (_gpu_enabled, BatchNorm(2), randn(Float32, 2, 10), "BatchNorm(2)"),  # NNlib.batchnorm rrule!! (NNlibMooncakeCUDAExt, FluxML/NNlib.jl#727)
     (
         _gpu_enabled,
         first ∘ MultiHeadAttention(16),


### PR DESCRIPTION
`Flux.BatchNorm` on GPU dispatches to `NNlib.batchnorm`, which previously had no Mooncake rule and was marked `_gpu_disabled` in the Flux integration test suite with a stale comment attributing the gap to `batchnorm_cudnn!` (that's
actually LuxLib's function, on Lux's separate BatchNorm path, not Flux's).

[FluxML/NNlib.jl#727](https://github.com/FluxML/NNlib.jl/pull/727) (merged, released in NNlib 0.9.37) added an `rrule!!` for `NNlib.batchnorm` in [`NNlibMooncakeCUDAExt`](https://github.com/FluxML/NNlib.jl/blob/master/ext/NNlibMooncakeCUDAExt.jl), caching the forward pass's batch mean/inverse-variance so the backward pass
doesn't recompute them via a non-deterministic GPU reduction (was breaking Mooncake's Reuse test before)

This PR just flips the test flag in [`test/integration_testing/flux/flux.jl`](https://github.com/chalk-lab/Mooncake.jl/blob/main/test/integration_testing/flux/flux.jl) now that the rule exists upstream, and fixes the comment to point at the right function/PR.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1255 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1255/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 201.0 ns │     1.55 │         1.5 │   0.597 │        2.99 │   5.53 │
│                  _sum_1000 │ 962.0 ns │     6.97 │        1.03 │  3680.0 │        36.8 │   1.07 │
│               sum_sin_1000 │  7.12 μs │     3.49 │        1.34 │     1.5 │        11.0 │   1.79 │
│              _sum_sin_1000 │  6.41 μs │     3.44 │        1.79 │   226.0 │        12.2 │   2.07 │
│                   kron_sum │ 209.0 μs │     13.3 │        3.02 │    23.6 │       348.0 │   19.3 │
│              kron_view_sum │ 292.0 μs │     10.6 │        4.92 │    24.7 │       301.0 │   10.8 │
│      naive_map_sin_cos_exp │  2.49 μs │     2.98 │        1.48 │ missing │        7.03 │   1.97 │
│            map_sin_cos_exp │  2.38 μs │     3.45 │        1.67 │    1.42 │        6.38 │   2.55 │
│      broadcast_sin_cos_exp │  2.51 μs │     3.01 │        1.51 │    3.62 │        1.39 │   1.94 │
│                 simple_mlp │ 382.0 μs │      4.4 │        2.54 │    2.12 │        8.45 │   2.66 │
│                     gp_lml │ 378.0 μs │     5.88 │        1.78 │    2.94 │     missing │   3.32 │
│ turing_broadcast_benchmark │  1.66 ms │     6.89 │        3.54 │ missing │        40.2 │   2.38 │
│         large_single_block │ 401.0 ns │      6.6 │        2.12 │  4910.0 │        38.0 │   2.15 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->