### PR TITLE
Friendly gradients for `Adjoint` and `Transpose`

### DIFF
--- a/docs/src/utilities/defining_rules.md
+++ b/docs/src/utilities/defining_rules.md
@@ -93,6 +93,7 @@ When `friendly_tangents=true` is passed to `value_and_gradient!!` or `prepare_gr
 - **`AbstractArray` with `IEEEFloat` (or complex) eltype**: plain array tangent, unchanged.
 - **Callables with no captured differentiable state**: `NoTangent()`, unchanged.
 - **`AbstractDict`**: a dict of the same type as the primal, with the same keys and gradient values.
+- **`LinearAlgebra.Adjoint` / `Transpose`** over a differentiable parent eltype: the same wrapper around the parent's gradient — an `AbstractMatrix` of `size(x)`, not a dense `Matrix`.
 - **Everything else** (primitive types, zero-field types, mutable structs with custom tangent types): raw Mooncake tangent, unchanged unless customised as described below.
 
 For example, with `friendly_tangents=false` (default), an immutable struct `Foo` with fields `a::Float64` and `b::Vector{Float64}` returns a `Mooncake.Tangent` wrapping `(a = da, b = db)`, and a mutable struct `Bar` with the same fields returns a `Mooncake.MutableTangent` wrapping `(a = da, b = db)`. With `friendly_tangents=true` both unwrap to the plain `NamedTuple` `(a = da, b = db)` where `da::Float64` and `db::Vector{Float64}`.

--- a/src/rules/linear_algebra.jl
+++ b/src/rules/linear_algebra.jl
@@ -18,6 +18,23 @@
 # tangent accumulation), and the non-stored triangle is zero-initialised. copyto! copies
 # the full data matrix (including complex entries) to dest, which is a plain Matrix{T}.
 
+# Adjoint and Transpose lose nothing — each entry is one parent entry, relabelled — so AsPrimal
+# can rebuild the wrapper around the parent's gradient, giving an `AbstractMatrix` of `size(x)`
+# rather than a raw `Tangent`. Reconstruction recurses, so `Adjoint(Symmetric(A))` works too.
+#
+# The conjugation in `Adjoint(dparent)` is right: Mooncake cotangents are real gradients
+# (∂L/∂re + i ∂L/∂im) and x[i, j] == conj(parent[j, i]), so d/dx[i, j] == conj(dparent[j, i]).
+#
+# Test the parent's eltype, not `eltype(x)`, which is `Union{}` for e.g. `Matrix{Symbol}`. A
+# non-differentiable one stays AsRaw; AsPrimal would return primal entries as a gradient.
+function Mooncake.friendly_tangent_cache(
+    x::Union{LinearAlgebra.Adjoint,LinearAlgebra.Transpose}
+)
+    tangent_type(eltype(parent(x))) == NoTangent &&
+        return FriendlyTangentCache{AsRaw}(nothing)
+    return FriendlyTangentCache{AsPrimal}(_copy_output(x))
+end
+
 function Mooncake.friendly_tangent_cache(x::LinearAlgebra.Symmetric{T}) where {T}
     FriendlyTangentCache{AsCustomised}(Matrix{T}(undef, size(x)...))
 end

--- a/src/tangents/tangents.jl
+++ b/src/tangents/tangents.jl
@@ -1385,6 +1385,7 @@ caches instead.
 | `AbstractArray` with non-float eltype whose `tangent_type` is not `NoTangent` | `Array` of per-element caches via `map` *(composite)* |
 | Mutable struct with fields and standard `MutableTangent` | `FriendlyTangentCache{AsMutableFields}` — per-field `NamedTuple` at runtime *(non-composite, internal mode)* |
 | `AbstractDict` | `FriendlyTangentCache{AsPrimal}` *(non-composite)* |
+| `LinearAlgebra.Adjoint` / `Transpose` over a differentiable parent eltype | `FriendlyTangentCache{AsPrimal}` *(non-composite)* |
 | `LinearAlgebra.Symmetric` / `Hermitian` / `SymTridiagonal` | `FriendlyTangentCache{AsCustomised}` *(non-composite)* |
 | Everything else (Julia primitive types, float arrays, non-differentiable arrays, custom-tangent types, zero-field types) | `FriendlyTangentCache{AsRaw}` *(non-composite)* |
 
@@ -1395,8 +1396,9 @@ Mooncake.friendly_tangent_cache(x::MyMatrix{T}) where {T} =
     Mooncake.FriendlyTangentCache{Mooncake.AsCustomised}(Matrix{T}(undef, size(x)...))
 ```
 
