### PR TITLE
Fix three tangent-construction crashes hit while debugging SciMLSensitivity #1427

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2220,9 +2220,8 @@ function Base.show(io::IO, ::MIME"text/plain", cache::HVPCache)
 end
 
 @inline function _assert_matching_tangent_shape(primal, tangent, arg_index::Int)
-    # `axes(x) = map(oneto, size(x))` is defined for any `x`, so `applicable(axes, x)` is
-    # `true` even when `x` has no `size` method (e.g. a struct-shaped `Tangent`) - check
-    # `size` itself instead, since that's what `axes` actually depends on.
+    # Base's generic `axes(x) = map(oneto, size(x))` makes `applicable(axes, x)` true even
+    # for a struct-shaped `Tangent` with no `size` method, so check `size` instead.
     if applicable(size, primal) && applicable(size, tangent)
         axes(primal) == axes(tangent) || throw(
             ArgumentError(

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2220,7 +2220,10 @@ function Base.show(io::IO, ::MIME"text/plain", cache::HVPCache)
 end
 
 @inline function _assert_matching_tangent_shape(primal, tangent, arg_index::Int)
-    if applicable(axes, primal) && applicable(axes, tangent)
+    # `axes(x) = map(oneto, size(x))` is defined for any `x`, so `applicable(axes, x)` is
+    # `true` even when `x` has no `size` method (e.g. a struct-shaped `Tangent`) -- check
+    # `size` itself instead, since that's what `axes` actually depends on.
+    if applicable(size, primal) && applicable(size, tangent)
         axes(primal) == axes(tangent) || throw(
             ArgumentError(
                 "Tangent direction for argument $arg_index must match the primal axes; got axes $(axes(tangent)) for tangent vs $(axes(primal)) for primal",

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2221,7 +2221,7 @@ end
 
 @inline function _assert_matching_tangent_shape(primal, tangent, arg_index::Int)
     # `axes(x) = map(oneto, size(x))` is defined for any `x`, so `applicable(axes, x)` is
-    # `true` even when `x` has no `size` method (e.g. a struct-shaped `Tangent`) -- check
+    # `true` even when `x` has no `size` method (e.g. a struct-shaped `Tangent`) - check
     # `size` itself instead, since that's what `axes` actually depends on.
     if applicable(size, primal) && applicable(size, tangent)
         axes(primal) == axes(tangent) || throw(

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -1,8 +1,4 @@
-# `MooncakeInterpreter` holds compiler-internal state (world age, inference caches, a
-# cache of compiled rules) and never a differentiable value. Without this, `zero_tangent`
-# recurses into that cache and hits a raw `OpaqueClosure` with an untranslatable
-# `llvmcall`. Needed because `@zero_derivative` rules like `get_interpreter` below still
-# need a zero tangent for their return value, not just their arguments.
+# Without this, zeroing the `@zero_derivative` return value below duals every cached rule.
 tangent_type(::Type{<:MooncakeInterpreter}) = NoTangent
 
 @zero_derivative MinimalCtx Tuple{typeof(get_interpreter),Type{<:Mode}}

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -1,5 +1,5 @@
 # `MooncakeInterpreter` holds compiler-internal state (world age, inference caches, a
-# cache of compiled rules) -- never a differentiable value. Without this, `zero_tangent`
+# cache of compiled rules) and never a differentiable value. Without this, `zero_tangent`
 # recurses into that cache and hits a raw `OpaqueClosure` with an untranslatable
 # `llvmcall`. Needed because `@zero_derivative` rules like `get_interpreter` below still
 # need a zero tangent for their return value, not just their arguments.

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -1,3 +1,10 @@
+# `MooncakeInterpreter` holds compiler-internal state (world age, inference caches, a
+# cache of compiled rules) -- never a differentiable value. Without this, `zero_tangent`
+# recurses into that cache and hits a raw `OpaqueClosure` with an untranslatable
+# `llvmcall`. Needed because `@zero_derivative` rules like `get_interpreter` below still
+# need a zero tangent for their return value, not just their arguments.
+tangent_type(::Type{<:MooncakeInterpreter}) = NoTangent
+
 @zero_derivative MinimalCtx Tuple{typeof(get_interpreter),Type{<:Mode}}
 @zero_derivative MinimalCtx Tuple{typeof(get_interpreter),Type{<:Mode},UInt}
 @zero_derivative MinimalCtx Tuple{

--- a/src/rules/new.jl
+++ b/src/rules/new.jl
@@ -47,6 +47,14 @@ end
 @inline function build_output_tangent(::Type{P}, x::Tuple, t::Tuple) where {P}
     return _build_output_tangent_cartesian(P, x, t, Val(fieldcount(P)), Val(fieldnames(P)))
 end
+# `IdDict`'s fields (`ht::Memory`, `count`, `ndel`) are hash-table bookkeeping, not
+# differentiable data, and `IdDict` has no field-wise constructor -- only the key-value
+# one, which the generic path below would call by mistake and crash on `ht`'s `#undef`
+# slots. A fresh IdDict starts empty, so its tangent is just its own zero_tangent;
+# increment/setindex in `src/rules/iddict.jl` fills it in later.
+@inline function build_output_tangent(::Type{P}, x::Tuple, ::Tuple) where {P<:IdDict}
+    return zero_tangent(_new_(P, x...))
+end
 @generated function _build_output_tangent_cartesian(
     ::Type{P}, x::Tuple, t::Tt, ::Val{nfield}, ::Val{names}
 ) where {P,nfield,names,Tt<:Tuple}
@@ -210,6 +218,11 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:new})
             UnitUpperTriangular{Float64,Matrix{Float64}},
             randn(2, 2),
         ),
+        # Regression test: `IdDict`'s raw fields (`ht::Memory`, `count`, `ndel`) are hash-
+        # table bookkeeping, not differentiable data, and the generic _new_ tangent-
+        # construction path used to misread `ht` as a (k, v) pair and crash with
+        # UndefRefError on its #undef slots.
+        (false, :none, nothing, _new_, IdDict{Int,Float64}),
     ]
     general_test_cases = map(TestTypes.PRIMALS) do (interface_only, P, args)
         return (interface_only, :none, nothing, _new_, P, args...)

--- a/src/rules/new.jl
+++ b/src/rules/new.jl
@@ -43,17 +43,28 @@ function rrule!!(
     end
     return CoDual(y, dy), pb!!
 end
+# The generic mutable-type branch above assumes fdata is a MutableTangent with a
+# `.fields` NamedTuple, but IdDict's fdata is a plain IdDict (fields `ht`/`count`/`ndel`),
+# so `dy.fields` throws. IdDict's rdata is always NoRData (rules/iddict.jl) anyway, so
+# there's nothing to compute - skip straight to NoPullback, same as the immutable branch
+# does whenever R == NoRData.
+function rrule!!(
+    f::CoDual{typeof(_new_)}, p::CoDual{Type{P}}, x::Vararg{CoDual,N}
+) where {P<:IdDict,N}
+    y = _new_(P, tuple_map(primal, x)...)
+    dy = build_fdata(P, tuple_map(primal, x), tuple_map(tangent, x))
+    return CoDual(y, dy), NoPullback(f, p, x...)
+end
 
 @inline function build_output_tangent(::Type{P}, x::Tuple, t::Tuple) where {P}
     return _build_output_tangent_cartesian(P, x, t, Val(fieldcount(P)), Val(fieldnames(P)))
 end
-# `IdDict`'s fields (`ht::Memory`, `count`, `ndel`) are hash-table bookkeeping, not
-# differentiable data, and `IdDict` has no field-wise constructor -- only the key-value
-# one, which the generic path below would call by mistake and crash on `ht`'s `#undef`
-# slots. A fresh IdDict starts empty, so its tangent is just its own zero_tangent;
-# increment/setindex in `src/rules/iddict.jl` fills it in later.
+# IdDict has no field-wise constructor - only the key-value one, so the generic path
+# below would misread its raw `ht::Memory` field as a (k, v) pair and crash. A fresh
+# IdDict starts empty, so just build its tangent directly via tangent_type(P)'s own
+# constructor.
 @inline function build_output_tangent(::Type{P}, x::Tuple, ::Tuple) where {P<:IdDict}
-    return zero_tangent(_new_(P, x...))
+    return tangent_type(P)()
 end
 @generated function _build_output_tangent_cartesian(
     ::Type{P}, x::Tuple, t::Tt, ::Val{nfield}, ::Val{names}
@@ -80,6 +91,13 @@ end
 
 @inline function build_fdata(::Type{P}, x::Tuple, fdata::Tuple) where {P}
     return _build_fdata_cartesian(P, x, fdata, Val(fieldcount(P)), Val(fieldnames(P)))
+end
+# Same issue as build_output_tangent above, on the fdata path: the generic cartesian path
+# builds a NamedTuple of IdDict's raw fields and hands it to IdDict's key-value-pairs
+# constructor, which misreads it as an iterable of (k, v) pairs and crashes. Build the
+# empty fdata-typed IdDict directly instead.
+@inline function build_fdata(::Type{P}, x::Tuple, ::Tuple) where {P<:IdDict}
+    return fdata_type(tangent_type(P))()
 end
 @generated function _build_fdata_cartesian(
     ::Type{P}, x::Tuple, fdata::Tfdata, ::Val{nfield}, ::Val{names}
@@ -218,11 +236,10 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:new})
             UnitUpperTriangular{Float64,Matrix{Float64}},
             randn(2, 2),
         ),
-        # Regression test: `IdDict`'s raw fields (`ht::Memory`, `count`, `ndel`) are hash-
-        # table bookkeeping, not differentiable data, and the generic _new_ tangent-
-        # construction path used to misread `ht` as a (k, v) pair and crash with
-        # UndefRefError on its #undef slots.
-        (false, :none, nothing, _new_, IdDict{Int,Float64}),
+        # Regression test for IdDict's _new_ tangent-construction bugs above. Real, valid
+        # field values here, not zero args - _new_ with no arguments leaves `ht`
+        # uninitialized, which segfaults on its own, unrelated to the bug being tested.
+        (false, :none, nothing, _new_, IdDict{Int,Float64}, Memory{Any}(undef, 0), 0, 0),
     ]
     general_test_cases = map(TestTypes.PRIMALS) do (interface_only, P, args)
         return (interface_only, :none, nothing, _new_, P, args...)

--- a/src/rules/new.jl
+++ b/src/rules/new.jl
@@ -43,28 +43,22 @@ function rrule!!(
     end
     return CoDual(y, dy), pb!!
 end
-# The generic mutable-type branch above assumes fdata is a MutableTangent with a
-# `.fields` NamedTuple, but IdDict's fdata is a plain IdDict (fields `ht`/`count`/`ndel`),
-# so `dy.fields` throws. IdDict's rdata is always NoRData (rules/iddict.jl) anyway, so
-# there's nothing to compute - skip straight to NoPullback, same as the immutable branch
-# does whenever R == NoRData.
+# A `_new_`ed IdDict has an empty tangent (itself an IdDict, which `fdata_type` maps to
+# itself), and a pullback that returns nothing, every field it is built from having
+# `NoRData` rdata. The generic method above instead reads the raw `ht::Memory` field as an
+# iterable of `(k, v)` pairs, and builds a pullback expecting a `MutableTangent`.
 function rrule!!(
     f::CoDual{typeof(_new_)}, p::CoDual{Type{P}}, x::Vararg{CoDual,N}
 ) where {P<:IdDict,N}
     y = _new_(P, tuple_map(primal, x)...)
-    dy = build_fdata(P, tuple_map(primal, x), tuple_map(tangent, x))
-    return CoDual(y, dy), NoPullback(f, p, x...)
+    return CoDual(y, tangent_type(P)()), NoPullback(f, p, x...)
 end
 
 @inline function build_output_tangent(::Type{P}, x::Tuple, t::Tuple) where {P}
     return _build_output_tangent_cartesian(P, x, t, Val(fieldcount(P)), Val(fieldnames(P)))
 end
-# IdDict has no field-wise constructor - only the key-value one, so the generic path
-# below would misread its raw `ht::Memory` field as a (k, v) pair and crash. A fresh
-# IdDict starts empty, so just build its tangent directly via tangent_type(P)'s own
-# constructor.
-@inline function build_output_tangent(::Type{P}, x::Tuple, ::Tuple) where {P<:IdDict}
-    return tangent_type(P)()
+@inline function build_output_tangent(::Type{P}, ::Tuple, ::Tuple) where {P<:IdDict}
+    return tangent_type(P)()   # see the IdDict `rrule!!` above
 end
 @generated function _build_output_tangent_cartesian(
     ::Type{P}, x::Tuple, t::Tt, ::Val{nfield}, ::Val{names}
@@ -91,13 +85,6 @@ end
 
 @inline function build_fdata(::Type{P}, x::Tuple, fdata::Tuple) where {P}
     return _build_fdata_cartesian(P, x, fdata, Val(fieldcount(P)), Val(fieldnames(P)))
-end
-# Same issue as build_output_tangent above, on the fdata path: the generic cartesian path
-# builds a NamedTuple of IdDict's raw fields and hands it to IdDict's key-value-pairs
-# constructor, which misreads it as an iterable of (k, v) pairs and crashes. Build the
-# empty fdata-typed IdDict directly instead.
-@inline function build_fdata(::Type{P}, x::Tuple, ::Tuple) where {P<:IdDict}
-    return fdata_type(tangent_type(P))()
 end
 @generated function _build_fdata_cartesian(
     ::Type{P}, x::Tuple, fdata::Tfdata, ::Val{nfield}, ::Val{names}
@@ -236,10 +223,8 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:new})
             UnitUpperTriangular{Float64,Matrix{Float64}},
             randn(2, 2),
         ),
-        # Regression test for IdDict's _new_ tangent-construction bugs above. Real, valid
-        # field values here, not zero args - _new_ with no arguments leaves `ht`
-        # uninitialized, which segfaults on its own, unrelated to the bug being tested.
-        # `ht` is Memory{Any} on 1.11+ but Vector{Any} on 1.10, so get it via fieldtype.   
+        # `ht` is `Memory{Any}` on 1.11+ but `Vector{Any}` on 1.10. Omitting the fields
+        # entirely leaves `ht` undefined, which segfaults for reasons of its own.
         (
             false,
             :none,

--- a/src/rules/new.jl
+++ b/src/rules/new.jl
@@ -239,7 +239,17 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:new})
         # Regression test for IdDict's _new_ tangent-construction bugs above. Real, valid
         # field values here, not zero args - _new_ with no arguments leaves `ht`
         # uninitialized, which segfaults on its own, unrelated to the bug being tested.
