### PR TITLE
Fix wrong gradient through NNlib.sigmoid at exactly zero

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.40"
+version = "0.5.41"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -377,4 +377,29 @@ function rrule!!(
     return x, bias_act_id_pb!!
 end
 
+# NNlib computes the smooth `σ` in overflow-safe form, `t = exp(-abs(x));
+# ifelse(x ≥ 0, inv(1 + t), t / (1 + t))`. AD through that implementation picks up a factor
+# of `sign(x)`, which is `0` at `x == 0`, so it reports `0` there instead of `1/4`: the kink
+# `abs` introduces cancels between the two branches analytically, but not via the chain
+# rule. Exactly-zero arguments are common (zero-initialised biases, dead ReLU units).
+for f in (:σ, :sigmoid_fast)
+    @eval @is_primitive MinimalCtx Tuple{typeof(NNlib.$f),P} where {P<:IEEEFloat}
+    @eval function frule!!(::Dual{typeof(NNlib.$f)}, x::Dual{P}) where {P<:IEEEFloat}
+        Ω = NNlib.$f(primal(x))
+        return Dual(Ω, tangent(x) * Ω * (one(P) - Ω))
+    end
+    @eval function rrule!!(::CoDual{typeof(NNlib.$f)}, x::CoDual{P}) where {P<:IEEEFloat}
+        Ω = NNlib.$f(primal(x))
+        sigmoid_pb!!(dΩ::P) = NoRData(), dΩ * Ω * (one(P) - Ω)
+        return zero_fcodual(Ω), sigmoid_pb!!
+    end
+    # GPU elementwise and reduction rules evaluate the whole fused broadcast on `NDual`s
+    # inside one kernel, so they never reach the rules above and need the derivative too.
+    @eval @inline function NNlib.$f(x::NDual{P,N}) where {P<:IEEEFloat,N}
+        Ω = NNlib.$f(x.value)
+        d = Ω * (one(P) - Ω)
+        return NDual{P,N}(Ω, ntuple(i -> x.partials[i] * d, Val(N)))
+    end
+end
+
 end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -13,11 +13,11 @@ dropout_tester_1(Trng, x, p) = dropout(Trng(1), x, p; dims=1)
 dropout_tester_2(Trng, x, p) = dropout(Trng(1), x, p; dims=2)
 dropout_tester_3(Trng, x, p) = dropout(Trng(1), x, p; dims=(1, 2))
 
-@testset "nnlib" begin
-    # TODO: CUDA version bound when 
-    #  https://github.com/JuliaGPU/CUDA.jl/issues/2886 is fixed and released
-    cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
+# TODO: CUDA version bound when
+#  https://github.com/JuliaGPU/CUDA.jl/issues/2886 is fixed and released
+cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
 
+@testset "nnlib" begin
     _rand = if cuda
         (rng, size...) -> cu(randn(rng, size...))
     else
@@ -490,4 +490,17 @@ end
     @test isinf(ndual_value(y_nd_neg)) && ndual_value(y_nd_neg) < 0
     @test !isnan(ndual_partial(y_nd_neg, 1))
     @test ndual_partial(y_nd_neg, 1) ≈ 0.5f0
+end
+
+# NNlib's `exp(-abs(x))` form of σ has a kink at zero that the function itself does not.
+@testset "sigmoid at zero: $f" for f in (NNlib.σ, NNlib.sigmoid_fast)
+    test_rule(StableRNG(123), f, 0.0; perf_flag=:stability)
+    # The reported failure was a gradient through a broadcast containing an exact zero.
+    test_rule(StableRNG(123), x -> sum(f.(x)), [0.0, 0.5, -0.5]; is_primitive=false)
+    # On GPU that broadcast is evaluated on `NDual`s in-kernel, an independent code path.
+    if cuda
+        test_rule(
+            StableRNG(123), x -> sum(f.(x)), cu([0.0f0, 0.5f0, -0.5f0]); is_primitive=false
+        )
+    end
 end


### PR DESCRIPTION
Fixes #1257. NNlib computes σ via `exp(-abs(x))`; differentiating that picks up `sign(x)`, zero at `x == 0`, so AD gave σ'(0) = 0, not 1/4. Adds σ/sigmoid_fast rules using the analytic Ω(1-Ω), plus an NDual method — GPU broadcasts evaluate σ in-kernel, reaching no rule.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1258 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1258/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 190.0 ns │     1.63 │        1.42 │   0.632 │        2.79 │   5.96 │
│                  _sum_1000 │ 952.0 ns │     7.07 │        1.03 │  3650.0 │        38.1 │   1.08 │
│               sum_sin_1000 │   7.2 μs │     3.45 │        1.33 │    1.48 │        10.9 │   1.76 │
│              _sum_sin_1000 │  5.69 μs │     3.77 │         2.0 │   255.0 │        14.1 │   2.27 │
│                   kron_sum │ 216.0 μs │     12.0 │         3.1 │    22.9 │       330.0 │   18.7 │
│              kron_view_sum │ 292.0 μs │     10.7 │        5.04 │    24.1 │       314.0 │   6.98 │
│      naive_map_sin_cos_exp │  2.51 μs │      2.9 │         1.5 │ missing │        7.11 │   1.99 │
│            map_sin_cos_exp │  2.28 μs │     3.57 │        1.63 │    1.52 │        7.11 │   2.52 │
│      broadcast_sin_cos_exp │  2.31 μs │      3.2 │        1.56 │    4.56 │        1.46 │   2.14 │
│                 simple_mlp │ 320.0 μs │     5.13 │        2.94 │    2.24 │        9.71 │   3.18 │
│                     gp_lml │ 381.0 μs │     5.62 │        1.67 │     2.9 │     missing │   2.98 │
│ turing_broadcast_benchmark │  1.66 ms │     6.65 │        3.53 │ missing │        38.6 │   2.28 │
│         large_single_block │ 401.0 ns │     5.72 │         2.0 │  4750.0 │        36.3 │    2.0 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->