### PR TITLE
Fix three tangent-construction crashes hit while debugging `SciMLSensitivity` #1427

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2220,7 +2220,10 @@ function Base.show(io::IO, ::MIME"text/plain", cache::HVPCache)
 end
 
 @inline function _assert_matching_tangent_shape(primal, tangent, arg_index::Int)
-    if applicable(axes, primal) && applicable(axes, tangent)
+    # `axes(x) = map(oneto, size(x))` is defined for any `x`, so `applicable(axes, x)` is
+    # `true` even when `x` has no `size` method (e.g. a struct-shaped `Tangent`) -- check
+    # `size` itself instead, since that's what `axes` actually depends on.
+    if applicable(size, primal) && applicable(size, tangent)
         axes(primal) == axes(tangent) || throw(
             ArgumentError(
                 "Tangent direction for argument $arg_index must match the primal axes; got axes $(axes(tangent)) for tangent vs $(axes(primal)) for primal",

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -1,3 +1,10 @@
+# `MooncakeInterpreter` holds compiler-internal state (world age, inference caches, a
+# cache of compiled rules) -- never a differentiable value. Without this, `zero_tangent`
+# recurses into that cache and hits a raw `OpaqueClosure` with an untranslatable
+# `llvmcall`. Needed because `@zero_derivative` rules like `get_interpreter` below still
+# need a zero tangent for their return value, not just their arguments.
+tangent_type(::Type{<:MooncakeInterpreter}) = NoTangent
+
 @zero_derivative MinimalCtx Tuple{typeof(get_interpreter),Type{<:Mode}}
 @zero_derivative MinimalCtx Tuple{typeof(get_interpreter),Type{<:Mode},UInt}
 @zero_derivative MinimalCtx Tuple{

--- a/src/rules/new.jl
+++ b/src/rules/new.jl
@@ -47,6 +47,14 @@ end
 @inline function build_output_tangent(::Type{P}, x::Tuple, t::Tuple) where {P}
     return _build_output_tangent_cartesian(P, x, t, Val(fieldcount(P)), Val(fieldnames(P)))
 end
+# `IdDict`'s fields (`ht::Memory`, `count`, `ndel`) are hash-table bookkeeping, not
+# differentiable data, and `IdDict` has no field-wise constructor -- only the key-value
+# one, which the generic path below would call by mistake and crash on `ht`'s `#undef`
+# slots. A fresh IdDict starts empty, so its tangent is just its own zero_tangent;
+# increment/setindex in `src/rules/iddict.jl` fills it in later.
+@inline function build_output_tangent(::Type{P}, x::Tuple, ::Tuple) where {P<:IdDict}
+    return zero_tangent(_new_(P, x...))
+end
 @generated function _build_output_tangent_cartesian(
     ::Type{P}, x::Tuple, t::Tt, ::Val{nfield}, ::Val{names}
 ) where {P,nfield,names,Tt<:Tuple}
@@ -210,6 +218,11 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:new})
             UnitUpperTriangular{Float64,Matrix{Float64}},
             randn(2, 2),
         ),
+        # Regression test: `IdDict`'s raw fields (`ht::Memory`, `count`, `ndel`) are hash-
+        # table bookkeeping, not differentiable data, and the generic _new_ tangent-
+        # construction path used to misread `ht` as a (k, v) pair and crash with
+        # UndefRefError on its #undef slots.
+        (false, :none, nothing, _new_, IdDict{Int,Float64}),
     ]
     general_test_cases = map(TestTypes.PRIMALS) do (interface_only, P, args)
         return (interface_only, :none, nothing, _new_, P, args...)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1410,6 +1410,22 @@ end
                 @test_throws ArgumentError value_and_hvp!!(cache2, f, ([1.0], [0.0]), x, y)
             end
 
+            # Regression test: `applicable(axes, x)` is `true` for any `x` (Base's generic
+            # `axes(A) = map(oneto, size(A))` fallback matches unconditionally), so the
+            # shape check used to run `axes(...)` on struct-shaped primals/tangents that
+            # have no `size` method at all, throwing an unrelated MethodError instead of
+            # either skipping the check or reporting a real shape mismatch.
+            @testset "HVP with struct-shaped (non-array) primal/tangent" begin
+                f(x::SimplePair) = x.x1^2 + x.x2^2
+                x = SimplePair(3.0, 4.0)
+                v = Mooncake.Tangent((; x1=1.0, x2=0.0))
+                cache = prepare_hvp_cache(f, x)
+                f_val, grad, hvp = value_and_hvp!!(cache, f, v, x)
+                @test f_val ≈ 25.0
+                @test grad.fields == (; x1=6.0, x2=8.0)
+                @test hvp.fields == (; x1=2.0, x2=0.0)
+            end
+
             @testset "HVP cache mismatch errors" begin
                 f(x) = sum(x .* x)
                 x = [1.0, 2.0]

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -292,4 +292,17 @@ end
         _, _, H = value_gradient_and_hessian!!(prepare_hessian_cache(f, x), f, x)
         @test H ≈ [6.0 0.0; 0.0 6.0]
     end
+
+    # Regression test for the `tangent_type(::Type{<:MooncakeInterpreter}) = NoTangent`
+    # fix at the top of this file -- see that comment for why it's needed.
+    @testset "MooncakeInterpreter has NoTangent tangent_type" begin
+        interp = get_interpreter(ForwardMode)
+        @test Mooncake.tangent_type(typeof(interp)) == Mooncake.NoTangent
+        @test Mooncake.zero_tangent(interp) isa Mooncake.NoTangent
+        # Exercise it with real, already-compiled rule state present, not just a bare
+        # fresh interpreter, since that's the scenario the recursion bug actually hit.
+        prepare_hvp_cache(x -> sum(x .* x), [1.0, 2.0])
+        interp2 = get_interpreter(ForwardMode)
+        @test Mooncake.zero_tangent(interp2) isa Mooncake.NoTangent
+    end
 end


### PR DESCRIPTION
Fixes, while getting Mooncake's HVP working for a neural ODE (SciML/SciMLSensitivity.jl#1427):

- `applicable(axes, x)` is true for any `x` (Base's generic axes fallback), so the tangent-shape check ran `axes` on struct-shaped tangents with no `size` method and threw an unrelated MethodError. Check `size` instead, since `axes` is defined in terms of it.

- `MooncakeInterpreter` had no `tangent_type`, so `zero_tangent` recursed into its own compiled-rule cache and hit an untranslatable `llvmcall`. It's compiler-internal state, never differentiable -- give it `NoTangent`.

- `_new_`'s generic path misread `IdDict`'s raw `ht::Memory` field as a (k, v) pair and crashed with `UndefRefError`. A fresh `IdDict` starts empty, so its tangent is just `zero_tangent(IdDict(...))`; existing increment/setindex machinery fills it in later.