-        (false, :none, nothing, _new_, IdDict{Int,Float64}, Memory{Any}(undef, 0), 0, 0),
+        # `ht` is Memory{Any} on 1.11+ but Vector{Any} on 1.10, so get it via fieldtype.   
+        (
+            false,
+            :none,
+            nothing,
+            _new_,
+            IdDict{Int,Float64},
+            fieldtype(IdDict{Int,Float64}, :ht)(undef, 0),
+            0,
+            0,
+        ),
     ]
     general_test_cases = map(TestTypes.PRIMALS) do (interface_only, P, args)
         return (interface_only, :none, nothing, _new_, P, args...)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1408,21 +1408,13 @@ end
 
                 cache2 = prepare_hvp_cache(f, x, y)
                 @test_throws ArgumentError value_and_hvp!!(cache2, f, ([1.0], [0.0]), x, y)
-            end
 
-            # Regression test: `applicable(axes, x)` is `true` for any `x` (Base's generic
-            # `axes(A) = map(oneto, size(A))` fallback matches unconditionally), so the
-            # shape check used to run `axes(...)` on struct-shaped primals/tangents that
-            # have no `size` method at all, throwing an unrelated MethodError instead of
-            # either skipping the check or reporting a real shape mismatch.
-            @testset "HVP with struct-shaped (non-array) primal/tangent" begin
-                f(x::SimplePair) = x.x1^2 + x.x2^2
-                x = SimplePair(3.0, 4.0)
+                # A struct-shaped primal has no `size`, so the check must skip it rather
+                # than throw a MethodError from `axes`.
+                g(p::SimplePair) = p.x1^2 + p.x2^2
+                p = SimplePair(3.0, 4.0)
                 v = Mooncake.Tangent((; x1=1.0, x2=0.0))
