### PR TITLE
Restrict nnlib rules' scoping

### DIFF
--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -268,36 +268,6 @@ Instead, you will need to use lower-level (internal) functionality, such as `Moo
 
 Honestly, your best bet is just to avoid differentiating functions whose arguments are pointers if you can.
 
-## Forward mode over some NNlib reductions on GPU arrays
-
-`NNlib.softmax`, `logsoftmax`, `logsumexp` and `gather` have reverse-mode rules but no
-forward-mode ones, so forward mode traces their primals. On CPU arrays that works. On GPU
-arrays it does not, and the two failure modes are worth separating.
-
-For `softmax`, `logsoftmax` and `logsumexp` the traced primal reaches a GPU kernel launch,
-which is a foreigncall with no `frule!!`, so Mooncake raises
-`MissingForeigncallRuleError` — its own error, naming the foreigncall it cannot
-differentiate. That is a clear diagnosis, if not a fix.
-
-`gather` is worse: forward mode over a GPU array terminates the process with
-`signal 4 (Illegal instruction)` from inside the derived rule, with no Julia exception to
-catch. Nothing about the failure is recoverable or informative.
-
-Reverse mode over all four works on GPU arrays, as does forward mode over the same functions
-on CPU arrays. Writing `frule!!`s for them would remove the limitation; short of that, a
-GPU-array `frule!!` that raises deliberately would turn the `gather` crash into an ordinary
-error.
-
-Tracing the primal also means the two modes disagree at infinite inputs. `NNlib.logsumexp`
-returns `NaN` for `[Inf, Inf]`, `[Inf, 1]` and `[-Inf, -Inf]`, because the maximal entry
-forms `exp(Inf - Inf)`. The reverse-mode rule deliberately does not reproduce that: it
-substitutes the limit, giving `Inf` with weights `[1, 0]` where one entry attains the
-extremum and an equal share where several tie. Forward mode has no rule to substitute
-anything, so it differentiates what NNlib actually computes and returns `NaN` for both the
-value and the derivative. Neither answer is silently wrong — the primal is `NaN` there too —
-but a gradient and a JVP through the same function will not agree at those inputs until
-these functions have `frule!!`s of their own.
-
 ```@meta
 DocTestSetup = nothing
 ```

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -272,15 +272,31 @@ Honestly, your best bet is just to avoid differentiating functions whose argumen
 
 `NNlib.softmax`, `logsoftmax`, `logsumexp` and `gather` have reverse-mode rules but no
 forward-mode ones, so forward mode traces their primals. On CPU arrays that works. On GPU
-arrays it does not: the traced primal reaches `GPUArrays`' reduction internals, whose IR
-contains a value-less `Core.UpsilonNode` that Mooncake's forward transform reads
-unconditionally, and the result is an `UndefRefError` raised from inside the transform rather
-than a message naming what is unsupported.
+arrays it does not, and the two failure modes are worth separating.
 
-Reverse mode over these functions works on GPU arrays, as does forward mode over the same
-functions on CPU arrays. Writing `frule!!`s for them would remove the limitation; failing
-that, a GPU-array `frule!!` that raises deliberately would at least make the diagnosis
-obvious.
+For `softmax`, `logsoftmax` and `logsumexp` the traced primal reaches a GPU kernel launch,
+which is a foreigncall with no `frule!!`, so Mooncake raises
+`MissingForeigncallRuleError` — its own error, naming the foreigncall it cannot
+differentiate. That is a clear diagnosis, if not a fix.
+
+`gather` is worse: forward mode over a GPU array terminates the process with
+`signal 4 (Illegal instruction)` from inside the derived rule, with no Julia exception to
+catch. Nothing about the failure is recoverable or informative.
+
+Reverse mode over all four works on GPU arrays, as does forward mode over the same functions
+on CPU arrays. Writing `frule!!`s for them would remove the limitation; short of that, a
+GPU-array `frule!!` that raises deliberately would turn the `gather` crash into an ordinary
+error.
+
+Tracing the primal also means the two modes disagree at infinite inputs. `NNlib.logsumexp`
+returns `NaN` for `[Inf, Inf]`, `[Inf, 1]` and `[-Inf, -Inf]`, because the maximal entry
+forms `exp(Inf - Inf)`. The reverse-mode rule deliberately does not reproduce that: it
+substitutes the limit, giving `Inf` with weights `[1, 0]` where one entry attains the
+extremum and an equal share where several tie. Forward mode has no rule to substitute
+anything, so it differentiates what NNlib actually computes and returns `NaN` for both the
+value and the derivative. Neither answer is silently wrong — the primal is `NaN` there too —
+but a gradient and a JVP through the same function will not agree at those inputs until
+these functions have `frule!!`s of their own.
 
 ```@meta
 DocTestSetup = nothing

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -268,6 +268,20 @@ Instead, you will need to use lower-level (internal) functionality, such as `Moo
 
 Honestly, your best bet is just to avoid differentiating functions whose arguments are pointers if you can.
 
+## Forward mode over some NNlib reductions on GPU arrays
+
+`NNlib.softmax`, `logsoftmax`, `logsumexp` and `gather` have reverse-mode rules but no
+forward-mode ones, so forward mode traces their primals. On CPU arrays that works. On GPU
+arrays it does not: the traced primal reaches `GPUArrays`' reduction internals, whose IR
+contains a value-less `Core.UpsilonNode` that Mooncake's forward transform reads
+unconditionally, and the result is an `UndefRefError` raised from inside the transform rather
+than a message naming what is unsupported.
+
+Reverse mode over these functions works on GPU arrays, as does forward mode over the same
+functions on CPU arrays. Writing `frule!!`s for them would remove the limitation; failing
+that, a GPU-array `frule!!` that raises deliberately would at least make the diagnosis
+obvious.
+
 ```@meta
 DocTestSetup = nothing
 ```

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -288,14 +288,10 @@ end
         typeof(NNlib.gather),SupportedArray{P,N},SupportedArray{<:Union{Integer,Tuple},M}
     } where {P<:IEEEFloat,N,M},
 )
-# Scoping the declaration above to reverse mode lets forward mode trace `gather`'s primal,
-# which is what we want for CPU arrays. For GPU arrays the traced kernel launch does not
-# survive the transform: the process dies with `signal 4 (Illegal instruction)` raised from
-# inside the derived rule, with no Julia exception to catch. An unscoped declaration would
-# have given a `MethodError` naming the missing `frule!!`, so tracing trades an informative
-# error for an uncatchable crash. Declaring the GPU signature a forward primitive and
-# raising here keeps it an ordinary error. Reverse mode is untouched and works on GPU
-# arrays.
+# Tracing `gather`'s primal is what we want on CPU arrays, but a GPU kernel launch does not
+# survive the forward transform: the process dies with signal 4, no Julia exception to
+# catch. Declaring the GPU signature a forward primitive and raising keeps it an ordinary
+# error. Reverse mode is untouched.
 @is_primitive(
     MinimalCtx,
     ForwardMode,

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -20,7 +20,8 @@ import Mooncake:
     tangent,
     arrayify,
     frule!!,
-    Dual
+    Dual,
+    ReverseMode
 
 @inline function _nf_logsumexp_accum(
     grad::NTuple{N,T}, w::T, partials::NTuple{N,T}
@@ -100,10 +101,10 @@ _maximum(x, dims, init) = maximum(x; dims, init)
 )
 
 # logsoftmax rrules
-@is_primitive MinimalCtx Tuple{
+@is_primitive MinimalCtx ReverseMode Tuple{
     typeof(logsoftmax),SupportedArray{T,N}
 } where {T<:IEEEFloat,N}
-@is_primitive MinimalCtx Tuple{
+@is_primitive MinimalCtx ReverseMode Tuple{
     typeof(Core.kwcall),NamedTuple,typeof(logsoftmax),SupportedArray{T,N}
 } where {T<:IEEEFloat,N}
 
@@ -154,8 +155,10 @@ function Mooncake.rrule!!(
 end
 
 # softmax rrules
-@is_primitive MinimalCtx Tuple{typeof(softmax),SupportedArray{T,N}} where {T<:IEEEFloat,N}
-@is_primitive MinimalCtx Tuple{
+@is_primitive MinimalCtx ReverseMode Tuple{
+    typeof(softmax),SupportedArray{T,N}
+} where {T<:IEEEFloat,N}
+@is_primitive MinimalCtx ReverseMode Tuple{
     typeof(Core.kwcall),NamedTuple,typeof(softmax),SupportedArray{T,N}
 } where {T<:IEEEFloat,N}
 
@@ -202,8 +205,10 @@ function Mooncake.rrule!!(
 end
 
 # logsumexp rrules
-@is_primitive MinimalCtx Tuple{typeof(logsumexp),SupportedArray{T,N}} where {T<:IEEEFloat,N}
-@is_primitive MinimalCtx Tuple{
+@is_primitive MinimalCtx ReverseMode Tuple{
+    typeof(logsumexp),SupportedArray{T,N}
+} where {T<:IEEEFloat,N}
+@is_primitive MinimalCtx ReverseMode Tuple{
     typeof(Core.kwcall),NamedTuple,typeof(logsumexp),SupportedArray{T,N}
 } where {T<:IEEEFloat,N}
 
@@ -277,6 +282,7 @@ end
 # accumulating straight into `src`'s fdata, avoiding its intermediate allocation.
 @is_primitive(
     MinimalCtx,
+    ReverseMode,
     Tuple{
         typeof(NNlib.gather),SupportedArray{P,N},SupportedArray{<:Union{Integer,Tuple},M}
     } where {P<:IEEEFloat,N,M},

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -21,6 +21,7 @@ import Mooncake:
     arrayify,
     frule!!,
     Dual,
+    ForwardMode,
     ReverseMode
 
 @inline function _nf_logsumexp_accum(
@@ -287,6 +288,36 @@ end
         typeof(NNlib.gather),SupportedArray{P,N},SupportedArray{<:Union{Integer,Tuple},M}
     } where {P<:IEEEFloat,N,M},
 )
+# Scoping the declaration above to reverse mode lets forward mode trace `gather`'s primal,
+# which is what we want for CPU arrays. For GPU arrays the traced kernel launch does not
+# survive the transform: the process dies with `signal 4 (Illegal instruction)` raised from
+# inside the derived rule, with no Julia exception to catch. An unscoped declaration would
+# have given a `MethodError` naming the missing `frule!!`, so tracing trades an informative
+# error for an uncatchable crash. Declaring the GPU signature a forward primitive and
+# raising here keeps it an ordinary error. Reverse mode is untouched and works on GPU
+# arrays.
+@is_primitive(
+    MinimalCtx,
+    ForwardMode,
+    Tuple{
+        typeof(NNlib.gather),AbstractGPUArray{P,N},SupportedArray{<:Union{Integer,Tuple},M}
+    } where {P<:IEEEFloat,N,M},
+)
+function Mooncake.frule!!(
+    ::Dual{typeof(NNlib.gather)},
+    ::Dual{<:AbstractGPUArray{P,N}},
+    ::Dual{<:SupportedArray{<:Union{Integer,Tuple},M}},
+) where {P<:IEEEFloat,N,M}
+    throw(
+        ArgumentError(
+            "forward mode over `NNlib.gather` is not supported for GPU arrays: " *
+            "differentiating the traced kernel launch crashes the process. Reverse mode " *
+            "has a rule for this signature and does work; on the CPU, so does forward " *
+            "mode.",
+        ),
+    )
+end
+
 function Mooncake.rrule!!(
     ::CoDual{typeof(NNlib.gather)},
     src::CoDual{<:SupportedArray{P,N}},

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -514,8 +514,12 @@ end
 @testset "forward mode traces reverse-only rules" begin
     x = randn(StableRNG(123), 3)
     for f in (
-        x -> sum(softmax(x)),
-        x -> sum(softmax(x; dims=1)),
+        # `softmax` is returned whole rather than summed: its outputs sum to 1 identically,
+        # so `1ᵀJ = 0` and a summed case is blind to every error inside that kernel — a JVP
+        # off by a factor or a sign passes it, and both fail once the array is compared.
+        # `logsoftmax` does not sum to a constant, so summing it stays a real check.
+        x -> softmax(x),
+        x -> softmax(x; dims=1),
         x -> sum(logsoftmax(x)),
         x -> sum(logsoftmax(x; dims=1)),
         x -> logsumexp(x),

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -529,3 +529,22 @@ end
         test_rule(StableRNG(123), f, x; mode=Mooncake.ForwardMode, is_primitive=false)
     end
 end
+
+# Tracing works for the CPU arrays above, but `gather`'s GPU kernel launch does not survive
+# the forward transform — it took the process down with an illegal instruction, which no
+# test
+# can catch. The rule for that signature raises instead, which this pins where a device is
+# available. Reverse mode over the same call keeps working.
+if cuda
+    @testset "forward mode over gather on a GPU array raises" begin
+        gather_sum(z) = sum(NNlib.gather(z, [1, 3]))
+        xg = cu(randn(StableRNG(123), Float32, 4))
+        rule = Mooncake.build_frule(gather_sum, xg)
+        @test_throws ArgumentError rule(
+            Mooncake.zero_dual(gather_sum), Mooncake.Dual(copy(xg), CUDA.ones(Float32, 4))
+        )
+        cache = Mooncake.prepare_gradient_cache(gather_sum, xg)
+        @test Array(Mooncake.value_and_gradient!!(cache, gather_sum, xg)[2][2]) ==
+            Float32[1, 0, 1, 0]
+    end
+end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -508,9 +508,10 @@ end
 # Each rule below exists only in reverse mode, so its `@is_primitive` has to say so;
 # declared for both modes, forward mode finds a primitive with no `frule!!` and raises a
 # `MethodError` instead of tracing the primal. CPU arrays only, and not because the array
-# type is irrelevant: on a GPU array the traced primal reaches GPUArrays' reduction
-# internals, which Mooncake's forward transform cannot yet handle, so it raises there
-# instead. See `docs/src/known_limitations.md`.
+# type is irrelevant: on a GPU array the traced primal reaches a kernel launch, which is a
+# foreigncall with no `frule!!`, so Mooncake raises `MissingForeigncallRuleError` there
+# instead. `gather` was worse still — it took the process down — which is why it has a rule
+# of its own below.
 @testset "forward mode traces reverse-only rules" begin
     x = randn(StableRNG(123), 3)
     for f in (

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -515,6 +515,7 @@ end
         x -> sum(softmax(x)),
         x -> sum(softmax(x; dims=1)),
         x -> sum(logsoftmax(x)),
+        x -> sum(logsoftmax(x; dims=1)),
         x -> logsumexp(x),
         x -> sum(logsumexp(x; dims=1)),
         x -> sum(NNlib.gather(x, [1, 3])),

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -504,3 +504,20 @@ end
         )
     end
 end
+
+# Each rule below exists only in reverse mode, so its `@is_primitive` has to say so; declared for
+# both modes, forward mode finds a primitive with no `frule!!` and raises a `MethodError` instead
+# of tracing the primal. CPU only: the mode declaration is what is under test, not the array type.
+@testset "forward mode traces reverse-only rules" begin
+    x = randn(StableRNG(123), 3)
+    for f in (
+        x -> sum(softmax(x)),
+        x -> sum(softmax(x; dims=1)),
+        x -> sum(logsoftmax(x)),
+        x -> logsumexp(x),
+        x -> sum(logsumexp(x; dims=1)),
+        x -> sum(NNlib.gather(x, [1, 3])),
+    )
+        test_rule(StableRNG(123), f, x; mode=Mooncake.ForwardMode, is_primitive=false)
+    end
+end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -507,8 +507,10 @@ end
 
 # Each rule below exists only in reverse mode, so its `@is_primitive` has to say so;
 # declared for both modes, forward mode finds a primitive with no `frule!!` and raises a
-# `MethodError` instead of tracing the primal. CPU only: the mode declaration is what is
-# under test, not the array type.
+# `MethodError` instead of tracing the primal. CPU arrays only, and not because the array
+# type is irrelevant: on a GPU array the traced primal reaches GPUArrays' reduction
+# internals, which Mooncake's forward transform cannot yet handle, so it raises there
+# instead. See `docs/src/known_limitations.md`.
 @testset "forward mode traces reverse-only rules" begin
     x = randn(StableRNG(123), 3)
     for f in (

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -505,9 +505,10 @@ end
     end
 end
 
-# Each rule below exists only in reverse mode, so its `@is_primitive` has to say so; declared for
-# both modes, forward mode finds a primitive with no `frule!!` and raises a `MethodError` instead
-# of tracing the primal. CPU only: the mode declaration is what is under test, not the array type.
+# Each rule below exists only in reverse mode, so its `@is_primitive` has to say so;
+# declared for both modes, forward mode finds a primitive with no `frule!!` and raises a
+# `MethodError` instead of tracing the primal. CPU only: the mode declaration is what is
+# under test, not the array type.
 @testset "forward mode traces reverse-only rules" begin
     x = randn(StableRNG(123), 3)
     for f in (

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -505,19 +505,16 @@ end
     end
 end
 
-# Each rule below exists only in reverse mode, so its `@is_primitive` has to say so;
-# declared for both modes, forward mode finds a primitive with no `frule!!` and raises a
-# `MethodError` instead of tracing the primal. CPU arrays only, and not because the array
-# type is irrelevant: on a GPU array the traced primal reaches a kernel launch, which is a
-# foreigncall with no `frule!!`, so Mooncake raises `MissingForeigncallRuleError` there
-# instead. `gather` was worse still — it took the process down — which is why it has a rule
-# of its own below.
+# Each rule below exists only in reverse mode, so its `@is_primitive` says so; declared for
+# both, forward mode finds a primitive with no `frule!!` and raises instead of tracing. CPU
+# arrays only: on a GPU array the traced primal reaches a kernel launch, a foreigncall, and
+# raises `MissingForeigncallRuleError`. `gather` took the process down, hence its own rule
+# below.
 @testset "forward mode traces reverse-only rules" begin
     x = randn(StableRNG(123), 3)
     for f in (
         # `softmax` is returned whole rather than summed: its outputs sum to 1 identically,
-        # so `1ᵀJ = 0` and a summed case is blind to every error inside that kernel — a JVP
-        # off by a factor or a sign passes it, and both fail once the array is compared.
+        # so `1ᵀJ = 0` and a summed case is blind to every error inside that kernel.
         # `logsoftmax` does not sum to a constant, so summing it stays a real check.
         x -> softmax(x),
         x -> softmax(x; dims=1),
@@ -531,11 +528,9 @@ end
     end
 end
 
-# Tracing works for the CPU arrays above, but `gather`'s GPU kernel launch does not survive
-# the forward transform — it took the process down with an illegal instruction, which no
-# test
-# can catch. The rule for that signature raises instead, which this pins where a device is
-# available. Reverse mode over the same call keeps working.
+# `gather`'s GPU kernel launch does not survive the forward transform — an illegal
+# instruction no test can catch — so its rule raises instead, which this pins where a device
+# is available.
 if cuda
     @testset "forward mode over gather on a GPU array raises" begin
         gather_sum(z) = sum(NNlib.gather(z, [1, 3]))


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1265 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1265/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 450.0 ns │     1.63 │        1.64 │   0.227 │       0.831 │   1.32 │
│                  _sum_1000 │ 765.0 ns │     8.41 │        1.14 │  4360.0 │        42.6 │   1.56 │
│               sum_sin_1000 │  6.02 μs │     3.23 │        1.27 │    1.98 │        10.9 │    2.1 │
│              _sum_sin_1000 │  6.18 μs │     2.95 │         1.8 │   269.0 │        10.6 │   1.94 │
│                   kron_sum │ 379.0 μs │      7.2 │        2.67 │    16.7 │       255.0 │   12.1 │
│              kron_view_sum │ 374.0 μs │     8.72 │        4.24 │    21.3 │       308.0 │    8.5 │
│      naive_map_sin_cos_exp │  2.87 μs │     2.44 │        1.25 │ missing │        4.97 │   1.45 │
│            map_sin_cos_exp │  2.66 μs │     2.94 │        1.54 │    1.19 │        4.71 │   1.99 │
│      broadcast_sin_cos_exp │  2.85 μs │     2.73 │        1.43 │    2.82 │        1.04 │   1.48 │
│                 simple_mlp │ 155.0 μs │     7.12 │         2.9 │    1.97 │        17.2 │   3.58 │
│                     gp_lml │ 219.0 μs │     8.73 │        2.49 │    4.84 │     missing │   4.26 │
│ turing_broadcast_benchmark │  1.97 ms │     4.64 │        2.74 │ missing │        34.5 │   1.41 │
│         large_single_block │ 623.0 ns │     6.12 │        1.92 │  3300.0 │        20.0 │   1.63 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->