-Overloads for `LinearAlgebra.Symmetric`, `LinearAlgebra.Hermitian`, and
-`LinearAlgebra.SymTridiagonal` live in `src/rules/linear_algebra.jl`.
+Overloads for `LinearAlgebra.Adjoint`, `LinearAlgebra.Transpose`,
+`LinearAlgebra.Symmetric`, `LinearAlgebra.Hermitian`, and `LinearAlgebra.SymTridiagonal`
+live in `src/rules/linear_algebra.jl`.
 
 !!! warning
     Mutable structs whose fields form a self-referential cycle (e.g. a linked-list node

--- a/test/tangents/tangents.jl
+++ b/test/tangents/tangents.jl
@@ -391,6 +391,21 @@ using DispatchDoctor: allow_unstable
             Mooncake.FriendlyTangentCache{Mooncake.AsRaw}
     end
 
+    # Adjoint and Transpose relabel their parent's entries without loss, so the friendly
+    # gradient keeps the wrapper rather than falling back to the raw Tangent (#1250).
+    @testset "$W friendly gradient keeps the wrapper (#1250)" for W in (Adjoint, Transpose)
+        x = W([1.0 2.0; 3.0 4.0; 5.0 6.0])
+        tx_parent = [0.5 1.5; 2.5 3.5; 4.5 5.5]
+        tx = Mooncake.build_tangent(typeof(x), tx_parent)
+        @test Mooncake.friendly_tangent_cache(x) isa
+            Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}
+        g = Mooncake.tangent_to_friendly!!(x, tx)
+        @test g isa W
+        @test g == W(tx_parent)
+        # AsPrimal copies the primal into its buffer, so the gradient cannot alias the primal.
+        @test parent(g) !== parent(x)
+    end
+
     @testset "friendly_tangent_cache Transpose{Int} returns AsRaw (#1149)" begin
         A = transpose([1, 2])
         @test Mooncake.friendly_tangent_cache(A) isa


### PR DESCRIPTION
Fixes #1250. These wrappers only relabel entries, so `AsPrimal` can keep the wrapper around
the parent's gradient instead of returning a raw `Tangent` — no conversion hook, and nested
parents work. Non-differentiable parent eltypes stay `AsRaw` (#1149). 

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1262 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1262/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 180.0 ns │     1.72 │        1.67 │   0.667 │        3.23 │   6.23 │
│                  _sum_1000 │ 962.0 ns │     6.76 │        1.03 │  3260.0 │        37.2 │   1.07 │
│               sum_sin_1000 │  7.49 μs │     3.39 │        1.32 │    1.45 │        10.5 │   1.69 │
│              _sum_sin_1000 │  6.81 μs │     3.35 │        1.68 │   204.0 │        11.7 │   1.94 │
│                   kron_sum │ 206.0 μs │     13.4 │        3.25 │    24.0 │       366.0 │   20.2 │
│              kron_view_sum │ 292.0 μs │     11.4 │         5.0 │    25.1 │       314.0 │   12.2 │
│      naive_map_sin_cos_exp │  2.46 μs │     2.95 │        1.49 │ missing │        7.42 │   2.01 │
│            map_sin_cos_exp │  2.34 μs │      3.5 │        1.65 │    1.47 │        6.48 │   2.62 │
│      broadcast_sin_cos_exp │  2.52 μs │     3.06 │        1.43 │    3.74 │        1.34 │   1.94 │
│                 simple_mlp │ 342.0 μs │      4.9 │        2.77 │    1.54 │        9.08 │   2.98 │
│                     gp_lml │ 387.0 μs │     5.56 │        1.65 │    4.51 │     missing │   3.19 │
│ turing_broadcast_benchmark │  1.66 ms │     6.87 │        3.59 │ missing │        38.1 │   2.38 │
│         large_single_block │ 421.0 ns │      7.3 │        2.02 │  4640.0 │        32.1 │   2.05 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->