-                cache = prepare_hvp_cache(f, x)
-                f_val, grad, hvp = value_and_hvp!!(cache, f, v, x)
-                @test f_val ≈ 25.0
-                @test grad.fields == (; x1=6.0, x2=8.0)
+                _, _, hvp = value_and_hvp!!(prepare_hvp_cache(g, p), g, v, p)
                 @test hvp.fields.fields == (; x1=2.0, x2=0.0)
             end
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1410,6 +1410,22 @@ end
                 @test_throws ArgumentError value_and_hvp!!(cache2, f, ([1.0], [0.0]), x, y)
             end
 
+            # Regression test: `applicable(axes, x)` is `true` for any `x` (Base's generic
+            # `axes(A) = map(oneto, size(A))` fallback matches unconditionally), so the
+            # shape check used to run `axes(...)` on struct-shaped primals/tangents that
+            # have no `size` method at all, throwing an unrelated MethodError instead of
+            # either skipping the check or reporting a real shape mismatch.
+            @testset "HVP with struct-shaped (non-array) primal/tangent" begin
+                f(x::SimplePair) = x.x1^2 + x.x2^2
+                x = SimplePair(3.0, 4.0)
+                v = Mooncake.Tangent((; x1=1.0, x2=0.0))
+                cache = prepare_hvp_cache(f, x)
+                f_val, grad, hvp = value_and_hvp!!(cache, f, v, x)
+                @test f_val ≈ 25.0
+                @test grad.fields == (; x1=6.0, x2=8.0)
+                @test hvp.fields == (; x1=2.0, x2=0.0)
+            end
+
             @testset "HVP cache mismatch errors" begin
                 f(x) = sum(x .* x)
                 x = [1.0, 2.0]

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1423,7 +1423,7 @@ end
                 f_val, grad, hvp = value_and_hvp!!(cache, f, v, x)
                 @test f_val ≈ 25.0
                 @test grad.fields == (; x1=6.0, x2=8.0)
