### PR TITLE
Improve `nnlib` activation rules

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
       matrix:
         test_group: [
           'basic',
+          'Nfwd',
           'rules/avoiding_non_differentiable_code',
           'rules/blas_Float64',
           'rules/blas_Float32',

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.41"
+version = "0.5.42"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -401,8 +401,9 @@ end
 # a tenth of a gradient through a large broadcast, and is bit-identical over [-5, 5]. It is
 # not done because it means restating the primal's branch here, and `sigmoid_fast`'s clamps
 # with it: 2 ns against a rule whose *value* could then drift from the function it
-# differentiates, in a formulation that has already changed once. Revisit with a profile
-# showing σ matters, and add a value-agreement test if so.
+# differentiates, in a formulation that has already changed once. `test_rule` does compare
+# the two values, but only to `√eps`, so a drift on the scale of those clamps would pass;
+# revisit with a profile showing σ matters, and with a tighter value check than that.
 #
 # Both rules differentiate the unclamped sigmoid. For large positive `x` that is not a
 # choice: σ is already exactly `1.0` in Float64 from about 36.8, so both primals are flat

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -439,15 +439,22 @@ for f in (:σ, :sigmoid_fast)
     end
 end
 
-# `tanh_fast(x::Float64)` evaluates `y = (exp(2x) - 1) / (exp(2x) + 1)` and only then
-# selects `ifelse(2x > 900, sign(x), y)`. `ifelse` is a call, so the primal computes the
-# branch it discards: past `|x| ≈ 355` that branch is `Inf/Inf`, i.e. `NaN`. The primal is
-# unharmed, but reverse mode sends a zero cotangent into the discarded `y` and the
-# quotient's pullback forms `0 * Inf`, so `NaN` reaches the argument. A rule keeps AD out of
-# that body altogether. `gelu`/`gelu_tanh` inherit the failure at `|x| ≈ 21`, far inside
-# their useful range, because they feed `λ(x + 0.044715x³)` through `tanh_fast`. An `NDual`
-# method is deliberately absent: `NDual` is not an `IEEEFloat`, so the in-kernel path
-# reaches `Base.tanh` and never this body.
+# `tanh_fast(x::Float64)` evaluates both `y = (exp(2x) - 1) / (exp(2x) + 1)` and a Remez
+# polynomial `ypoly`, and only then selects between them and `sign(x)` with
+# `ifelse(x^2 > 900, sign(x), ifelse(x^2 < 0.017, ypoly, y))`. `ifelse` is a call, so the
+# primal computes the branches it discards, and past `|x| ≈ 355` the `y` branch is
+# `Inf/Inf`, i.e. `NaN`. The primal is unharmed — `x^2 > 900` switched to `sign(x)` from
+# `|x| > 30`, well below — but reverse mode sends a zero cotangent into the discarded `y`
+# and the quotient's pullback forms `0 * Inf`, so `NaN` reaches the argument. A rule keeps
+# AD out of that body altogether. `gelu`/`gelu_tanh` inherit the failure at `|x| ≈ 21`, far
+# inside their useful range, because they feed `λ(x + 0.044715x³)` through `tanh_fast` and
+# that argument reaches 355 first. An `NDual` method is deliberately absent: `NDual` is not
+# an `IEEEFloat`, so the in-kernel path reaches `Base.tanh` and never this body.
+#
+# Below `|x| ≈ 0.13` the primal is `ypoly` while this rule reports the analytic derivative,
+# the same rule-versus-primal gap recorded for `σ`'s clamps above. The discrepancy is far
+# under the polynomial's own approximation error, and matching it would mean restating the
+# primal here.
 #
 # Writing `u = exp(-2 * abs(x))`, the derivative `1 - tanh(x)^2` is `4u / (1 + u)^2`. As for
 # `σ` above, that form is used because the textbook one collapses once `tanh(x)` rounds to

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -377,28 +377,43 @@ function rrule!!(
     return x, bias_act_id_pb!!
 end
 
-# NNlib computes the smooth `σ` in overflow-safe form, `t = exp(-abs(x));
-# ifelse(x ≥ 0, inv(1 + t), t / (1 + t))`. AD through that implementation picks up a factor
-# of `sign(x)`, which is `0` at `x == 0`, so it reports `0` there instead of `1/4`: the kink
-# `abs` introduces cancels between the two branches analytically, but not via the chain
-# rule. Exactly-zero arguments are common (zero-initialised biases, dead ReLU units).
+# The logistic sigmoid, `σ(x) = 1 / (1 + exp(-x))`, and its clamped variant `sigmoid_fast`.
+# Both are smooth, so neither needs a rule for the derivative to exist — but two numerical
+# traps make tracing the primal give the wrong answer, at opposite ends of the input range.
+#
+# Near zero: the primal is written for overflow safety, branching on the sign of `x` and
+# routing through `abs(x)`. AD therefore picks up a factor of `sign(x)`, which Julia defines as
+# `0` at `x == 0`, and reports a derivative of `0` there instead of `1/4`. The kink that `abs`
+# introduces cancels between the two branches analytically, but not through the chain rule.
+# Exactly-zero arguments are common (zero-initialised biases, dead ReLU units).
+#
+# For saturated `x`: writing `t = exp(-abs(x))`, the derivative `σ(x) * (1 - σ(x))` equals
+# `t / (1 + t)^2` for either sign of `x`. The rules use that form because it holds the small
+# quantity in `t`'s exponent, where it keeps full relative precision. The textbook form does
+# not: floats near `1.0` are spaced `eps` apart, so forming `σ(x) = 1 - δ` destroys any
+# `δ < eps/2`, and the later `1 - σ(x)` — exact in itself — recovers only what survived. That
+# quantises the derivative to one ulp and then to exactly `0` (Float64 `x ≳ 37`, Float32
+# `x ≳ 17`, Float16 `x ≳ 8`) while the true value is still a normal float. `t ≤ 1`, so the
+# quotient cannot overflow.
 for f in (:σ, :sigmoid_fast)
     @eval @is_primitive MinimalCtx Tuple{typeof(NNlib.$f),P} where {P<:IEEEFloat}
     @eval function frule!!(::Dual{typeof(NNlib.$f)}, x::Dual{P}) where {P<:IEEEFloat}
-        Ω = NNlib.$f(primal(x))
-        return Dual(Ω, tangent(x) * Ω * (one(P) - Ω))
+        t = exp(-abs(primal(x)))
+        d = t / (one(P) + t)^2
+        return Dual(NNlib.$f(primal(x)), tangent(x) * d)
     end
     @eval function rrule!!(::CoDual{typeof(NNlib.$f)}, x::CoDual{P}) where {P<:IEEEFloat}
-        Ω = NNlib.$f(primal(x))
-        sigmoid_pb!!(dΩ::P) = NoRData(), dΩ * Ω * (one(P) - Ω)
-        return zero_fcodual(Ω), sigmoid_pb!!
+        t = exp(-abs(primal(x)))
+        d = t / (one(P) + t)^2
+        sigmoid_pb!!(dΩ::P) = NoRData(), dΩ * d
+        return zero_fcodual(NNlib.$f(primal(x))), sigmoid_pb!!
     end
     # GPU elementwise and reduction rules evaluate the whole fused broadcast on `NDual`s
     # inside one kernel, so they never reach the rules above and need the derivative too.
     @eval @inline function NNlib.$f(x::NDual{P,N}) where {P<:IEEEFloat,N}
-        Ω = NNlib.$f(x.value)
-        d = Ω * (one(P) - Ω)
-        return NDual{P,N}(Ω, ntuple(i -> x.partials[i] * d, Val(N)))
+        t = exp(-abs(x.value))
+        d = t / (one(P) + t)^2
+        return NDual{P,N}(NNlib.$f(x.value), ntuple(i -> x.partials[i] * d, Val(N)))
     end
 end
 

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -452,6 +452,14 @@ end
 # that argument reaches 355 first. An `NDual` method is deliberately absent: `NDual` is not
 # an `IEEEFloat`, so the in-kernel path reaches `Base.tanh` and never this body.
 #
+# `tanh_fast(x::Float32)` is a separate body — a Remez rational `x * (n / d)` discarded when
+# `x2 < 66f0` fails — so it fails in the same way for an unrelated reason, its `n`/`d`
+# overflowing past `|x| ≈ 618587`. Through `gelu_tanh` that is reached from `|x| ≈ 258.8`,
+# only about 12x the `Float64` threshold rather than the three orders of magnitude the bare
+# functions differ by, and well inside what a `Float32` pre-activation sees. The rule covers
+# `IEEEFloat` and so covers both; what needs a test of its own is the boundary, since
+# `Float64` cases stay green with `Float32` dispatching elsewhere.
+#
 # Below `|x| ≈ 0.13` the primal is `ypoly` while this rule reports the analytic derivative,
 # the same rule-versus-primal gap recorded for `σ`'s clamps above. The discrepancy is far
 # under the polynomial's own approximation error, and matching it would mean restating the

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -391,10 +391,18 @@ end
 # `t / (1 + t)^2` for either sign of `x`. The rules use that form because it holds the small
 # quantity in `t`'s exponent, where it keeps full relative precision. The textbook form does
 # not: floats near `1.0` are spaced `eps` apart, so forming `σ(x) = 1 - δ` destroys any
-# `δ < eps/2`, and the later `1 - σ(x)` — exact in itself — recovers only what survived. That
-# quantises the derivative to one ulp and then to exactly `0` (Float64 `x ≳ 37`, Float32
-# `x ≳ 17`, Float16 `x ≳ 8`) while the true value is still a normal float. `t ≤ 1`, so the
-# quotient cannot overflow.
+# `δ < eps/2`, and the later `1 - σ(x)` — exact in itself — recovers only what survived.
+# That quantises the derivative to one ulp and then to exactly `0` (Float64 `x ≳ 37`,
+# Float32 `x ≳ 17`, Float16 `x ≳ 8`) while the true value is still a normal float. `t ≤ 1`,
+# so the quotient cannot overflow.
+#
+# `t` and the value are computed separately, so `exp` runs twice — the primal recomputes it
+# internally. Deriving the value from `t` would cut the rule body from 5.5 to 3.5 ns, about
+# a tenth of a gradient through a large broadcast, and is bit-identical over [-5, 5]. It is
+# not done because it means restating the primal's branch here, and `sigmoid_fast`'s clamps
+# with it: 2 ns against a rule whose *value* could then drift from the function it
+# differentiates, in a formulation that has already changed once. Revisit with a profile
+# showing σ matters, and add a value-agreement test if so.
 for f in (:σ, :sigmoid_fast)
     @eval @is_primitive MinimalCtx Tuple{typeof(NNlib.$f),P} where {P<:IEEEFloat}
     @eval function frule!!(::Dual{typeof(NNlib.$f)}, x::Dual{P}) where {P<:IEEEFloat}

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -417,4 +417,29 @@ for f in (:σ, :sigmoid_fast)
     end
 end
 
+# `tanh_fast(x::Float64)` evaluates `y = (exp(2x) - 1) / (exp(2x) + 1)` and only then selects
+# `ifelse(2x > 900, sign(x), y)`. `ifelse` is a call, so the primal computes the branch it
+# discards: past `|x| ≈ 355` that branch is `Inf/Inf`, i.e. `NaN`. The primal is unharmed, but
+# reverse mode sends a zero cotangent into the discarded `y` and the quotient's pullback forms
+# `0 * Inf`, so `NaN` reaches the argument. A rule keeps AD out of that body altogether.
+# `gelu`/`gelu_tanh` inherit the failure at `|x| ≈ 21`, far inside their useful range, because
+# they feed `λ(x + 0.044715x³)` through `tanh_fast`. An `NDual` method is deliberately absent:
+# `NDual` is not an `IEEEFloat`, so the in-kernel path reaches `Base.tanh` and never this body.
+#
+# Writing `u = exp(-2 * abs(x))`, the derivative `1 - tanh(x)^2` is `4u / (1 + u)^2`. As for `σ`
+# above, that form is used because the textbook one collapses once `tanh(x)` rounds to `1.0`
+# (exactly `0` for Float64 `|x| ≳ 19.5`, Float32 `|x| ≳ 9`, against a true value near `1e-17`).
+@is_primitive MinimalCtx Tuple{typeof(tanh_fast),P} where {P<:IEEEFloat}
+function frule!!(::Dual{typeof(tanh_fast)}, x::Dual{P}) where {P<:IEEEFloat}
+    u = exp(-2 * abs(primal(x)))
+    d = 4u / (one(P) + u)^2
+    return Dual(tanh_fast(primal(x)), tangent(x) * d)
+end
+function rrule!!(::CoDual{typeof(tanh_fast)}, x::CoDual{P}) where {P<:IEEEFloat}
+    u = exp(-2 * abs(primal(x)))
+    d = 4u / (one(P) + u)^2
+    tanh_fast_pb!!(dΩ::P) = NoRData(), dΩ * d
+    return zero_fcodual(tanh_fast(primal(x))), tanh_fast_pb!!
+end
+
 end

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -377,36 +377,18 @@ function rrule!!(
     return x, bias_act_id_pb!!
 end
 
-# The logistic sigmoid `σ(x) = 1 / (1 + exp(-x))` and its clamped variant `sigmoid_fast`.
-# Both are smooth, so a rule is not needed for the derivative to exist — but tracing the
-# primal gets it wrong at both ends of the range.
+# σ is smooth, but tracing the primal is wrong at both ends. At zero it routes through
+# `abs(x)`, so AD picks up `sign(0) == 0` and reports `0` for `1/4`. When saturated the
+# textbook `σ(x) * (1 - σ(x))` collapses: floats near `1.0` are spaced `eps` apart, so any
+# `δ < eps/2` is destroyed and the derivative quantises to `0` (Float64 `x ≳ 37`, Float32 `≳
+# 17`, Float16 `≳ 8`) while the true value is still normal. `t / (1 + t)^2` with `t =
+# exp(-abs(x))` holds it in an exponent instead, and `t ≤ 1` bounds the quotient.
 #
-# At zero: the primal branches on the sign of `x` for overflow safety and routes through
-# `abs(x)`, so AD picks up `sign(0)`, which Julia defines as `0`, and reports `0` instead of
-# `1/4`. The kink `abs` introduces cancels between the branches analytically but not through
-# the chain rule. Exactly-zero arguments are common — zero-initialised biases, dead ReLU
-# units.
-#
-# When saturated: writing `t = exp(-abs(x))`, the derivative is `t / (1 + t)^2` for either
-# sign, which holds the small quantity in an exponent. The textbook `σ(x) * (1 - σ(x))` does
-# not: floats near `1.0` are spaced `eps` apart, so `σ = 1 - δ` destroys any `δ < eps/2` and
-# the exact `1 - σ` recovers only what survived. That quantises the derivative to one ulp
-# and then to `0` (Float64 `x ≳ 37`, Float32 `≳ 17`, Float16 `≳ 8`) while the true value is
-# still normal. `t ≤ 1`, so the quotient cannot overflow.
-#
-# `exp` therefore runs twice, here and inside the primal. Deriving the value from `t` would
-# save 2 ns of 5.5 and is bit-identical over [-5, 5], but it means restating the primal's
-# branch and `sigmoid_fast`'s clamps here, where the value could drift from the function
-# being differentiated — and `test_rule` compares values only to `√eps`, too loose to catch
-# drift on the scale of those clamps.
-#
-# Both rules differentiate the unclamped sigmoid. Past `x ≈ 36.8` that is not a choice: σ is
-# already exactly `1.0`, so the analytic derivative — 4.2e-18 at `x = 40` — is all there is
-# to report. Below `x = -80` `sigmoid_fast` clamps the value to `0` where σ gives 6.6e-36,
-# and the rule still reports σ's. Deliberate: NNlib documents `sigmoid_fast` as a less
-# accurate σ, so its clamps are an accuracy compromise rather than a different function, and
-# matching them would put a discontinuity at exactly -80 for a value below 1e-35. Finite
-# differences see neither end.
+# `exp` runs twice, here and in the primal, rather than restating the primal's branch and
+# `sigmoid_fast`'s clamps where they could drift from it — 2 ns of 5.5. Both rules
+# differentiate the unclamped σ: past `x ≈ 36.8` the analytic value is all there is, and
+# below `-80` `sigmoid_fast`'s clamp is documented as an accuracy compromise, not a
+# different function.
 for f in (:σ, :sigmoid_fast)
     @eval @is_primitive MinimalCtx Tuple{typeof(NNlib.$f),P} where {P<:IEEEFloat}
     @eval function Mooncake.frule!!(
@@ -433,30 +415,17 @@ for f in (:σ, :sigmoid_fast)
     end
 end
 
-# `tanh_fast(x::Float64)` evaluates both `y = (exp(2x) - 1) / (exp(2x) + 1)` and a Remez
-# polynomial, then selects with `ifelse(x^2 > 900, sign(x), ifelse(x^2 < 0.017, ypoly, y))`.
-# `ifelse` is a call, so the discarded branches are computed, and past `|x| ≈ 355` the `y`
-# branch is `Inf/Inf`. The primal is unharmed — it switched to `sign(x)` back at `|x| > 30`
-# — but reverse mode sends a zero cotangent into the discarded `y` and the quotient's
-# pullback forms `0 * Inf`, putting `NaN` on the argument. A rule keeps AD out of that body.
-# `gelu`/`gelu_tanh` inherit it from `|x| ≈ 21`, since they feed `λ(x + 0.044715x³)` through
-# and that argument reaches 355 first. No `NDual` method: `NDual` is not an `IEEEFloat`, so
-# the in-kernel path reaches `Base.tanh` instead.
+# `tanh_fast` selects between branches with `ifelse`, which is a call, so the discarded
+# branch is computed: past `|x| ≈ 355` the Float64 body's `(exp(2x) - 1) / (exp(2x) + 1)` is
+# `Inf/Inf`, and a zero cotangent into that quotient's pullback forms `0 * Inf` and puts
+# `NaN` on the argument. The Float32 body overflows its Remez rational the same way past
+# `|x| ≈ 618587`, or `≈ 258.8` through `gelu_tanh`, well inside a Float32 pre-activation,
+# and needs its own test since Float64 cases stay green while Float32 dispatches elsewhere.
+# A rule keeps AD out of both bodies; `gelu`/`gelu_tanh` inherit from `|x| ≈ 21`. No `NDual`
+# method — it is not an `IEEEFloat`, so the in-kernel path reaches `Base.tanh`.
 #
-# `tanh_fast(x::Float32)` is a separate body — a Remez rational `x * (n / d)`, discarded
-# once `x2 < 66f0` fails — failing the same way for an unrelated reason, its `n`/`d`
-# overflowing past `|x| ≈ 618587`. Through `gelu_tanh` that is reached from `|x| ≈ 258.8`,
-# only 12x the Float64 threshold rather than the three orders of magnitude the bare
-# functions differ by, and well inside what a Float32 pre-activation sees. The rule covers
-# `IEEEFloat` and so covers both; the boundary needs its own test, since Float64 cases stay
-# green with Float32 dispatching elsewhere.
-#
-# Writing `u = exp(-2 * abs(x))`, the derivative `1 - tanh(x)^2` is `4u / (1 + u)^2`, used
-# for the reason given for `σ` above: the textbook form collapses to exactly `0` once
-# `tanh(x)` rounds to `1.0` (Float64 `|x| ≳ 19.5`, Float32 `≳ 9`) against a true value near
-# 1e-17. Below `|x| ≈ 0.13` the primal is `ypoly` while this reports the analytic derivative
-# — the same rule-versus-primal gap as σ's clamps, far under the polynomial's own error, and
-# matching it would mean restating the primal.
+# `4u / (1 + u)^2` with `u = exp(-2|x|)` for σ's reason: `1 - tanh(x)^2` collapses to `0`
+# once `tanh(x)` rounds to `1.0` (Float64 `|x| ≳ 19.5`, Float32 `≳ 9`).
 @is_primitive MinimalCtx Tuple{typeof(tanh_fast),P} where {P<:IEEEFloat}
 function Mooncake.frule!!(::Dual{typeof(tanh_fast)}, x::Dual{P}) where {P<:IEEEFloat}
     u = exp(-2 * abs(primal(x)))

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -382,10 +382,10 @@ end
 # traps make tracing the primal give the wrong answer, at opposite ends of the input range.
 #
 # Near zero: the primal is written for overflow safety, branching on the sign of `x` and
-# routing through `abs(x)`. AD therefore picks up a factor of `sign(x)`, which Julia defines as
-# `0` at `x == 0`, and reports a derivative of `0` there instead of `1/4`. The kink that `abs`
-# introduces cancels between the two branches analytically, but not through the chain rule.
-# Exactly-zero arguments are common (zero-initialised biases, dead ReLU units).
+# routing through `abs(x)`. AD therefore picks up a factor of `sign(x)`, which Julia defines
+# as `0` at `x == 0`, and reports a derivative of `0` there instead of `1/4`. The kink that
+# `abs` introduces cancels between the two branches analytically, but not through the chain
+# rule. Exactly-zero arguments are common (zero-initialised biases, dead ReLU units).
 #
 # For saturated `x`: writing `t = exp(-abs(x))`, the derivative `σ(x) * (1 - σ(x))` equals
 # `t / (1 + t)^2` for either sign of `x`. The rules use that form because it holds the small
@@ -435,18 +435,20 @@ for f in (:σ, :sigmoid_fast)
     end
 end
 
-# `tanh_fast(x::Float64)` evaluates `y = (exp(2x) - 1) / (exp(2x) + 1)` and only then selects
-# `ifelse(2x > 900, sign(x), y)`. `ifelse` is a call, so the primal computes the branch it
-# discards: past `|x| ≈ 355` that branch is `Inf/Inf`, i.e. `NaN`. The primal is unharmed, but
-# reverse mode sends a zero cotangent into the discarded `y` and the quotient's pullback forms
-# `0 * Inf`, so `NaN` reaches the argument. A rule keeps AD out of that body altogether.
-# `gelu`/`gelu_tanh` inherit the failure at `|x| ≈ 21`, far inside their useful range, because
-# they feed `λ(x + 0.044715x³)` through `tanh_fast`. An `NDual` method is deliberately absent:
-# `NDual` is not an `IEEEFloat`, so the in-kernel path reaches `Base.tanh` and never this body.
+# `tanh_fast(x::Float64)` evaluates `y = (exp(2x) - 1) / (exp(2x) + 1)` and only then
+# selects `ifelse(2x > 900, sign(x), y)`. `ifelse` is a call, so the primal computes the
+# branch it discards: past `|x| ≈ 355` that branch is `Inf/Inf`, i.e. `NaN`. The primal is
+# unharmed, but reverse mode sends a zero cotangent into the discarded `y` and the
+# quotient's pullback forms `0 * Inf`, so `NaN` reaches the argument. A rule keeps AD out of
+# that body altogether. `gelu`/`gelu_tanh` inherit the failure at `|x| ≈ 21`, far inside
+# their useful range, because they feed `λ(x + 0.044715x³)` through `tanh_fast`. An `NDual`
+# method is deliberately absent: `NDual` is not an `IEEEFloat`, so the in-kernel path
+# reaches `Base.tanh` and never this body.
 #
-# Writing `u = exp(-2 * abs(x))`, the derivative `1 - tanh(x)^2` is `4u / (1 + u)^2`. As for `σ`
-# above, that form is used because the textbook one collapses once `tanh(x)` rounds to `1.0`
-# (exactly `0` for Float64 `|x| ≳ 19.5`, Float32 `|x| ≳ 9`, against a true value near `1e-17`).
+# Writing `u = exp(-2 * abs(x))`, the derivative `1 - tanh(x)^2` is `4u / (1 + u)^2`. As for
+# `σ` above, that form is used because the textbook one collapses once `tanh(x)` rounds to
+# `1.0` (exactly `0` for Float64 `|x| ≳ 19.5`, Float32 `|x| ≳ 9`, against a true value near
+# `1e-17`).
 @is_primitive MinimalCtx Tuple{typeof(tanh_fast),P} where {P<:IEEEFloat}
 function frule!!(::Dual{typeof(tanh_fast)}, x::Dual{P}) where {P<:IEEEFloat}
     u = exp(-2 * abs(primal(x)))

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -415,12 +415,16 @@ end
 # differences cannot see either case — they give `0` at both ends.
 for f in (:σ, :sigmoid_fast)
     @eval @is_primitive MinimalCtx Tuple{typeof(NNlib.$f),P} where {P<:IEEEFloat}
-    @eval function frule!!(::Dual{typeof(NNlib.$f)}, x::Dual{P}) where {P<:IEEEFloat}
+    @eval function Mooncake.frule!!(
+        ::Dual{typeof(NNlib.$f)}, x::Dual{P}
+    ) where {P<:IEEEFloat}
         t = exp(-abs(primal(x)))
         d = t / (one(P) + t)^2
         return Dual(NNlib.$f(primal(x)), tangent(x) * d)
     end
-    @eval function rrule!!(::CoDual{typeof(NNlib.$f)}, x::CoDual{P}) where {P<:IEEEFloat}
+    @eval function Mooncake.rrule!!(
+        ::CoDual{typeof(NNlib.$f)}, x::CoDual{P}
+    ) where {P<:IEEEFloat}
         t = exp(-abs(primal(x)))
         d = t / (one(P) + t)^2
         sigmoid_pb!!(dΩ::P) = NoRData(), dΩ * d
@@ -450,12 +454,12 @@ end
 # `1.0` (exactly `0` for Float64 `|x| ≳ 19.5`, Float32 `|x| ≳ 9`, against a true value near
 # `1e-17`).
 @is_primitive MinimalCtx Tuple{typeof(tanh_fast),P} where {P<:IEEEFloat}
-function frule!!(::Dual{typeof(tanh_fast)}, x::Dual{P}) where {P<:IEEEFloat}
+function Mooncake.frule!!(::Dual{typeof(tanh_fast)}, x::Dual{P}) where {P<:IEEEFloat}
     u = exp(-2 * abs(primal(x)))
     d = 4u / (one(P) + u)^2
     return Dual(tanh_fast(primal(x)), tangent(x) * d)
 end
-function rrule!!(::CoDual{typeof(tanh_fast)}, x::CoDual{P}) where {P<:IEEEFloat}
+function Mooncake.rrule!!(::CoDual{typeof(tanh_fast)}, x::CoDual{P}) where {P<:IEEEFloat}
     u = exp(-2 * abs(primal(x)))
     d = 4u / (one(P) + u)^2
     tanh_fast_pb!!(dΩ::P) = NoRData(), dΩ * d

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -377,43 +377,36 @@ function rrule!!(
     return x, bias_act_id_pb!!
 end
 
-# The logistic sigmoid, `σ(x) = 1 / (1 + exp(-x))`, and its clamped variant `sigmoid_fast`.
-# Both are smooth, so neither needs a rule for the derivative to exist — but two numerical
-# traps make tracing the primal give the wrong answer, at opposite ends of the input range.
+# The logistic sigmoid `σ(x) = 1 / (1 + exp(-x))` and its clamped variant `sigmoid_fast`.
+# Both are smooth, so a rule is not needed for the derivative to exist — but tracing the
+# primal gets it wrong at both ends of the range.
 #
-# Near zero: the primal is written for overflow safety, branching on the sign of `x` and
-# routing through `abs(x)`. AD therefore picks up a factor of `sign(x)`, which Julia defines
-# as `0` at `x == 0`, and reports a derivative of `0` there instead of `1/4`. The kink that
-# `abs` introduces cancels between the two branches analytically, but not through the chain
-# rule. Exactly-zero arguments are common (zero-initialised biases, dead ReLU units).
+# At zero: the primal branches on the sign of `x` for overflow safety and routes through
+# `abs(x)`, so AD picks up `sign(0)`, which Julia defines as `0`, and reports `0` instead of
+# `1/4`. The kink `abs` introduces cancels between the branches analytically but not through
+# the chain rule. Exactly-zero arguments are common — zero-initialised biases, dead ReLU
+# units.
 #
-# For saturated `x`: writing `t = exp(-abs(x))`, the derivative `σ(x) * (1 - σ(x))` equals
-# `t / (1 + t)^2` for either sign of `x`. The rules use that form because it holds the small
-# quantity in `t`'s exponent, where it keeps full relative precision. The textbook form does
-# not: floats near `1.0` are spaced `eps` apart, so forming `σ(x) = 1 - δ` destroys any
-# `δ < eps/2`, and the later `1 - σ(x)` — exact in itself — recovers only what survived.
-# That quantises the derivative to one ulp and then to exactly `0` (Float64 `x ≳ 37`,
-# Float32 `x ≳ 17`, Float16 `x ≳ 8`) while the true value is still a normal float. `t ≤ 1`,
-# so the quotient cannot overflow.
+# When saturated: writing `t = exp(-abs(x))`, the derivative is `t / (1 + t)^2` for either
+# sign, which holds the small quantity in an exponent. The textbook `σ(x) * (1 - σ(x))` does
+# not: floats near `1.0` are spaced `eps` apart, so `σ = 1 - δ` destroys any `δ < eps/2` and
+# the exact `1 - σ` recovers only what survived. That quantises the derivative to one ulp
+# and then to `0` (Float64 `x ≳ 37`, Float32 `≳ 17`, Float16 `≳ 8`) while the true value is
+# still normal. `t ≤ 1`, so the quotient cannot overflow.
 #
-# `t` and the value are computed separately, so `exp` runs twice — the primal recomputes it
-# internally. Deriving the value from `t` would cut the rule body from 5.5 to 3.5 ns, about
-# a tenth of a gradient through a large broadcast, and is bit-identical over [-5, 5]. It is
-# not done because it means restating the primal's branch here, and `sigmoid_fast`'s clamps
-# with it: 2 ns against a rule whose *value* could then drift from the function it
-# differentiates, in a formulation that has already changed once. `test_rule` does compare
-# the two values, but only to `√eps`, so a drift on the scale of those clamps would pass;
-# revisit with a profile showing σ matters, and with a tighter value check than that.
+# `exp` therefore runs twice, here and inside the primal. Deriving the value from `t` would
+# save 2 ns of 5.5 and is bit-identical over [-5, 5], but it means restating the primal's
+# branch and `sigmoid_fast`'s clamps here, where the value could drift from the function
+# being differentiated — and `test_rule` compares values only to `√eps`, too loose to catch
+# drift on the scale of those clamps.
 #
-# Both rules differentiate the unclamped sigmoid. For large positive `x` that is not a
-# choice: σ is already exactly `1.0` in Float64 from about 36.8, so both primals are flat
-# there and the analytic derivative — 4.2e-18 at `x = 40` — is all there is to report.
-# `sigmoid_fast`'s `x < -80` clamp does change the value, to exactly `0` where σ gives
-# 6.6e-36, and there the derivative reported is σ's rather than the clamped primal's `0`.
-# Deliberate: NNlib documents `sigmoid_fast` as a less accurate σ, so its clamps are an
-# accuracy compromise rather than a different function, and matching them would put a
-# discontinuity in the derivative at exactly -80 for the sake of a value below 1e-35. Finite
-# differences cannot see either case — they give `0` at both ends.
+# Both rules differentiate the unclamped sigmoid. Past `x ≈ 36.8` that is not a choice: σ is
+# already exactly `1.0`, so the analytic derivative — 4.2e-18 at `x = 40` — is all there is
+# to report. Below `x = -80` `sigmoid_fast` clamps the value to `0` where σ gives 6.6e-36,
+# and the rule still reports σ's. Deliberate: NNlib documents `sigmoid_fast` as a less
+# accurate σ, so its clamps are an accuracy compromise rather than a different function, and
+# matching them would put a discontinuity at exactly -80 for a value below 1e-35. Finite
+# differences see neither end.
 for f in (:σ, :sigmoid_fast)
     @eval @is_primitive MinimalCtx Tuple{typeof(NNlib.$f),P} where {P<:IEEEFloat}
     @eval function Mooncake.frule!!(
@@ -441,34 +434,29 @@ for f in (:σ, :sigmoid_fast)
 end
 
 # `tanh_fast(x::Float64)` evaluates both `y = (exp(2x) - 1) / (exp(2x) + 1)` and a Remez
-# polynomial `ypoly`, and only then selects between them and `sign(x)` with
-# `ifelse(x^2 > 900, sign(x), ifelse(x^2 < 0.017, ypoly, y))`. `ifelse` is a call, so the
-# primal computes the branches it discards, and past `|x| ≈ 355` the `y` branch is
-# `Inf/Inf`, i.e. `NaN`. The primal is unharmed — `x^2 > 900` switched to `sign(x)` from
-# `|x| > 30`, well below — but reverse mode sends a zero cotangent into the discarded `y`
-# and the quotient's pullback forms `0 * Inf`, so `NaN` reaches the argument. A rule keeps
-# AD out of that body altogether. `gelu`/`gelu_tanh` inherit the failure at `|x| ≈ 21`, far
-# inside their useful range, because they feed `λ(x + 0.044715x³)` through `tanh_fast` and
-# that argument reaches 355 first. An `NDual` method is deliberately absent: `NDual` is not
-# an `IEEEFloat`, so the in-kernel path reaches `Base.tanh` and never this body.
+# polynomial, then selects with `ifelse(x^2 > 900, sign(x), ifelse(x^2 < 0.017, ypoly, y))`.
+# `ifelse` is a call, so the discarded branches are computed, and past `|x| ≈ 355` the `y`
+# branch is `Inf/Inf`. The primal is unharmed — it switched to `sign(x)` back at `|x| > 30`
+# — but reverse mode sends a zero cotangent into the discarded `y` and the quotient's
+# pullback forms `0 * Inf`, putting `NaN` on the argument. A rule keeps AD out of that body.
+# `gelu`/`gelu_tanh` inherit it from `|x| ≈ 21`, since they feed `λ(x + 0.044715x³)` through
+# and that argument reaches 355 first. No `NDual` method: `NDual` is not an `IEEEFloat`, so
+# the in-kernel path reaches `Base.tanh` instead.
 #
-# `tanh_fast(x::Float32)` is a separate body — a Remez rational `x * (n / d)` discarded when
-# `x2 < 66f0` fails — so it fails in the same way for an unrelated reason, its `n`/`d`
+# `tanh_fast(x::Float32)` is a separate body — a Remez rational `x * (n / d)`, discarded
+# once `x2 < 66f0` fails — failing the same way for an unrelated reason, its `n`/`d`
 # overflowing past `|x| ≈ 618587`. Through `gelu_tanh` that is reached from `|x| ≈ 258.8`,
-# only about 12x the `Float64` threshold rather than the three orders of magnitude the bare
-# functions differ by, and well inside what a `Float32` pre-activation sees. The rule covers
-# `IEEEFloat` and so covers both; what needs a test of its own is the boundary, since
-# `Float64` cases stay green with `Float32` dispatching elsewhere.
+# only 12x the Float64 threshold rather than the three orders of magnitude the bare
+# functions differ by, and well inside what a Float32 pre-activation sees. The rule covers
+# `IEEEFloat` and so covers both; the boundary needs its own test, since Float64 cases stay
+# green with Float32 dispatching elsewhere.
 #
-# Below `|x| ≈ 0.13` the primal is `ypoly` while this rule reports the analytic derivative,
-# the same rule-versus-primal gap recorded for `σ`'s clamps above. The discrepancy is far
-# under the polynomial's own approximation error, and matching it would mean restating the
-# primal here.
-#
-# Writing `u = exp(-2 * abs(x))`, the derivative `1 - tanh(x)^2` is `4u / (1 + u)^2`. As for
-# `σ` above, that form is used because the textbook one collapses once `tanh(x)` rounds to
-# `1.0` (exactly `0` for Float64 `|x| ≳ 19.5`, Float32 `|x| ≳ 9`, against a true value near
-# `1e-17`).
+# Writing `u = exp(-2 * abs(x))`, the derivative `1 - tanh(x)^2` is `4u / (1 + u)^2`, used
+# for the reason given for `σ` above: the textbook form collapses to exactly `0` once
+# `tanh(x)` rounds to `1.0` (Float64 `|x| ≳ 19.5`, Float32 `≳ 9`) against a true value near
+# 1e-17. Below `|x| ≈ 0.13` the primal is `ypoly` while this reports the analytic derivative
+# — the same rule-versus-primal gap as σ's clamps, far under the polynomial's own error, and
+# matching it would mean restating the primal.
 @is_primitive MinimalCtx Tuple{typeof(tanh_fast),P} where {P<:IEEEFloat}
 function Mooncake.frule!!(::Dual{typeof(tanh_fast)}, x::Dual{P}) where {P<:IEEEFloat}
     u = exp(-2 * abs(primal(x)))

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -403,6 +403,16 @@ end
 # with it: 2 ns against a rule whose *value* could then drift from the function it
 # differentiates, in a formulation that has already changed once. Revisit with a profile
 # showing σ matters, and add a value-agreement test if so.
+#
+# Both rules differentiate the unclamped sigmoid. For large positive `x` that is not a
+# choice: σ is already exactly `1.0` in Float64 from about 36.8, so both primals are flat
+# there and the analytic derivative — 4.2e-18 at `x = 40` — is all there is to report.
+# `sigmoid_fast`'s `x < -80` clamp does change the value, to exactly `0` where σ gives
+# 6.6e-36, and there the derivative reported is σ's rather than the clamped primal's `0`.
+# Deliberate: NNlib documents `sigmoid_fast` as a less accurate σ, so its clamps are an
+# accuracy compromise rather than a different function, and matching them would put a
+# discontinuity in the derivative at exactly -80 for the sake of a value below 1e-35. Finite
+# differences cannot see either case — they give `0` at both ends.
 for f in (:σ, :sigmoid_fast)
     @eval @is_primitive MinimalCtx Tuple{typeof(NNlib.$f),P} where {P<:IEEEFloat}
     @eval function frule!!(::Dual{typeof(NNlib.$f)}, x::Dual{P}) where {P<:IEEEFloat}

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -831,10 +831,9 @@ end
 @inline function Base.cosh(a::NDual{T,N}) where {T,N}
     return NDual{T,N}(cosh(a.value), _pt_scale(a.partials, sinh(a.value)))
 end
-# `4u / (1 + u)^2` with `u = exp(-2|x|)`, not the textbook `1 - tanh(x)^2`: floats near
-# `1.0` are spaced `eps` apart, so once `tanh(x)` rounds to `1.0` the subtraction returns
-# exactly `0`, while the true derivative is still normal (Float64 `|x| ≳ 19.5`, Float32
-# `|x| ≳ 9`). The forms are algebraically equal, and `u ≤ 1` bounds the quotient.
+# `4u / (1 + u)^2` with `u = exp(-2|x|)`: `1 - tanh(x)^2` returns exactly `0` once `tanh(x)`
+# rounds to `1.0`, while the true derivative is still normal (Float64 `|x| ≳ 19.5`, Float32
+# `≳ 9`).
 @inline function Base.tanh(a::NDual{T,N}) where {T,N}
     u = exp(-2 * abs(a.value))
     return NDual{T,N}(tanh(a.value), _pt_scale(a.partials, 4u / (one(T) + u)^2))

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -831,9 +831,13 @@ end
 @inline function Base.cosh(a::NDual{T,N}) where {T,N}
     return NDual{T,N}(cosh(a.value), _pt_scale(a.partials, sinh(a.value)))
 end
+# `4u / (1 + u)^2` with `u = exp(-2|x|)`, not the textbook `1 - tanh(x)^2`: floats near
+# `1.0` are spaced `eps` apart, so once `tanh(x)` rounds to `1.0` the subtraction returns
+# exactly `0`, while the true derivative is still normal (Float64 `|x| ≳ 19.5`, Float32
+# `|x| ≳ 9`). The forms are algebraically equal, and `u ≤ 1` bounds the quotient.
 @inline function Base.tanh(a::NDual{T,N}) where {T,N}
-    tv = tanh(a.value)
-    return NDual{T,N}(tv, _pt_scale(a.partials, one(T) - tv^2))
+    u = exp(-2 * abs(a.value))
+    return NDual{T,N}(tanh(a.value), _pt_scale(a.partials, 4u / (one(T) + u)^2))
 end
 @inline function Base.asinh(a::NDual{T,N}) where {T,N}
     return NDual{T,N}(asinh(a.value), _pt_scale(a.partials, inv(sqrt(a.value^2 + one(T)))))

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1092,13 +1092,21 @@ when *any* single `ε` on the grid agrees, which is what lets several things thr
     derivative entirely passes as readily as an exact one — with no tolerance slack
     involved, since most of the grid agrees exactly.
 
-- low-precision primals, where differencing cannot reconstruct `ẋ`.
-    `(fl(x + ε) - fl(x - ε)) / 2ε` is accurate only to about a spacing over `2ε`: at
-    `Float16` it is 1 to 2.3% off for the largest step and exactly `0` for the rest, missing
-    the default `1e-3` at every magnitude — including where the spacing sits well inside the
-    grid. Such arguments are untestable here rather than merely imprecise, whatever the rule
-    returns. Loosening `atol`/`rtol` is what makes them usable at all: the BFloat16 suite
-    runs at `0.2`/`0.4`.
+- arguments whose spacing is coarse against the step grid. What decides this is
+    `spacing(x)` versus `2ε`, not the element type: `Float16` is simply where ordinary
+    magnitudes reach it first. Once `spacing(x)` exceeds the largest step, `x ± ε` rounds
+    back to `x`, so the reconstruction of `ẋ` is exactly `0` for every step and the `x̄·ẋ`
+    term vanishes whatever the rule returns — from `Float16(64)`, whose spacing is `0.0625`,
+    and equally from `Float64` `1e15`, whose spacing is `0.125`. Below that boundary the
+    reconstruction degrades rather than vanishing: `Float16(2)` gives `0.977` then `1.465`
+    for the first two steps before collapsing to `0`.
+
+    Where the argument does move, the *output's* precision can still spoil the `ȳ·ẏ` term
+    independently. At `Float16(0)`, whose spacing is `6e-8`, `ẋ` reconstructs to within
+    0.02%, yet `exp` and a `sigmoid` differ from their true derivatives by 2.3% because the
+    output rounds to `Float16` — so a `Float16` case at zero fails on `ẏ`, not on `ẋ`.
+    Loosening `atol`/`rtol` is what makes that usable: the BFloat16 suite runs at
+    `0.2`/`0.4`. It does not help the vanishing case, where no tolerance below 1 suffices.
 
 - ties and kinks, where whether they agree depends on the case. A central difference returns
     the mean of the one-sided directional derivatives. At a two-way tie that mean *is* the

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1077,6 +1077,21 @@ signature associated to `x` corresponds to a primitive, a hand-written rule will
     so each argument is perturbed by at most `max_fd_step` in L2 norm. Set this for
     domain-restricted functions (`log`, `sqrt`, `cholesky`) to keep perturbations inside
     the domain. The FD grid ends at `1e-7`; the smallest usable cap is `1e-6`.
+
+# Limitations
+
+Correctness is assessed only against central finite differences, so properties that finite
+differencing cannot resolve are not covered. Two cases arise in practice:
+
+- derivative *precision* in a saturated regime. Where `f(x ± ε)` round to the same float for
+    every `ε` on the grid, the finite-difference estimate is `0` whatever the rule returns, so
+    a rule that has lost the derivative entirely passes as readily as an exact one.
+- primal types whose spacing at `x` exceeds the step grid. `Float16` hits this well inside its
+    normal range, which makes such arguments untestable here rather than merely imprecise.
+
+Accepting a caller-supplied reference derivative to compare against would close both gaps.
+Until then, a rule whose value depends on either property needs that reasoning recorded
+alongside it, since no `test_rule` call can hold it in place.
 """
 function test_rule(
     rng::AbstractRNG,

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1082,29 +1082,35 @@ signature associated to `x` corresponds to a primitive, a hand-written rule will
 
 The rule's *value* is checked directly, against `f(x)` at `√eps` tolerance, along with
 argument equality, address-map consistency and — in reverse mode — restoration of the inputs
-by the pullback. It is the *derivative* that is assessed only against central finite
-differences, so derivative properties that finite differencing cannot resolve are not
-covered. Three cases arise in practice:
+by the pullback. The *derivative* is assessed against central finite differences, as one
+`isapprox` over `ȳ·ẏ + x̄·ẋ`. Note that `ẋ` is itself reconstructed by differencing, so that
+term's accuracy — not only the derivative's — decides the outcome. The comparison passes
+when *any* single `ε` on the grid agrees, which is what lets several things through:
 
 - derivative *precision* in a saturated regime. Where `f(x ± ε)` round to the same float for
-    every `ε` on the grid, the finite-difference estimate is `0` whatever the rule returns,
-    so a rule that has lost the derivative entirely passes as readily as an exact one.
-- primal types whose spacing at `x` exceeds the step grid. `Float16` hits this well inside
-    its normal range, making such arguments untestable here rather than merely imprecise.
-- ties and kinks. At a tie or a kink a central difference returns the midpoint of the
-    one-sided derivatives, which is a different member of the subdifferential from the one a
-    rule is likely to pick. Neither is wrong, so a disagreement there is not evidence of a
-    defect — and an agreement is not evidence of correctness.
+    every `ε`, the estimate is `0` whatever the rule returns, so a rule that has lost the
+    derivative entirely passes as readily as an exact one — with no tolerance slack
+    involved, since most of the grid agrees exactly.
 
-The step grid matters for the first two: the comparison passes when *any* single `ε` agrees,
-so a derivative that has collapsed to `0` passes outright if most of the grid also estimates
-`0`. That is the usual way a saturated case slips through, and it involves no tolerance
-slack at all.
+- low-precision primals, where differencing cannot reconstruct `ẋ`.
+    `(fl(x + ε) - fl(x - ε)) / 2ε` is accurate only to about a spacing over `2ε`: at
+    `Float16` it is 1 to 2.3% off for the largest step and exactly `0` for the rest, missing
+    the default `1e-3` at every magnitude — including where the spacing sits well inside the
+    grid. Such arguments are untestable here rather than merely imprecise, whatever the rule
+    returns. Loosening `atol`/`rtol` is what makes them usable at all: the BFloat16 suite
+    runs at `0.2`/`0.4`.
 
-Accepting a caller-supplied reference derivative to compare against would close the first
-two. Until then, a rule whose derivative depends on any of these needs pinning some other
-way — calling the rule and comparing a wider-precision or analytic reference is what the
-rules in `ext/` do — since no `test_rule` call can hold it in place.
+- ties and kinks, where whether they agree depends on the case. A central difference returns
+    the mean of the one-sided directional derivatives. At a two-way tie that mean *is* the
+    symmetric split, so they agree exactly and such a case is testable. With three or more
+    tied members they part company, and at a kink they part company too when the rule takes
+    a one-sided value — `abs` at zero gives `0` against the rule's `1`. Where they differ
+    both are subgradients, so a disagreement is not evidence of a defect, and an agreement
+    is not evidence of correctness.
+
+Accepting a caller-supplied reference derivative would close the first two. Until then, a
+rule whose derivative depends on any of these needs pinning some other way — calling the
+rule and comparing a wider-precision or analytic reference is what the rules in `ext/` do.
 """
 function test_rule(
     rng::AbstractRNG,

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1080,18 +1080,31 @@ signature associated to `x` corresponds to a primitive, a hand-written rule will
 
 # Limitations
 
-Correctness is assessed only against central finite differences, so properties that finite
-differencing cannot resolve are not covered. Two cases arise in practice:
+The rule's *value* is checked directly, against `f(x)` at `√eps` tolerance, along with
+argument equality, address-map consistency and — in reverse mode — restoration of the inputs
+by the pullback. It is the *derivative* that is assessed only against central finite
+differences, so derivative properties that finite differencing cannot resolve are not
+covered. Three cases arise in practice:
 
 - derivative *precision* in a saturated regime. Where `f(x ± ε)` round to the same float for
     every `ε` on the grid, the finite-difference estimate is `0` whatever the rule returns,
     so a rule that has lost the derivative entirely passes as readily as an exact one.
 - primal types whose spacing at `x` exceeds the step grid. `Float16` hits this well inside
     its normal range, making such arguments untestable here rather than merely imprecise.
+- ties and kinks. At a tie or a kink a central difference returns the midpoint of the
+    one-sided derivatives, which is a different member of the subdifferential from the one a
+    rule is likely to pick. Neither is wrong, so a disagreement there is not evidence of a
+    defect — and an agreement is not evidence of correctness.
 
-Accepting a caller-supplied reference derivative to compare against would close both gaps.
-Until then, a rule whose value depends on either property needs that reasoning recorded
-alongside it, since no `test_rule` call can hold it in place.
+The step grid matters for the first two: the comparison passes when *any* single `ε` agrees,
+so a derivative that has collapsed to `0` passes outright if most of the grid also estimates
+`0`. That is the usual way a saturated case slips through, and it involves no tolerance
+slack at all.
+
+Accepting a caller-supplied reference derivative to compare against would close the first
+two. Until then, a rule whose derivative depends on any of these needs pinning some other
+way — calling the rule and comparing a wider-precision or analytic reference is what the
+rules in `ext/` do — since no `test_rule` call can hold it in place.
 """
 function test_rule(
     rng::AbstractRNG,

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1084,10 +1084,10 @@ Correctness is assessed only against central finite differences, so properties t
 differencing cannot resolve are not covered. Two cases arise in practice:
 
 - derivative *precision* in a saturated regime. Where `f(x ± ε)` round to the same float for
-    every `ε` on the grid, the finite-difference estimate is `0` whatever the rule returns, so
-    a rule that has lost the derivative entirely passes as readily as an exact one.
-- primal types whose spacing at `x` exceeds the step grid. `Float16` hits this well inside its
-    normal range, which makes such arguments untestable here rather than merely imprecise.
+    every `ε` on the grid, the finite-difference estimate is `0` whatever the rule returns,
+    so a rule that has lost the derivative entirely passes as readily as an exact one.
+- primal types whose spacing at `x` exceeds the step grid. `Float16` hits this well inside
+    its normal range, making such arguments untestable here rather than merely imprecise.
 
 Accepting a caller-supplied reference derivative to compare against would close both gaps.
 Until then, a rule whose value depends on either property needs that reasoning recorded

--- a/test/ext/bfloat16s/bfloat16s.jl
+++ b/test/ext/bfloat16s/bfloat16s.jl
@@ -78,11 +78,20 @@ end
     end
 
     # `sigmoid_shaped` at exactly zero comes out right for BFloat16, where it does not for
-    # the IEEEFloat types: `abs(::BFloat16)` is BFloat16s' own method rather than the
-    # `abs_float` intrinsic, so its derivative at zero is 1 not `sign(0) == 0`, and the
-    # chain rule recovers 1/4. That is why the NNlib activation rules being `IEEEFloat`-only
-    # leave BFloat16 on a correct path rather than an excluded one — see #1257 for the
-    # IEEEFloat behaviour. Composite, so not a primitive.
+    # the IEEEFloat types, and the reason is this repo's own choice rather than BFloat16s'.
+    # `ext/MooncakeBFloat16sExt.jl` makes `abs` a primitive whose rules branch on
+    # `x >= zero(P)`, taking the positive side at zero and so reporting a derivative of 1;
+    # AD therefore never traces `abs` down to the `abs_float` intrinsic, whose rule
+    # multiplies by `sign(x)` and collapses at zero because `sign(0) == 0`. The chain rule
+    # then recovers 1/4. So these two cases are what pin that rule's behaviour at zero: with
+    # `abs` traced through BFloat16s' own `BFloat16(abs(Float32(x)))`, the derivative here
+    # is 0 instead, exactly as for the IEEEFloat types — see #1257 for those.
+    #
+    # `abs` itself cannot be checked at zero this way, which is why it is absent from the
+    # cases above: at a kink a central difference returns the midpoint of the one-sided
+    # derivatives, 0, against the rule's 1. This composite is smooth there — the kink
+    # cancels between the `ifelse` branches — so finite differences do agree with it.
+    # Composite, so not a primitive.
     @testset "sigmoid_shaped at zero" for x in (P(0), P(0.5))
         test_rule(sr(123), sigmoid_shaped, x; is_primitive=false, atol=0.2, rtol=0.4)
     end

--- a/test/ext/bfloat16s/bfloat16s.jl
+++ b/test/ext/bfloat16s/bfloat16s.jl
@@ -15,8 +15,8 @@ end
 const sr = StableRNG
 const P = Core.BFloat16
 
-# The shape NNlib gives `sigmoid`: `exp(-abs(x))` selected by an `ifelse`. Smooth at zero even
-# though `abs` is not, because the kink cancels between the two branches.
+# The shape NNlib gives `sigmoid`: `exp(-abs(x))` selected by an `ifelse`. Smooth at zero
+# even though `abs` is not, because the kink cancels between the two branches.
 function sigmoid_shaped(x)
     (t=exp(-abs(x)); ifelse(x >= zero(x), inv(one(x) + t), t / (one(x) + t)))
 end
@@ -77,12 +77,12 @@ end
         test_rule(sr(123), f, xs...; is_primitive=true, atol=0.2, rtol=0.4)
     end
 
-    # `sigmoid_shaped` at exactly zero comes out right for BFloat16, where it does not for the
-    # IEEEFloat types: `abs(::BFloat16)` is BFloat16s' own method rather than the `abs_float`
-    # intrinsic, so its derivative at zero is 1 instead of `sign(0) == 0`, and the chain rule
-    # recovers 1/4. That is why the NNlib activation rules being `IEEEFloat`-only leaves
-    # BFloat16 on a correct path rather than an excluded one — see chalk-lab/Mooncake.jl#1257
-    # for the IEEEFloat behaviour. Composite, so not a primitive.
+    # `sigmoid_shaped` at exactly zero comes out right for BFloat16, where it does not for
+    # the IEEEFloat types: `abs(::BFloat16)` is BFloat16s' own method rather than the
+    # `abs_float` intrinsic, so its derivative at zero is 1 not `sign(0) == 0`, and the
+    # chain rule recovers 1/4. That is why the NNlib activation rules being `IEEEFloat`-only
+    # leave BFloat16 on a correct path rather than an excluded one — see #1257 for the
+    # IEEEFloat behaviour. Composite, so not a primitive.
     @testset "sigmoid_shaped at zero" for x in (P(0), P(0.5))
         test_rule(sr(123), sigmoid_shaped, x; is_primitive=false, atol=0.2, rtol=0.4)
     end

--- a/test/ext/bfloat16s/bfloat16s.jl
+++ b/test/ext/bfloat16s/bfloat16s.jl
@@ -83,17 +83,31 @@ end
     # `x >= zero(P)`, taking the positive side at zero and so reporting a derivative of 1;
     # AD therefore never traces `abs` down to the `abs_float` intrinsic, whose rule
     # multiplies by `sign(x)` and collapses at zero because `sign(0) == 0`. The chain rule
-    # then recovers 1/4. So these two cases are what pin that rule's behaviour at zero: with
-    # `abs` traced through BFloat16s' own `BFloat16(abs(Float32(x)))`, the derivative here
-    # is 0 instead, exactly as for the IEEEFloat types — see #1257 for those.
+    # then recovers 1/4. With `abs` traced through BFloat16s' own
+    # `BFloat16(abs(Float32(x)))` the derivative here is 0 instead, exactly as for the
+    # IEEEFloat types — see #1257 for those.
     #
-    # `abs` itself cannot be checked at zero this way, which is why it is absent from the
-    # cases above: at a kink a central difference returns the midpoint of the one-sided
-    # derivatives, 0, against the rule's 1. This composite is smooth there — the kink
-    # cancels between the `ifelse` branches — so finite differences do agree with it.
-    # Composite, so not a primitive.
-    @testset "sigmoid_shaped at zero" for x in (P(0), P(0.5))
-        test_rule(sr(123), sigmoid_shaped, x; is_primitive=false, atol=0.2, rtol=0.4)
+    # `test_rule` cannot tell those apart, so the derivative is pinned by calling the rule.
+    # Only ε = 1e-2 gives a nonzero finite difference here: at every smaller step
+    # `sigmoid_shaped(±ε)` rounds back to `0.5` and the estimate is exactly 0. Since the
+    # check passes when any one step agrees, a collapsed derivative of 0 matches six of the
+    # seven exactly, with no tolerance involved. Switching this rule's branch to the
+    # intrinsic's `sign(x)` moves the value below from 1/4 to 0 and leaves the whole group
+    # green.
+    #
+    # `abs` itself is absent from the cases above for the related reason that at a kink a
+    # central difference returns the midpoint of the one-sided derivatives, 0, against the
+    # rule's 1. The composite is smooth at zero — the kink cancels between the `ifelse`
+    # branches — which is what lets `test_rule` run on it at all.
+    @testset "sigmoid_shaped at zero" begin
+        rule = Mooncake.build_rrule(sigmoid_shaped, P(0))
+        _, pb = rule(Mooncake.zero_fcodual(sigmoid_shaped), Mooncake.zero_fcodual(P(0)))
+        @test Float64(pb(one(P))[2]) ≈ 0.25 rtol = 1e-2
+        # `test_rule` still earns its place either side of zero: its value-agreement,
+        # interface and caching checks are unaffected by the finite-difference blind spot.
+        for x in (P(0), P(0.5))
+            test_rule(sr(123), sigmoid_shaped, x; is_primitive=false, atol=0.2, rtol=0.4)
+        end
     end
 
     # When x == 0 and 0 < y < 1: z = 0^y = 0, log(0) = -Inf, so z * log(x) = 0 * (-Inf) = NaN

--- a/test/ext/bfloat16s/bfloat16s.jl
+++ b/test/ext/bfloat16s/bfloat16s.jl
@@ -15,6 +15,12 @@ end
 const sr = StableRNG
 const P = Core.BFloat16
 
+# The shape NNlib gives `sigmoid`: `exp(-abs(x))` selected by an `ifelse`. Smooth at zero even
+# though `abs` is not, because the kink cancels between the two branches.
+function sigmoid_shaped(x)
+    (t=exp(-abs(x)); ifelse(x >= zero(x), inv(one(x) + t), t / (one(x) + t)))
+end
+
 @testset "bfloat16s" begin
     @testset "tangent interface" begin
         rng = sr(123)
@@ -69,6 +75,16 @@ const P = Core.BFloat16
     # inputs, yielding |LHS-RHS|≈0.16 even when ẏ_fd≠0 → atol=0.2.
     @testset "$(f) $(map(typeof, xs))" for (f, xs...) in cases
         test_rule(sr(123), f, xs...; is_primitive=true, atol=0.2, rtol=0.4)
+    end
+
+    # `sigmoid_shaped` at exactly zero comes out right for BFloat16, where it does not for the
+    # IEEEFloat types: `abs(::BFloat16)` is BFloat16s' own method rather than the `abs_float`
+    # intrinsic, so its derivative at zero is 1 instead of `sign(0) == 0`, and the chain rule
+    # recovers 1/4. That is why the NNlib activation rules being `IEEEFloat`-only leaves
+    # BFloat16 on a correct path rather than an excluded one — see chalk-lab/Mooncake.jl#1257
+    # for the IEEEFloat behaviour. Composite, so not a primitive.
+    @testset "sigmoid_shaped at zero" for x in (P(0), P(0.5))
+        test_rule(sr(123), sigmoid_shaped, x; is_primitive=false, atol=0.2, rtol=0.4)
     end
 
     # When x == 0 and 0 < y < 1: z = 0^y = 0, log(0) = -Inf, so z * log(x) = 0 * (-Inf) = NaN

--- a/test/ext/bfloat16s/bfloat16s.jl
+++ b/test/ext/bfloat16s/bfloat16s.jl
@@ -77,26 +77,12 @@ end
         test_rule(sr(123), f, xs...; is_primitive=true, atol=0.2, rtol=0.4)
     end
 
-    # `sigmoid_shaped` at exactly zero comes out right for BFloat16 where it does not for
-    # the IEEEFloat types, and the reason is this repo's own choice:
-    # `ext/MooncakeBFloat16sExt.jl` makes `abs` a primitive whose rules branch on `x >=
-    # zero(P)`, taking the positive side at zero and reporting 1, so AD never reaches the
-    # `abs_float` intrinsic whose rule multiplies by `sign(x)` and collapses at zero. The
-    # chain rule then recovers 1/4. Trace `abs` through BFloat16s' own
-    # `BFloat16(abs(Float32(x)))` and the derivative is 0 here too — see #1257 for the
-    # IEEEFloat types.
-    #
-    # `test_rule` cannot tell those apart, so the derivative is pinned by calling the rule.
-    # Only ε = 1e-2 gives a nonzero finite difference: at every smaller step
-    # `sigmoid_shaped(±ε)` rounds back to `0.5`. Since the check passes when any one step
-    # agrees, a collapsed derivative of 0 matches six of the seven exactly, no tolerance
-    # involved — switching this rule's branch to the intrinsic's `sign(x)` moves the value
-    # below from 1/4 to 0 and leaves the group green.
-    #
-    # `abs` itself is absent from the cases above for the related reason that at a kink a
-    # central difference returns the midpoint of the one-sided derivatives, 0, against the
-    # rule's 1. The composite is smooth at zero — the kink cancels between the `ifelse`
-    # branches — which is what lets `test_rule` run on it at all.
+    # Right at zero for BFloat16 where it is not for the IEEEFloat types, because this
+    # repo's `abs` rules branch on `x >= zero(P)` and take the positive side, never reaching
+    # the `abs_float` intrinsic's `sign(x)`. Pinned by calling the rule, since `test_rule`
+    # passes when any one step agrees and a collapsed 0 matches six of the seven exactly:
+    # below ε = 1e-2, `sigmoid_shaped(±ε)` rounds back to `0.5`. `abs` itself is absent
+    # above because a central difference returns 0 at its kink against the rule's 1.
     @testset "sigmoid_shaped at zero" begin
         rule = Mooncake.build_rrule(sigmoid_shaped, P(0))
         _, pb = rule(Mooncake.zero_fcodual(sigmoid_shaped), Mooncake.zero_fcodual(P(0)))

--- a/test/ext/bfloat16s/bfloat16s.jl
+++ b/test/ext/bfloat16s/bfloat16s.jl
@@ -77,23 +77,21 @@ end
         test_rule(sr(123), f, xs...; is_primitive=true, atol=0.2, rtol=0.4)
     end
 
-    # `sigmoid_shaped` at exactly zero comes out right for BFloat16, where it does not for
-    # the IEEEFloat types, and the reason is this repo's own choice rather than BFloat16s'.
-    # `ext/MooncakeBFloat16sExt.jl` makes `abs` a primitive whose rules branch on
-    # `x >= zero(P)`, taking the positive side at zero and so reporting a derivative of 1;
-    # AD therefore never traces `abs` down to the `abs_float` intrinsic, whose rule
-    # multiplies by `sign(x)` and collapses at zero because `sign(0) == 0`. The chain rule
-    # then recovers 1/4. With `abs` traced through BFloat16s' own
-    # `BFloat16(abs(Float32(x)))` the derivative here is 0 instead, exactly as for the
-    # IEEEFloat types — see #1257 for those.
+    # `sigmoid_shaped` at exactly zero comes out right for BFloat16 where it does not for
+    # the IEEEFloat types, and the reason is this repo's own choice:
+    # `ext/MooncakeBFloat16sExt.jl` makes `abs` a primitive whose rules branch on `x >=
+    # zero(P)`, taking the positive side at zero and reporting 1, so AD never reaches the
+    # `abs_float` intrinsic whose rule multiplies by `sign(x)` and collapses at zero. The
+    # chain rule then recovers 1/4. Trace `abs` through BFloat16s' own
+    # `BFloat16(abs(Float32(x)))` and the derivative is 0 here too — see #1257 for the
+    # IEEEFloat types.
     #
     # `test_rule` cannot tell those apart, so the derivative is pinned by calling the rule.
-    # Only ε = 1e-2 gives a nonzero finite difference here: at every smaller step
-    # `sigmoid_shaped(±ε)` rounds back to `0.5` and the estimate is exactly 0. Since the
-    # check passes when any one step agrees, a collapsed derivative of 0 matches six of the
-    # seven exactly, with no tolerance involved. Switching this rule's branch to the
-    # intrinsic's `sign(x)` moves the value below from 1/4 to 0 and leaves the whole group
-    # green.
+    # Only ε = 1e-2 gives a nonzero finite difference: at every smaller step
+    # `sigmoid_shaped(±ε)` rounds back to `0.5`. Since the check passes when any one step
+    # agrees, a collapsed derivative of 0 matches six of the seven exactly, no tolerance
+    # involved — switching this rule's branch to the intrinsic's `sign(x)` moves the value
+    # below from 1/4 to 0 and leaves the group green.
     #
     # `abs` itself is absent from the cases above for the related reason that at a kink a
     # central difference returns the midpoint of the one-sided derivatives, 0, against the

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -503,24 +503,16 @@ end
             StableRNG(123), x -> sum(f.(x)), cu([0.0f0, 0.5f0, -0.5f0]); is_primitive=false
         )
     end
-    # Saturated inputs, where `Ω * (1 - Ω)` loses the derivative entirely. These cover NaN,
-    # Inf and type stability out here, not the precision itself — see the "Limitations"
-    # section of `test_rule`'s docstring for why finite differences cannot see it. Float16
-    # is absent for a different reason, given below.
+    # Saturated inputs. These cover NaN, Inf and type stability, not the precision itself —
+    # see the Limitations section of `test_rule`'s docstring.
     test_rule(StableRNG(123), f, 37.0; perf_flag=:stability)
     test_rule(StableRNG(123), f, 17.0f0; perf_flag=:stability)
 
-    # Float16 collapses first, at x >= 8, and `test_rule` cannot be used on it at all —
-    # not because it would pass the collapsed formula, but because it fails whichever
-    # formula is in place. Its check compares `ȳ·ẏ + x̄·ẋ` in one `isapprox`, and at
-    # `Float16(8)` both terms are unusable. `ẏ` is exactly `0` for every step, σ's output
-    # being saturated: its spacing there is 4.88e-4 against a true change of 3.35e-6. `ẋ`,
-    # itself reconstructed by differencing, is 2.3% off for the largest step and `0` for the
-    # rest, the spacing being 0.0078 against a `2ε` of 0.02. So compare against a
-    # wider-precision reference. `Ω * (1 - Ω)` returns exactly 0 here, so these are the only
-    # tests pinning σ's precision, and the formula has three copies — one per rule and one
-    # for the in-kernel `NDual` method — so each gets its own. All three are directly
-    # callable, the rules because they take `P<:IEEEFloat`.
+    # Float16 collapses first, at x >= 8, where `test_rule` fails whichever formula is in
+    # place: both terms of its `ȳ·ẏ + x̄·ẋ` check are unusable, `ẏ` being exactly 0 for
+    # every step (spacing 4.88e-4 against a true change of 3.35e-6) and `ẋ` 2.3% off at
+    # best. So compare against a wider-precision reference. `Ω * (1 - Ω)` returns exactly 0
+    # here, so these are the only tests pinning σ's precision, once per copy of the formula.
     ref16 = (b=big(8.0); y=inv(1 + exp(-b)); Float64(y * (1 - y)))
     x16 = NDual{Float16,1}(Float16(8), (one(Float16),))
     @test Float64(ndual_partial(f(x16), 1)) ≈ ref16 rtol = 1e-2

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -512,14 +512,15 @@ end
 
     # Float16 collapses first, at x >= 8, and `test_rule` cannot be used on it at all —
     # not because it would pass the collapsed formula, but because it fails whichever
-    # formula is in place. Its check compares `ȳ·ẏ + x̄·ẋ` in one `isapprox`, and the `ẋ`
-    # term is itself reconstructed by differencing, which at Float16 lands 1 to 2.3% off for
-    # the largest step and exactly 0 for the rest — outside the default `1e-3` at every
-    # magnitude, spacing well inside the grid included. So compare against a wider-precision
-    # reference. `Ω * (1 - Ω)` returns exactly 0 here, so these are the only tests pinning
-    # σ's precision, and the formula has three copies — one per rule and one for the
-    # in-kernel `NDual` method — so each gets its own. All three are directly callable, the
-    # rules because they take `P<:IEEEFloat`.
+    # formula is in place. Its check compares `ȳ·ẏ + x̄·ẋ` in one `isapprox`, and at
+    # `Float16(8)` both terms are unusable. `ẏ` is exactly `0` for every step, σ's output
+    # being saturated: its spacing there is 4.88e-4 against a true change of 3.35e-6. `ẋ`,
+    # itself reconstructed by differencing, is 2.3% off for the largest step and `0` for the
+    # rest, the spacing being 0.0078 against a `2ε` of 0.02. So compare against a
+    # wider-precision reference. `Ω * (1 - Ω)` returns exactly 0 here, so these are the only
+    # tests pinning σ's precision, and the formula has three copies — one per rule and one
+    # for the in-kernel `NDual` method — so each gets its own. All three are directly
+    # callable, the rules because they take `P<:IEEEFloat`.
     ref16 = (b=big(8.0); y=inv(1 + exp(-b)); Float64(y * (1 - y)))
     x16 = NDual{Float16,1}(Float16(8), (one(Float16),))
     @test Float64(ndual_partial(f(x16), 1)) ≈ ref16 rtol = 1e-2

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -503,8 +503,20 @@ end
             StableRNG(123), x -> sum(f.(x)), cu([0.0f0, 0.5f0, -0.5f0]); is_primitive=false
         )
     end
-    # Saturated inputs, where `Ω * (1 - Ω)` loses the derivative entirely. Float16 is omitted:
-    # its spacing at such `x` exceeds every finite-difference step `test_rule` tries.
+    # Saturated inputs, where `Ω * (1 - Ω)` loses the derivative entirely. These cover NaN, Inf
+    # and type stability out here, not the precision itself — see the "Limitations" section of
+    # `test_rule`'s docstring for why finite differences cannot see it, and why Float16 (whose
+    # spacing at such `x` exceeds every step tried) is absent.
     test_rule(StableRNG(123), f, 37.0; perf_flag=:stability)
     test_rule(StableRNG(123), f, 17.0f0; perf_flag=:stability)
+end
+
+# `tanh_fast`'s primal discards an `ifelse` branch that overflows to `NaN`; reverse mode picked
+# that branch up as `0 * Inf`, which poisoned `gelu`/`gelu_tanh` from `|x| ≈ 21` upwards.
+@testset "tanh_fast at saturation" begin
+    test_rule(StableRNG(123), tanh_fast, 0.5; perf_flag=:stability)
+    test_rule(StableRNG(123), tanh_fast, 400.0; perf_flag=:stability)
+    test_rule(
+        StableRNG(123), x -> sum(NNlib.gelu_tanh.(x)), [1.0, 25.0]; is_primitive=false
+    )
 end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -503,4 +503,8 @@ end
             StableRNG(123), x -> sum(f.(x)), cu([0.0f0, 0.5f0, -0.5f0]); is_primitive=false
         )
     end
+    # Saturated inputs, where `Ω * (1 - Ω)` loses the derivative entirely. Float16 is omitted:
+    # its spacing at such `x` exceeds every finite-difference step `test_rule` tries.
+    test_rule(StableRNG(123), f, 37.0; perf_flag=:stability)
+    test_rule(StableRNG(123), f, 17.0f0; perf_flag=:stability)
 end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -493,7 +493,7 @@ end
 end
 
 # NNlib's `exp(-abs(x))` form of σ has a kink at zero that the function itself does not.
-@testset "sigmoid at zero: $f" for f in (NNlib.σ, NNlib.sigmoid_fast)
+@testset "sigmoid at zero and saturation: $f" for f in (NNlib.σ, NNlib.sigmoid_fast)
     test_rule(StableRNG(123), f, 0.0; perf_flag=:stability)
     # The reported failure was a gradient through a broadcast containing an exact zero.
     test_rule(StableRNG(123), x -> sum(f.(x)), [0.0, 0.5, -0.5]; is_primitive=false)
@@ -509,6 +509,15 @@ end
     # spacing at such `x` exceeds every step tried) is absent.
     test_rule(StableRNG(123), f, 37.0; perf_flag=:stability)
     test_rule(StableRNG(123), f, 17.0f0; perf_flag=:stability)
+
+    # Float16 collapses first, at x >= 8, and is the one width no finite-difference test can
+    # cover: the estimate is 0 too, and `isapprox(0, 3.35e-4; atol=1e-3)` holds, so
+    # `test_rule` would pass the collapsed implementation. The `NDual` method is directly
+    # callable, so compare it against a wider-precision reference instead. `Ω * (1 - Ω)`
+    # returns exactly 0 here, so this is the only test pinning σ's precision at all.
+    x16 = NDual{Float16,1}(Float16(8), (one(Float16),))
+    ref16 = (b=big(8.0); y=inv(1 + exp(-b)); Float64(y * (1 - y)))
+    @test Float64(ndual_partial(f(x16), 1)) ≈ ref16 rtol = 1e-2
 end
 
 # `tanh_fast`'s primal discards an `ifelse` branch that overflows to `NaN`; reverse mode picked

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -503,10 +503,10 @@ end
             StableRNG(123), x -> sum(f.(x)), cu([0.0f0, 0.5f0, -0.5f0]); is_primitive=false
         )
     end
-    # Saturated inputs, where `Ω * (1 - Ω)` loses the derivative entirely. These cover NaN, Inf
-    # and type stability out here, not the precision itself — see the "Limitations" section of
-    # `test_rule`'s docstring for why finite differences cannot see it, and why Float16 (whose
-    # spacing at such `x` exceeds every step tried) is absent.
+    # Saturated inputs, where `Ω * (1 - Ω)` loses the derivative entirely. These cover NaN,
+    # Inf and type stability out here, not the precision itself — see the "Limitations"
+    # section of `test_rule`'s docstring for why finite differences cannot see it, and why
+    # Float16 (whose spacing at such `x` exceeds every step tried) is absent.
     test_rule(StableRNG(123), f, 37.0; perf_flag=:stability)
     test_rule(StableRNG(123), f, 17.0f0; perf_flag=:stability)
 
@@ -520,8 +520,9 @@ end
     @test Float64(ndual_partial(f(x16), 1)) ≈ ref16 rtol = 1e-2
 end
 
-# `tanh_fast`'s primal discards an `ifelse` branch that overflows to `NaN`; reverse mode picked
-# that branch up as `0 * Inf`, which poisoned `gelu`/`gelu_tanh` from `|x| ≈ 21` upwards.
+# `tanh_fast`'s primal discards an `ifelse` branch that overflows to `NaN`; reverse mode
+# picked that branch up as `0 * Inf`, which poisoned `gelu`/`gelu_tanh` from `|x| ≈ 21`
+# upwards.
 @testset "tanh_fast at saturation" begin
     test_rule(StableRNG(123), tanh_fast, 0.5; perf_flag=:stability)
     test_rule(StableRNG(123), tanh_fast, 400.0; perf_flag=:stability)

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -523,9 +523,12 @@ end
 # `tanh_fast`'s primal discards an `ifelse` branch that overflows to `NaN`; reverse mode
 # picked that branch up as `0 * Inf`, which poisoned `gelu`/`gelu_tanh` from `|x| ≈ 21`
 # upwards.
-@testset "tanh_fast at saturation" begin
+@testset "tanh_fast across NNlib's branches" begin
     test_rule(StableRNG(123), tanh_fast, 0.5; perf_flag=:stability)
     test_rule(StableRNG(123), tanh_fast, 400.0; perf_flag=:stability)
+    # Below |x| ≈ 0.13 the primal switches to a polynomial while the rule stays analytic, so
+    # this pins the gap between them as small enough for finite differences not to see it.
+    test_rule(StableRNG(123), tanh_fast, 0.05; perf_flag=:stability)
     test_rule(
         StableRNG(123), x -> sum(NNlib.gelu_tanh.(x)), [1.0, 25.0]; is_primitive=false
     )

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -512,12 +512,20 @@ end
 
     # Float16 collapses first, at x >= 8, and is the one width no finite-difference test can
     # cover: the estimate is 0 too, and `isapprox(0, 3.35e-4; atol=1e-3)` holds, so
-    # `test_rule` would pass the collapsed implementation. The `NDual` method is directly
-    # callable, so compare it against a wider-precision reference instead. `Ω * (1 - Ω)`
-    # returns exactly 0 here, so this is the only test pinning σ's precision at all.
-    x16 = NDual{Float16,1}(Float16(8), (one(Float16),))
+    # `test_rule` would pass the collapsed implementation. Compare against a wider-precision
+    # reference instead. `Ω * (1 - Ω)` returns exactly 0 here, so these are the only tests
+    # pinning σ's precision, and the formula has three copies — one per rule and one for the
+    # in-kernel `NDual` method — so each gets its own. All three are directly callable, the
+    # rules because they take `P<:IEEEFloat`.
     ref16 = (b=big(8.0); y=inv(1 + exp(-b)); Float64(y * (1 - y)))
+    x16 = NDual{Float16,1}(Float16(8), (one(Float16),))
     @test Float64(ndual_partial(f(x16), 1)) ≈ ref16 rtol = 1e-2
+    d16 = Mooncake.frule!!(
+        Mooncake.Dual(f, Mooncake.NoTangent()), Mooncake.Dual(Float16(8), one(Float16))
+    )
+    @test Float64(Mooncake.tangent(d16)) ≈ ref16 rtol = 1e-2
+    _, pb16 = Mooncake.rrule!!(Mooncake.zero_fcodual(f), Mooncake.zero_fcodual(Float16(8)))
+    @test Float64(pb16(one(Float16))[2]) ≈ ref16 rtol = 1e-2
 end
 
 # `tanh_fast`'s primal discards an `ifelse` branch that overflows to `NaN`; reverse mode
@@ -532,4 +540,17 @@ end
     test_rule(
         StableRNG(123), x -> sum(NNlib.gelu_tanh.(x)), [1.0, 25.0]; is_primitive=false
     )
+    # As for σ, the saturated derivative's precision is beyond finite differences, and both
+    # rules carry their own copy of `4u / (1 + u)^2`. `1 - Ω^2` returns exactly 0 at
+    # Float16(6), against a true 2.46e-5, so this separates the two forms outright.
+    ref16 = Float64(1 - tanh(big(6.0))^2)
+    d16 = Mooncake.frule!!(
+        Mooncake.Dual(tanh_fast, Mooncake.NoTangent()),
+        Mooncake.Dual(Float16(6), one(Float16)),
+    )
+    @test Float64(Mooncake.tangent(d16)) ≈ ref16 rtol = 1e-2
+    _, pb16 = Mooncake.rrule!!(
+        Mooncake.zero_fcodual(tanh_fast), Mooncake.zero_fcodual(Float16(6))
+    )
+    @test Float64(pb16(one(Float16))[2]) ≈ ref16 rtol = 1e-2
 end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -543,6 +543,12 @@ end
     test_rule(
         StableRNG(123), x -> sum(NNlib.gelu_tanh.(x)), [1.0, 25.0]; is_primitive=false
     )
+    # NNlib's `tanh_fast(::Float32)` is a different body from the `Float64` one — a Remez
+    # rational whose discarded branch overflows, rather than an `exp` quotient — so none of
+    # the cases above reach it, and the rule kept working for `Float64` with `Float32`
+    # removed from it. Through `gelu_tanh` the Float32 gradient goes `NaN` from |x| ≈ 258.8,
+    # so a scalar there fails without the rule and passes with it.
+    test_rule(StableRNG(123), NNlib.gelu_tanh, 300.0f0; is_primitive=false)
     # As for σ, the saturated derivative's precision is beyond finite differences, and both
     # rules carry their own copy of `4u / (1 + u)^2`. `1 - Ω^2` returns exactly 0 at
     # Float16(6), against a true 2.46e-5, so this separates the two forms outright.

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -505,16 +505,19 @@ end
     end
     # Saturated inputs, where `Ω * (1 - Ω)` loses the derivative entirely. These cover NaN,
     # Inf and type stability out here, not the precision itself — see the "Limitations"
-    # section of `test_rule`'s docstring for why finite differences cannot see it, and why
-    # Float16 (whose spacing at such `x` exceeds every step tried) is absent.
+    # section of `test_rule`'s docstring for why finite differences cannot see it. Float16
+    # is absent for a different reason, given below.
     test_rule(StableRNG(123), f, 37.0; perf_flag=:stability)
     test_rule(StableRNG(123), f, 17.0f0; perf_flag=:stability)
 
-    # Float16 collapses first, at x >= 8, and is the one width no finite-difference test can
-    # cover: the estimate is 0 too, and `isapprox(0, 3.35e-4; atol=1e-3)` holds, so
-    # `test_rule` would pass the collapsed implementation. Compare against a wider-precision
-    # reference instead. `Ω * (1 - Ω)` returns exactly 0 here, so these are the only tests
-    # pinning σ's precision, and the formula has three copies — one per rule and one for the
+    # Float16 collapses first, at x >= 8, and `test_rule` cannot be used on it at all —
+    # not because it would pass the collapsed formula, but because it fails whichever
+    # formula is in place. Its check compares `ȳ·ẏ + x̄·ẋ` in one `isapprox`, and the `ẋ`
+    # term is itself reconstructed by differencing, which at Float16 lands 1 to 2.3% off for
+    # the largest step and exactly 0 for the rest — outside the default `1e-3` at every
+    # magnitude, spacing well inside the grid included. So compare against a wider-precision
+    # reference. `Ω * (1 - Ω)` returns exactly 0 here, so these are the only tests pinning
+    # σ's precision, and the formula has three copies — one per rule and one for the
     # in-kernel `NDual` method — so each gets its own. All three are directly callable, the
     # rules because they take `P<:IEEEFloat`.
     ref16 = (b=big(8.0); y=inv(1 + exp(-b)); Float64(y * (1 - y)))

--- a/test/nfwd/nfwd.jl
+++ b/test/nfwd/nfwd.jl
@@ -212,6 +212,12 @@ using Mooncake.Nfwd
                     (cosh, sinh),
                 ],
             ),
+            (
+                # Saturated: `1 - tanh(x)^2` returns exactly 0 out here, since `tanh(x)` has
+                # rounded to `1.0`, so the reference has to come from wider precision.
+                20.0,
+                [(tanh, x -> Float64(1 - tanh(big(x))^2))],
+            ),
         ]
             for (f, df) in fns
                 d = _d(v, 1.0)


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1263 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1263/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 191.0 ns │     1.62 │        1.63 │   0.628 │         3.2 │   5.87 │
│                  _sum_1000 │ 962.0 ns │     6.91 │        1.03 │  3520.0 │        41.5 │   1.07 │
│               sum_sin_1000 │  7.11 μs │     3.49 │        1.33 │    1.52 │        11.0 │   1.81 │
│              _sum_sin_1000 │  5.65 μs │     3.65 │        2.03 │   267.0 │        13.8 │   2.32 │
│                   kron_sum │ 214.0 μs │     12.0 │        3.08 │    8.99 │       343.0 │   18.9 │
│              kron_view_sum │ 290.0 μs │     11.1 │        5.09 │    24.9 │       317.0 │   12.1 │
│      naive_map_sin_cos_exp │   2.3 μs │     3.01 │        1.49 │ missing │        7.63 │   2.13 │
│            map_sin_cos_exp │  2.33 μs │     3.54 │         1.6 │    1.54 │        6.53 │    2.7 │
│      broadcast_sin_cos_exp │  2.43 μs │     3.05 │        1.55 │    4.27 │        1.39 │    2.0 │
│                 simple_mlp │ 354.0 μs │     4.88 │        2.72 │    2.21 │        8.76 │    2.9 │
│                     gp_lml │ 172.0 μs │     11.3 │        2.54 │    5.11 │     missing │   5.34 │
│ turing_broadcast_benchmark │  1.66 ms │     6.85 │         3.6 │ missing │        39.9 │   2.41 │
│         large_single_block │ 421.0 ns │     5.52 │         1.9 │  4700.0 │        32.8 │   2.05 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->