-                @test hvp.fields == (; x1=2.0, x2=0.0)
+                @test hvp.fields.fields == (; x1=2.0, x2=0.0)
             end
 
             @testset "HVP cache mismatch errors" begin

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -294,7 +294,6 @@ end
     end
 
     # Regression test for the `tangent_type(::Type{<:MooncakeInterpreter}) = NoTangent`
-    # fix at the top of this file -- see that comment for why it's needed.
     @testset "MooncakeInterpreter has NoTangent tangent_type" begin
         interp = get_interpreter(ForwardMode)
         @test Mooncake.tangent_type(typeof(interp)) == Mooncake.NoTangent

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -292,4 +292,17 @@ end
         _, _, H = value_gradient_and_hessian!!(prepare_hessian_cache(f, x), f, x)
         @test H ≈ [6.0 0.0; 0.0 6.0]
     end
+
+    # Regression test for the `tangent_type(::Type{<:MooncakeInterpreter}) = NoTangent`
+    # fix at the top of this file -- see that comment for why it's needed.
+    @testset "MooncakeInterpreter has NoTangent tangent_type" begin
+        interp = get_interpreter(ForwardMode)
+        @test Mooncake.tangent_type(typeof(interp)) == Mooncake.NoTangent
+        @test Mooncake.zero_tangent(interp) isa Mooncake.NoTangent
+        # Exercise it with real, already-compiled rule state present, not just a bare
+        # fresh interpreter, since that's the scenario the recursion bug actually hit.
+        prepare_hvp_cache(x -> sum(x .* x), [1.0, 2.0])
+        interp2 = get_interpreter(ForwardMode)
+        @test Mooncake.zero_tangent(interp2) isa Mooncake.NoTangent
+    end
 end

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -293,15 +293,5 @@ end
         @test H ≈ [6.0 0.0; 0.0 6.0]
     end
 
-    # Regression test for the `tangent_type(::Type{<:MooncakeInterpreter}) = NoTangent`
-    @testset "MooncakeInterpreter has NoTangent tangent_type" begin
-        interp = get_interpreter(ForwardMode)
-        @test Mooncake.tangent_type(typeof(interp)) == Mooncake.NoTangent
-        @test Mooncake.zero_tangent(interp) isa Mooncake.NoTangent
-        # Exercise it with real, already-compiled rule state present, not just a bare
-        # fresh interpreter, since that's the scenario the recursion bug actually hit.
-        prepare_hvp_cache(x -> sum(x .* x), [1.0, 2.0])
-        interp2 = get_interpreter(ForwardMode)
-        @test Mooncake.zero_tangent(interp2) isa Mooncake.NoTangent
-    end
+    @test Mooncake.tangent_type(typeof(get_interpreter(ForwardMode))) == Mooncake.NoTangent
 end


### PR DESCRIPTION
Fixes, while getting Mooncake's HVP working for a neural ODE (SciML/SciMLSensitivity.jl#1427):

- `applicable(axes, x)` is true for any `x` (Base's generic axes fallback), so the tangent-shape check ran `axes` on struct-shaped tangents with no `size` method and threw an unrelated MethodError. Check `size` instead, since `axes` is defined in terms of it.

- `MooncakeInterpreter` had no `tangent_type`, so `zero_tangent` recursed into its own compiled-rule cache and hit an untranslatable `llvmcall`. It's compiler-internal state, never differentiable -- give it `NoTangent`.

- `_new_`'s generic tangent/fdata-construction paths misread `IdDict`'s raw `ht::Memory` field as a (k, v) pair and crashed. A fresh `IdDict` starts empty, so its tangent and fdata are now built directly via their own real constructors. Its pullback needed its own rule too, since `IdDict`'s fdata isn't the `.fields`-shaped `MutableTangent` the generic pullback assumes.

(supersedes #1256)

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1259 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1259/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 190.0 ns │     1.53 │        1.58 │   0.684 │        3.37 │   6.64 │
│                  _sum_1000 │   1.1 μs │     6.09 │        1.01 │  3400.0 │        40.7 │   1.06 │
│               sum_sin_1000 │  7.42 μs │      2.5 │        1.11 │    1.63 │        10.9 │   1.76 │
│              _sum_sin_1000 │  4.57 μs │     3.86 │        2.68 │   348.0 │        18.0 │    3.1 │
│                   kron_sum │ 198.0 μs │     12.8 │        3.25 │    6.98 │       477.0 │   18.2 │
│              kron_view_sum │ 266.0 μs │     12.8 │        5.27 │    27.6 │       453.0 │   13.5 │
│      naive_map_sin_cos_exp │  2.22 μs │     2.77 │        1.52 │ missing │        8.41 │   2.15 │
│            map_sin_cos_exp │  2.12 μs │     3.41 │        1.63 │     1.7 │        7.44 │   2.77 │
│      broadcast_sin_cos_exp │  2.25 μs │     3.14 │        1.57 │    4.67 │        1.41 │   2.13 │
│                 simple_mlp │ 343.0 μs │     5.06 │        2.93 │    2.17 │        9.51 │   3.21 │
│                     gp_lml │ 368.0 μs │      6.2 │        1.76 │    3.02 │     missing │   3.44 │
│ turing_broadcast_benchmark │  1.62 ms │     7.75 │        4.08 │ missing │        48.1 │   2.27 │
│         large_single_block │ 471.0 ns │     5.53 │        1.96 │  4120.0 │        32.5 │   2.08 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->