### PR TITLE
More concise comments

### DIFF
--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -290,8 +290,7 @@ function benchmark_rules!!(
             return combine_results((args, suite), tags[n], ranges[n], default_ratios)
         end
 
-        # Perf ratios can spike spuriously on noisy CI runners, so retry an out-of-range
-        # result up to `retries` times; only a persistent failure counts as a regression.
+        # Only a persistent out-of-range ratio is a regression; CI runners are noisy.
         return map(enumerate(test_cases)) do (n, args)
             ratio = run_case(n, args)
             for _ in 1:retries

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -111,22 +111,13 @@ const CuGpuSumFArray = Union{
     Transpose{<:IEEEFloat,<:CuFloatArray},
 }
 
-# vcat/hcat/cat/permutedims also accept these wrapper types (Julia's own methods for
-# them already handle it at the primal level). Each argument is canonicalised via
-# `Mooncake.arrayify`, which already has generic overloads for Adjoint/Transpose/
-# SubArray (see `src/rules/blas.jl`): they recurse into `.parent` and re-wrap the
-# tangent in the same wrapper type. Without this, these wrapper types fall through to
-# the interpreter and hit the same untraceable `cufunction` try/finally the rules
-# below exist to avoid.
-#
-# Adjoint/Transpose and SubArray use different bounds because their `arrayify` methods
-# do: Adjoint/Transpose go through the generic `Union{IEEEFloat,BlasFloat}` method
-# (real `Float16` ok, `Complex{Float16}` not), while the SubArray method is bounded to
-# `BlasFloat` alone (excludes `Float16` entirely, real or complex). A wider bound here
-# than `arrayify` supports would let e.g. `vcat(view(cu_f16_mat, 1:2, :), y)` (a
-# strided view, which stays a genuine `SubArray`) through as primitive, only to fail
-# inside the rule with a misdirected `arrayify` error instead of falling through to the
-# interpreter like any other unsupported case.
+# vcat/hcat/cat/permutedims also accept these wrapper types; without them here the wrappers
+# fall through to the interpreter and hit the same untraceable `cufunction` try/finally the
+# rules below exist to avoid. `Mooncake.arrayify` canonicalises each argument (generic
+# Adjoint/Transpose/SubArray overloads in `src/rules/blas.jl`), and the bounds mirror its
+# own — `Union{IEEEFloat,BlasFloat}` for Adjoint/Transpose, `BlasFloat` alone for SubArray —
+# since a wider bound would claim a call as primitive only to fail inside the rule with a
+# misdirected `arrayify` error instead of falling through to the interpreter.
 const CuMaybeWrappedArray = Union{
     CuMaybeComplexArray,
     Adjoint{<:Union{IEEEFloat,LinearAlgebra.BlasFloat},<:CuMaybeComplexArray},
@@ -1425,11 +1416,9 @@ end
 end
 
 # `dims` a Tuple of K distinct dimensions: cat(A, B, ...; dims=(d1, d2, ...)) builds a
-# block-diagonal result, growing every listed dimension simultaneously for each array
-# and zero-filling elsewhere. Each input's gradient is the rectangular sub-block of
-# dy_out obtained by slicing every listed dimension by its own running offset, and
-# taking the full range on every dimension not in `dims` (inputs must already agree in
-# size there, per `cat`'s own requirements).
+# block-diagonal result, growing every listed dimension simultaneously and zero-filling
+# elsewhere. Each input's gradient is the sub-block of dy_out at its own running offset in
+# each listed dimension, full range elsewhere (`cat` requires equal sizes there).
 @inline function _cu_concat_pb!(fdatas, dy_out, dims::NTuple{K,Integer}) where {K}
     offsets = ntuple(_ -> 0, Val(K))
     nd = Val(ndims(dy_out))
@@ -1544,22 +1533,14 @@ end
     )
 end
 
-# Mixed CPU/GPU device guard for vcat/hcat/cat, covering array/array and array/scalar
-# mixing together, at any arity and any argument order.
-#
-# Tuple{typeof(vcat),CuMaybeWrappedArray,Vararg{CuMaybeWrappedArray}} above is a strict
-# subtype of Tuple{typeof(vcat),Vararg{Union{AbstractArray,Number}}} below with a
-# matching function-argument type (both `Dual{typeof(vcat)}`, no `<:`), so Julia's
-# method specificity picks it for pure-GPU calls; this guard is never consulted then.
-# Pure-CPU calls do reach this guard, but has_gpu=false there, so it returns false and
-# they fall through to the interpreter unaffected (this is what keeps CPU code, e.g.
-# NNlib's softmax, working). Only genuinely mixed CPU+GPU calls (any N, any order,
-# arrays or scalars) make `_is_primitive` return true, at which point frule!!/rrule!!
-# below throw a clear error instead of the opaque `cufunction` crash.
-#
-# `@is_primitive` can't express this: a plain declaration is always primitive for its
-# whole signature, but this decision has to depend on the concrete argument types, so
-# `_is_primitive` is implemented directly instead.
+# Mixed CPU/GPU device guard for vcat/hcat/cat, at any arity and any argument order, arrays
+# or scalars: only genuinely mixed calls make `_is_primitive` return true, at which point
+# frule!!/rrule!! below throw a clear error instead of the opaque `cufunction` crash.
+# Pure-GPU calls match the strictly more specific GPU-only signature above (same
+# function-argument type, so specificity decides); pure-CPU calls do reach here, get
+# has_gpu=false, and fall through to the interpreter, which keeps CPU code such as NNlib's
+# softmax working. `@is_primitive` can't express a decision that depends on the concrete
+# argument types, hence the direct `_is_primitive` method.
 _cu_isa_gpu_side(::Type{T}) where {T} = T <: CuMaybeWrappedArray
 
 # `any_matches_primitive` feeds every call site's type into `_is_primitive`, including
@@ -2180,13 +2161,11 @@ function _gpu_broadcast_dual(f::F, args...) where {F}
     return ((args...) -> _gpu_apply_with_duals(f, args...)).(args...)
 end
 
-# Single second-order chokepoint: the NDual-based GPU rules (`sum(f, x)`,
-# `materialize`, `materialize!`) all launch their kernel through
-# `_gpu_broadcast_dual`, traced only when nested AD differentiates a rule body.
-# Tracing it nests `NDual` over `NDual`, which raises an error (perturbation
-# confusion) — so intercept here; one primitive covers every NDual rule. Both modes
-# get a throwing rule so the unsupported reverse-over-* direction fails with the
-# same clear message rather than a missing-rule MethodError.
+# Single second-order chokepoint: the NDual-based GPU rules (`sum(f, x)`, `materialize`,
+# `materialize!`) all launch their kernel through `_gpu_broadcast_dual`, traced only when
+# nested AD differentiates a rule body, which nests `NDual` over `NDual` and errors
+# (perturbation confusion). Both modes get a throwing rule so the unsupported
+# reverse-over-* direction fails with the same clear message rather than a MethodError.
 const _GPU_SECOND_ORDER_MSG =
     "Mooncake: HVP / Hessian over a custom CUDA kernel (broadcasting, or " *
     "`sum(f, x)`-style mapped reductions) is not yet supported — the kernel is a " *
@@ -2957,13 +2936,11 @@ end
 # Mooncake can't trace. Split into two primitives: this one for array-valued m (dims
 # gives a CuArray output), and one below for scalar m (dims=: gives a scalar output).
 #
-# Two conventions hold throughout the varm/mean rules below. First, the primal value
-# comes from calling the real function — rules execute natively, so the mapreduce
-# closure only blocks tracing — which inherits the primal's kwarg validation,
-# NaN-on-empty convention, and exact value arithmetic. Second, each hand-rolled
-# derivative uses the same arithmetic as its own primal method — λ-prescaled where
-# the primal λ-prescales, divide-after-sum where it divides after — so value and
-# derivative degrade identically in Float16 edge cases.
+# Two conventions throughout the varm/mean rules below: the primal value comes from calling
+# the real function (rules run natively, so the closure only blocks tracing), inheriting its
+# kwarg validation and NaN-on-empty convention; and each hand-rolled derivative uses the
+# same arithmetic as its own primal method, so value and derivative degrade identically in
+# Float16 edge cases.
 
 # A real-valued fdata/rdata slot can't hold a complex value. When exactly one of x/m
 # is complex, the true partial derivative of |x-m|² is the real part of the naive
@@ -3116,20 +3093,16 @@ function _varm_scalar_colon_pb(px, dx, pm, corrected::Bool)
     return pb!!
 end
 
-# Scalar m must share x's underlying precision. With e.g. Float32 data and a Float64
-# mean, Statistics' scalar-m varm infers Union{Float32,Float64} (the n==0 branch
-# types σ² off x alone; the main branch promotes with m), and Mooncake's rule builder
-# cannot handle a Union-typed primitive output. Only same-precision combinations —
-# all concretely typed — are claimed as primitives; mismatched ones fail loudly in
-# the interpreter instead.
-#
-# The tie takes four explicit eltype combinations. In a single
-# `Tuple{..., CuArray{<:Union{P,Complex{P}}}, Union{P,Complex{P}}} where P`, P never
-# occurs twice covariantly, so it is not diagonal and subtyping may bind it to a
-# Union — e.g. P = Union{Float32,Float64} — letting mixed precision match anyway.
-# The invariant occurrence CuArray{P} pins P to one concrete eltype. The
-# frule!!/rrule!! methods below keep broad signatures; they are only reached for
-# claimed primitives.
+# Scalar m must share x's underlying precision: with e.g. Float32 data and a Float64 mean,
+# Statistics' scalar-m varm infers Union{Float32,Float64} (the n==0 branch types σ² off x
+# alone, the main branch promotes with m), and Mooncake's rule builder cannot handle a
+# Union-typed primitive output. Mismatched combinations are left to fail in the interpreter.
+# Hence four explicit eltype combinations, not one
+# `Tuple{..., CuArray{<:Union{P,Complex{P}}}, Union{P,Complex{P}}} where P`: there P never
+# occurs twice covariantly, so it is not diagonal and subtyping may bind it to
+# Union{Float32,Float64}, matching mixed precision anyway; the invariant CuArray{P} pins it
+# to one concrete eltype. frule!!/rrule!! below keep broad signatures; they are only reached
+# for claimed primitives.
 for A in (:(CuArray{P}), :(CuArray{Complex{P}})), M in (:P, :(Complex{P}))
     @eval @is_primitive(
         MinimalCtx,
@@ -3174,12 +3147,10 @@ function rrule!!(
     return CoDual(σ², NoFData()), varm_scalar_mean_pb!!
 end
 
-# Bare `varm(x, m::scalar)`: a kwarg-less call dispatches straight to varm rather
-# than through Core.kwcall, so it needs its own rules. Statistics.jl's
-# `varm(A::AbstractArray, m; corrected=true) = _varm(A, m, corrected, :)` has no
+# Bare `varm(x, m::scalar)`: a kwarg-less call dispatches straight to varm rather than
+# through Core.kwcall, so it needs its own rules. Statistics.jl's scalar-m method has no
 # `dims` kwarg, so this spelling is always the Colon case with corrected=true. Its
-# @is_primitive declarations live in the loop above so the precision tie is stated
-# once.
+# @is_primitive declarations live in the loop above so the precision tie is stated once.
 function frule!!(
     ::Dual{typeof(varm)}, x::Dual{<:CuMaybeComplexArray}, m::Dual{<:CuFloatOrComplex}
 )

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -2163,7 +2163,7 @@ end
 
 # Single second-order chokepoint: the NDual-based GPU rules (`sum(f, x)`, `materialize`,
 # `materialize!`) all launch their kernel through `_gpu_broadcast_dual`, traced only when
-# nested AD differentiates a rule body, which nests `NDual` over `NDual` and errors
+# nested AD differentiates a rule body. Tracing it nests `NDual` over `NDual`, which errors
 # (perturbation confusion). Both modes get a throwing rule so the unsupported
 # reverse-over-* direction fails with the same clear message rather than a MethodError.
 const _GPU_SECOND_ORDER_MSG =
@@ -2938,9 +2938,9 @@ end
 #
 # Two conventions throughout the varm/mean rules below: the primal value comes from calling
 # the real function (rules run natively, so the closure only blocks tracing), inheriting its
-# kwarg validation and NaN-on-empty convention; and each hand-rolled derivative uses the
-# same arithmetic as its own primal method, so value and derivative degrade identically in
-# Float16 edge cases.
+# kwarg validation and NaN-on-empty convention; and each hand-rolled derivative uses the same
+# arithmetic as its own primal method — λ-prescaled where the primal prescales, divide-after
+# where it divides the sum — so value and derivative degrade identically in Float16 edge cases.
 
 # A real-valued fdata/rdata slot can't hold a complex value. When exactly one of x/m
 # is complex, the true partial derivative of |x-m|² is the real part of the naive
@@ -3097,7 +3097,7 @@ end
 # Statistics' scalar-m varm infers Union{Float32,Float64} (the n==0 branch types σ² off x
 # alone, the main branch promotes with m), and Mooncake's rule builder cannot handle a
 # Union-typed primitive output. Mismatched combinations are left to fail in the interpreter.
-# Hence four explicit eltype combinations, not one
+# Hence the tie takes four explicit eltype combinations, not one
 # `Tuple{..., CuArray{<:Union{P,Complex{P}}}, Union{P,Complex{P}}} where P`: there P never
 # occurs twice covariantly, so it is not diagonal and subtyping may bind it to
 # Union{Float32,Float64}, matching mixed precision anyway; the invariant CuArray{P} pins it

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -333,7 +333,8 @@ end
 # ChainRules' `∇scatter_src` for `max`/`min` gives the full cotangent to every tied source,
 # so the gradient sums to the tie multiplicity rather than to 1, not a subdifferential
 # member. Dividing by the count picks the symmetric member; `init` competes for the same
-# extremum, so a source tied with it gets `1/(m+1)`.
+# extremum, so a source tied with it gets `1/(m+1)`. Returns `init`'s share, or `nothing`
+# when it has no rdata slot to receive one.
 @inline function _scatter_extremum_grads!(
     dsrc, psrc::AbstractArray{P}, pidx, y, dy, init
 ) where {P}
@@ -531,8 +532,9 @@ end
 
 # σ is smooth, but tracing the primal is wrong at both ends. At zero it routes through
 # `abs(x)`, so AD picks up `sign(0) == 0` and reports `0` for `1/4`. When saturated the
-# textbook `σ(x) * (1 - σ(x))` collapses: floats near `1.0` are spaced `eps` apart, so the
-# derivative quantises to `0` (Float64 `x ≳ 37`, Float32 `≳ 17`, Float16 `≳ 8`) while the
+# textbook `σ(x) * (1 - σ(x))` collapses: floats near `1.0` are spaced `eps` apart, so once
+# `σ(x)` rounds to `1.0` the factor `1 - σ(x)` is exactly `0` (Float64 `x ≳ 37`, Float32
+# `≳ 17`, Float16 `≳ 8`) while the
 # true value is still normal. `t / (1 + t)^2` with `t = exp(-abs(x))` holds it in an
 # exponent instead, and `t ≤ 1` bounds the quotient. `exp` therefore runs twice, here and in
 # the primal, rather than restating the primal's branch and `sigmoid_fast`'s clamps where

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -100,9 +100,8 @@ _maximum(x, dims, init) = maximum(x; dims, init)
     } where {P<:IEEEFloat},
 )
 # At `p ≤ 0` `dropout` returns its input itself, where ChainRules' rrule allocates and draws
-# from `rng` regardless: a different program from the primal. Checked, not assumed, because
-# if that fast path ever allocates, returning the input would alias where the primal does
-# not.
+# from `rng` regardless. The `===` is checked, not assumed, because if that fast path ever
+# allocates, returning the input would alias where the primal does not.
 @is_primitive MinimalCtx ReverseMode Tuple{
     typeof(dropout),AbstractRNG,SupportedArray{P,N},P
 } where {P<:IEEEFloat,N}
@@ -174,9 +173,7 @@ function Mooncake.rrule!!(
     function logsoftmax_pb!!(::NoRData)
         _, dx = arrayify(x)
         dy = tangent(res)
-        # TODO: Drop the fallback once NNlib >= 0.9.37 is more widely supported.
-        # Until then, use the public softmax backpass API when available and delegate
-        # NNlib < 0.9.37 to the legacy `_data` helpers.
+        # TODO: Drop the `_data` fallback once NNlib >= 0.9.37 is more widely supported.
         # See https://github.com/chalk-lab/Mooncake.jl/pull/1229 for more context.
         @static if hasmethod(NNlib.∇logsoftmax, Tuple{AbstractArray,AbstractArray})
             dx .+= NNlib.∇logsoftmax(dy, y; dims=1)
@@ -333,11 +330,10 @@ end
     true,
 )
 
-# ChainRules' `∇scatter_src` for `max`/`min` gives the full cotangent to every tied source, so
-# the gradient sums to the tie multiplicity rather than to 1 — not a subdifferential member at
-# all. Dividing by the count picks the symmetric member; `init` competes for the same extremum,
-# so a source tied with it gets `1/(m+1)`. Returns `init`'s own share, or `nothing` when it has
-# no rdata slot to receive one.
+# ChainRules' `∇scatter_src` for `max`/`min` gives the full cotangent to every tied source,
+# so the gradient sums to the tie multiplicity rather than to 1, not a subdifferential
+# member. Dividing by the count picks the symmetric member; `init` competes for the same
+# extremum, so a source tied with it gets `1/(m+1)`.
 @inline function _scatter_extremum_grads!(
     dsrc, psrc::AbstractArray{P}, pidx, y, dy, init
 ) where {P}
@@ -391,8 +387,7 @@ function Mooncake.rrule!!(
         # gets its own specialisation and `kw_rdata` has one concrete type per call site.
         init = haskey(pkw, :init) ? pkw.init : nothing
         dinit = _scatter_extremum_grads!(dsrc, psrc, pidx, primal(res), tangent(res), init)
-        # With `init` supplied the keyword `NamedTuple`'s rdata is not `NoRData`; `dstsize`
-        # alone, or no keywords, still is.
+        # With `init` supplied the keyword `NamedTuple`'s rdata is not `NoRData`; without, it is.
         kw_rdata = if dinit === nothing
             Mooncake.zero_rdata(pkw)
         else
@@ -414,10 +409,8 @@ end
         typeof(NNlib.gather),SupportedArray{P,N},SupportedArray{<:Union{Integer,Tuple},M}
     } where {P<:IEEEFloat,N,M},
 )
-# Tracing `gather`'s primal is what we want on CPU arrays, but a GPU kernel launch does not
-# survive the forward transform: the process dies with signal 4, no Julia exception to
-# catch. Declaring the GPU signature a forward primitive and raising keeps it an ordinary
-# error. Reverse mode is untouched.
+# A GPU kernel launch does not survive the forward transform: the process dies with signal 4, no
+# Julia exception to catch. A forward primitive that raises keeps it an ordinary error.
 @is_primitive(
     MinimalCtx,
     ForwardMode,
@@ -538,16 +531,14 @@ end
 
 # σ is smooth, but tracing the primal is wrong at both ends. At zero it routes through
 # `abs(x)`, so AD picks up `sign(0) == 0` and reports `0` for `1/4`. When saturated the
-# textbook `σ(x) * (1 - σ(x))` collapses: floats near `1.0` are spaced `eps` apart, so any
-# `δ < eps/2` is destroyed and the derivative quantises to `0` (Float64 `x ≳ 37`, Float32 `≳
-# 17`, Float16 `≳ 8`) while the true value is still normal. `t / (1 + t)^2` with `t =
-# exp(-abs(x))` holds it in an exponent instead, and `t ≤ 1` bounds the quotient.
-#
-# `exp` runs twice, here and in the primal, rather than restating the primal's branch and
-# `sigmoid_fast`'s clamps where they could drift from it — 2 ns of 5.5. Both rules
-# differentiate the unclamped σ: past `x ≈ 36.8` the analytic value is all there is, and
-# below `-80` `sigmoid_fast`'s clamp is documented as an accuracy compromise, not a
-# different function.
+# textbook `σ(x) * (1 - σ(x))` collapses: floats near `1.0` are spaced `eps` apart, so the
+# derivative quantises to `0` (Float64 `x ≳ 37`, Float32 `≳ 17`, Float16 `≳ 8`) while the
+# true value is still normal. `t / (1 + t)^2` with `t = exp(-abs(x))` holds it in an
+# exponent instead, and `t ≤ 1` bounds the quotient. `exp` therefore runs twice, here and in
+# the primal, rather than restating the primal's branch and `sigmoid_fast`'s clamps where
+# they could drift from it — 2 ns of 5.5. Both rules differentiate the unclamped σ: past
+# `x ≈ 36.8` the analytic value is all there is, and below `-80` `sigmoid_fast`'s clamp is
+# documented as an accuracy compromise, not a different function.
 for f in (:σ, :sigmoid_fast)
     @eval @is_primitive MinimalCtx Tuple{typeof(NNlib.$f),P} where {P<:IEEEFloat}
     @eval function Mooncake.frule!!(
@@ -578,10 +569,9 @@ end
 # branch is computed: past `|x| ≈ 355` the Float64 body's `(exp(2x) - 1) / (exp(2x) + 1)` is
 # `Inf/Inf`, and a zero cotangent into that quotient's pullback forms `0 * Inf` and puts
 # `NaN` on the argument. The Float32 body overflows its Remez rational the same way past
-# `|x| ≈ 618587`, or `≈ 258.8` through `gelu_tanh`, well inside a Float32 pre-activation,
-# and needs its own test since Float64 cases stay green while Float32 dispatches elsewhere.
-# A rule keeps AD out of both bodies; `gelu`/`gelu_tanh` inherit from `|x| ≈ 21`. No `NDual`
-# method — it is not an `IEEEFloat`, so the in-kernel path reaches `Base.tanh`.
+# `|x| ≈ 618587`, or `≈ 258.8` through `gelu_tanh`, well inside a Float32 pre-activation.
+# `gelu`/`gelu_tanh` inherit the `NaN` from `|x| ≈ 21`. No `NDual` method — it is not an
+# `IEEEFloat`, so the in-kernel path reaches `Base.tanh`.
 #
 # `4u / (1 + u)^2` with `u = exp(-2|x|)` for σ's reason: `1 - tanh(x)^2` collapses to `0`
 # once `tanh(x)` rounds to `1.0` (Float64 `|x| ≳ 19.5`, Float32 `≳ 9`).

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -521,11 +521,9 @@ For types with custom copy semantics, overload this function (see `Core.SimpleVe
 _copy_output(x::Core.TypeName) = x
 _copy_output(x::Module) = x
 
-# Compiled callables retain reflection/IR objects whose reference graph is cyclic
-# (e.g. Method.specializations <-> MethodInstance.def), so field-by-field descent
-# never terminates. They are never differentiable, so return them as-is — this lets
-# the friendly `prepare_hvp_cache` path copy a gradient closure that captures a
-# compiled rule without overflowing.
+# Compiled callables hold reflection objects with cyclic references (Method.specializations
+# <-> MethodInstance.def), so field-by-field descent never terminates. They are never
+# differentiable, and `prepare_hvp_cache` copies gradient closures that capture them.
 _copy_output(x::Core.OpaqueClosure) = x
 _copy_output(x::MistyClosure) = x
 
@@ -760,7 +758,6 @@ Mooncake.value_and_pullback!!(cache, 1.0, f, x, y)
     ȳ,
     f::F,
     x::Vararg{Any,N};
-    # A `false` entry is an unsafe optimization unless the arg holds no differentiable data; see docstring / #1238.
     args_to_zero::NTuple=ntuple(Returns(true), Val(N + 1)),
 ) where {F,N}
     fx = (f, x...)
@@ -875,7 +872,6 @@ value_and_gradient!!(cache, f, x, y)
     cache::Cache,
     f::F,
     x::Vararg{Any,N};
-    # A `false` entry is an unsafe optimization unless the arg holds no differentiable data; see docstring / #1238.
     args_to_zero::NTuple=ntuple(Returns(true), Val(N + 1)),
 ) where {F,N}
     fx = (f, x...)
@@ -2161,9 +2157,7 @@ end
 end
 
 # `fwd_cache` is the derivative cache for `grad_f`. For non-primitive `f`, the compiled
-# inner rrule lives in the `DerivedFoRRule` captured by `grad_f` (built once at prep);
-# `get_inner_rrule`'s frule serves its `Dual` to the forward pass on every
-# `value_and_hvp!!` call.
+# inner rrule is built once at prep and lives in the `DerivedFoRRule` captured by `grad_f`.
 """
     HVPCache
 
@@ -2270,24 +2264,18 @@ true
     f::F, x::Vararg{Any,N}; config=Config()
 ) where {F,N}
     N == 0 && throw(ArgumentError("prepare_hvp_cache requires at least one x argument"))
-    # Validates that `f` returns an `IEEEFloat` (running `f` once), allocates the tangent
-    # buffers reused by `grad_f`, and supplies `output_spec`. The primitive
-    # (`DerivedFoRRule{Nothing}`) branches below also evaluate gradients through
-    # `grad_cache.rule`.
+    # Built even on the derived path, which bypasses `grad_cache.rule`: it validates that
+    # `f` returns an `IEEEFloat` and supplies the tangent buffers and `output_spec` below.
     grad_cache = prepare_gradient_cache(f, x...; config)
 
     # `DerivedFoRRule` wraps a pre-built `Dual(rule, rule_tangent)` so forward AD reuses
-    # the rule's forward-mode-compiled dual callables instead of `zero_tangent`
-    # re-deriving them and leaking reverse-mode primitives (e.g. inlined `IdDict()`)
-    # into the forward IR. The type parameter `D` discriminates derived
-    # (`D <: Dual`) from primitive (`D === Nothing`) rrules — primitive rrules have
-    # no MistyClosure IR and keep using `grad_cache`'s rule directly.
+    # the rule's forward-mode-compiled dual callables; letting `zero_tangent` re-derive
+    # them leaks reverse-mode primitives (e.g. inlined `IdDict()`) into the forward IR.
+    # `DerivedFoRRule{Nothing}` is a primitive rrule, with no MistyClosure IR to reuse.
     for_rule = compile_for_rule(f, x...; debug_mode=config.debug_mode)
 
-    # The derived branches capture only these buffers: capturing `grad_cache` itself
-    # would make `zero_tangent(grad_f)` traverse `grad_cache.rule`'s MistyClosures and
-    # eagerly build dual callables over reverse-mode-optimised IR that the derived path
-    # never invokes.
+    # The derived branches capture only these buffers: capturing `grad_cache` would make
+    # `zero_tangent(grad_f)` build dual callables over MistyClosure IR it never runs.
     tangents = grad_cache.tangents
     grad_f = if N == 1
         if for_rule isa DerivedFoRRule{Nothing}
@@ -2337,9 +2325,7 @@ true
 end
 
 function _make_hessian_buffers(::Type{T}, xs::Tuple) where {T}
-    # Allocate `v`/`grad` as the input's tangent type and `H` via `similar` so that
-    # GPU-array inputs get device-resident buffers; for `Vector{T}` inputs this is
-    # identical to host `zeros`.
+    # `similar`/`zero_tangent` rather than `zeros`: GPU inputs need device-resident buffers.
     if length(xs) == 1
         x = xs[1]
         n = length(x)
@@ -2767,8 +2753,7 @@ H
         return fval, g, H
     end
     local value
-    # One-hot writes via a reused host buffer + `copyto!`: `v[i] = x` is GPU scalar
-    # indexing (errors on CuArray), while `copyto!` serves both Vector and CuArray.
+    # `v[i] = one(T)` is scalar indexing and errors on CuArray; `copyto!` serves both.
     e = Vector{T}(undef, 1)
     for i in 1:n
         e[1] = one(T)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -523,7 +523,8 @@ _copy_output(x::Module) = x
 
 # Compiled callables hold reflection objects with cyclic references (Method.specializations
 # <-> MethodInstance.def), so field-by-field descent never terminates. They are never
-# differentiable, and `prepare_hvp_cache` copies gradient closures that capture them.
+# differentiable, so return them as-is: `prepare_hvp_cache` copies gradient closures that
+# capture a compiled rule, and would otherwise overflow.
 _copy_output(x::Core.OpaqueClosure) = x
 _copy_output(x::MistyClosure) = x
 
@@ -2271,7 +2272,8 @@ true
     # `DerivedFoRRule` wraps a pre-built `Dual(rule, rule_tangent)` so forward AD reuses
     # the rule's forward-mode-compiled dual callables; letting `zero_tangent` re-derive
     # them leaks reverse-mode primitives (e.g. inlined `IdDict()`) into the forward IR.
-    # `DerivedFoRRule{Nothing}` is a primitive rrule, with no MistyClosure IR to reuse.
+    # `DerivedFoRRule{Nothing}` instead means `f` is itself a reverse-mode primitive: no
+    # derived rule to carry, so those branches below use `grad_cache.rule` directly.
     for_rule = compile_for_rule(f, x...; debug_mode=config.debug_mode)
 
     # The derived branches capture only these buffers: capturing `grad_cache` would make
@@ -2753,7 +2755,8 @@ H
         return fval, g, H
     end
     local value
-    # `v[i] = one(T)` is scalar indexing and errors on CuArray; `copyto!` serves both.
+    # `v[i] = one(T)` is scalar indexing and errors on CuArray; `copyto!` from this
+    # one-element host buffer serves `Vector` and `CuArray` alike.
     e = Vector{T}(undef, 1)
     for i in 1:n
         e[1] = one(T)

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -360,7 +360,6 @@ yields a fresh, uncached interpreter, leaving the shared current-world cache unt
 """
 function get_interpreter(mode::Type{<:Mode}, world::UInt)
     world == Base.get_world_counter() && return get_interpreter(mode)
-    # Pinned older world (Lazy/Dynamic rule rebuild): fresh, never cached.
     return MooncakeInterpreter(DefaultCtx, mode; world)
 end
 

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -603,7 +603,7 @@ function (dynamic_rule::DynamicFRule)(args::Vararg{Dual,N}) where {N}
     sig = Tuple{map(Base._stable_typeof ∘ primal, args)...}
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
-        # Build at this rule's creation world, not the current one; see _build_rule! and #1218.
+        # Build at this rule's creation world, not the current one; see _build_rule! (#1218)
         interp = get_interpreter(ForwardMode, dynamic_rule.world)
         rule = build_frule(
             interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -193,11 +193,9 @@ function generate_dual_ir(
     end
     nargs = length(primal_ir.argtypes)
 
-    # Check for unsupported features before normalise! runs.
-    # Julia 1.12+ lowers non-const global writes (`global x = y`) to
-    # Base.setglobal! on 1.12 and Core.setglobal! on 1.13+.
-    # CC.verify_ir does not reject these calls because they are valid IR, so
-    # reject them here before rule construction reaches a missing frule!!.
+    # Reject before normalise! runs: Julia 1.12+ lowers non-const global writes
+    # (`global x = y`) to Base.setglobal! on 1.12 and Core.setglobal! on 1.13+. CC.verify_ir
+    # accepts these calls, so without this check the failure surfaces as a missing frule!!.
     @static if VERSION > v"1.12-"
         setglobal_calls = (GlobalRef(Base, :setglobal!), GlobalRef(Core, :setglobal!))
         for inst in stmt(primal_ir.stmts)
@@ -523,7 +521,6 @@ mutable struct LazyFRule{primal_sig,Trule}
     end
 end
 
-# Create new lazy rule with same method instance, debug mode, and prediction world
 _copy(x::P) where {P<:LazyFRule} = P(x.mi, x.debug_mode, x.world)
 
 # On Julia 1.10, the generic __call_rule fallback is @stable-checked and returns Any for
@@ -551,10 +548,9 @@ end
     return isdefined(rule, :rule) ? __call_rule(rule.rule, args) : _build_rule!(rule, args)
 end
 
-# Build at the world `Trule` was predicted at, not the current world: a world advance since
-# prediction can re-tighten `mi`'s inferred return type, yielding a rule that no longer
-# matches `Trule` and fails to `convert` on assignment below. Fixes the world-advance bug
-# #1218 (not the inference-complexity-widening case in #1209's headline MWE).
+# Build at the world `Trule` was predicted at: a later world can re-tighten `mi`'s inferred
+# return type, giving a rule that no longer matches `Trule` and fails to `convert` (#1218).
+# Not covered: the inference-complexity-widening case in #1209's headline MWE.
 @noinline function _build_rule!(rule::LazyFRule{sig,Trule}, args) where {sig,Trule}
     interp = get_interpreter(ForwardMode, rule.world)
     rule.rule = build_frule(
@@ -599,7 +595,6 @@ function DynamicFRule(debug_mode::Bool)
     return DynamicFRule(Dict{Any,Any}(), debug_mode, get_interpreter(ForwardMode).world)
 end
 
-# Create new dynamic rule with empty cache and same debug mode and build world
 _copy(x::P) where {P<:DynamicFRule} = P(Dict{Any,Any}(), x.debug_mode, x.world)
 
 function (dynamic_rule::DynamicFRule)(args::Vararg{Dual,N}) where {N}
@@ -608,8 +603,7 @@ function (dynamic_rule::DynamicFRule)(args::Vararg{Dual,N}) where {N}
     sig = Tuple{map(Base._stable_typeof ∘ primal, args)...}
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
-        # Build at the world this rule was created at (matching the enclosing rule), not the
-        # current world. See _build_rule! and issue #1218.
+        # Build at this rule's creation world, not the current one; see _build_rule! and #1218.
         interp = get_interpreter(ForwardMode, dynamic_rule.world)
         rule = build_frule(
             interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true

--- a/src/interpreter/ir_utils.jl
+++ b/src/interpreter/ir_utils.jl
@@ -1,8 +1,7 @@
 #
-# Shared IR primitives, used by both forward- and reverse-mode (and by `ir_utils` itself).
-# They live here, rather than alongside the reverse-mode working-IR layer in `reverse_mode.jl`,
-# because this file is loaded before `forward_mode.jl` / `reverse_mode.jl`, both of which use
-# them.
+# Shared IR primitives, used by both modes and by `ir_utils` itself. They live here, not with
+# the reverse-mode working IR in `reverse_mode.jl`, because both mode files are loaded after
+# this one.
 #
 
 const _id_count::Dict{Int,Int32} = Dict{Int,Int32}()

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1,11 +1,9 @@
 #
 # The reverse-mode working IR: an immutable, basic-block representation of `IRCode`.
 #
-# The working representation is a bare `Vector{CFGBlock}`. The metadata that an `IRCode`
-# carries besides its statements (argtypes, sptypes, debuginfo / linetable, meta, valid
-# worlds) is not duplicated here; it is supplied from the originating `IRCode` when lowering
-# back via `lower_cfg_blocks_to_ir`. The shared IR primitives (`ID`, `new_inst`, ...) live in
-# `ir_utils.jl`.
+# The working representation is a bare `Vector{CFGBlock}`: the metadata an `IRCode` carries
+# besides its statements is not duplicated, but supplied from the originating `IRCode` by
+# `lower_cfg_blocks_to_ir`. Shared IR primitives (`ID`, `new_inst`, ...) live in `ir_utils.jl`.
 #
 
 """
@@ -335,9 +333,7 @@ Convert an `Compiler.InstructionStream` into a list of `Compiler.NewInstruction`
 function new_inst_vec(x::CC.InstructionStream)
     stmt = @static VERSION < v"1.11.0-rc4" ? x.inst : x.stmt
     @static if VERSION > v"1.12-"
-        # In Julia 1.12+, x.line is a flat Vector{Int32} of length 3n (3 codeloc values per
-        # instruction). Construct each NewInstruction with its proper Tuple{Int32,Int32,Int32}
-        # line field by reading the 3 entries for instruction i at positions 3i-2, 3i-1, 3i.
+        # In Julia 1.12+, x.line is flat: 3 codeloc entries per instruction, not one line.
         n = length(stmt)
         return [
             NewInstruction(
@@ -445,10 +441,8 @@ function lower_cfg_blocks_to_ir(blks::Vector{CFGBlock}, ir::IRCode; argtypes=ir.
     cfg = control_flow_graph(blks)
     insts = _lines_to_blocks(insts, cfg)
     @static if VERSION > v"1.12-"
-        # Reconstruct codelocs from each instruction's own line field (a Tuple{Int32,Int32,Int32}
-        # in Julia 1.12+). This is always 3n entries by construction, regardless of how many
-        # instructions were added or removed while assembling the AD blocks, keeping the debug
-        # info aligned with the instruction stream (see Mooncake.jl#1216).
+        # Rebuild codelocs from each instruction's own line field, so they stay aligned with
+        # the instruction stream after AD adds and removes instructions (Mooncake.jl#1216).
         lines = Int32[v for inst in insts for v in inst.line]
         debuginfo = CC.copy(ir.debuginfo)
         debuginfo.codelocs = lines
@@ -2147,10 +2141,9 @@ function generate_ir(
                 "function. See the known limitations documentation for more context.",
             )
         end
-        # Julia 1.12+ lowers non-const global writes (`global x = y`) to
-        # Base.setglobal! on 1.12 and Core.setglobal! on 1.13+.
-        # CC.verify_ir does not reject these calls because they are valid IR, so
-        # reject them here before rule construction reaches a missing rrule!!.
+        # Julia 1.12+ lowers non-const global writes (`global x = y`) to Base.setglobal! on
+        # 1.12 and Core.setglobal! on 1.13+. CC.verify_ir accepts these calls, so reject here
+        # rather than later on a missing rrule!!.
         @static if VERSION > v"1.12-"
             if Meta.isexpr(inst, :call) && inst.args[1] in setglobal_calls
                 unhandled_feature(
@@ -2348,12 +2341,9 @@ function forwards_pass_ir(
         # Extract the `fwds` fields from the stmts for the forwards-pass block.
         fwds = reduce(vcat, map(x -> x.fwds, ad_stmts))
 
-        # Instructions to insert before the terminator:
-        # 1. communication instructions (see `create_comms_insts!` for an explanation), and
-        # 2. an instruction logging the ID of the current basic block. This is needed to know
-        #   which basic block to jump to during the reverse-pass if the current block is not
-        #   the unique predecessor of each of its successors (in which case there is no need
-        #   to log that control passed through this block as opposed to any other).
+        # Insert before the terminator: comms instructions (see `create_comms_insts!`) and,
+        # unless this block is the unique predecessor of all its successors, an instruction
+        # logging its ID so the reverse-pass knows which block to jump back to.
         extra = copy(comms_insts)
         if !is_unique_pred[block_id]
             ins_stmt = Expr(:call, __push_blk_stack!, info.block_stack_id, block_id.id)
@@ -2363,8 +2353,7 @@ function forwards_pass_ir(
         return CFGBlock(block_id, insert_before_terminator(fwds, extra))
     end
 
-    # Lower and return the `IRCode` for the forwards-pass. Its argument types are the shared
-    # data followed by the fdata-augmented primal argument types.
+    # Lower and return the `IRCode` for the forwards-pass.
     arg_types = vcat(Tshared_data, map(fcodual_type ∘ CC.widenconst, ir.argtypes))
     all_blocks = _remove_unreachable_cfg_blocks!(vcat(entry_block, fwd_blocks))
     return lower_cfg_blocks_to_ir(all_blocks, ir; argtypes=arg_types)
@@ -2761,7 +2750,6 @@ function DynamicDerivedRule(debug_mode::Bool)
     )
 end
 
-# Create new dynamic rule with empty cache and same debug mode and build world
 _copy(x::P) where {P<:DynamicDerivedRule} = P(Dict{Any,Any}(), x.debug_mode, x.world)
 
 function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
@@ -2775,8 +2763,7 @@ function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
 
     rule = get(dynamic_rule.cache, sig, nothing)
     if rule === nothing
-        # Build at the world this rule was created at (matching the enclosing rule), not the
-        # current world. See _build_rule! and issue #1218.
+        # Build at this rule's creation world, not the current one; see _build_rule! and #1218.
         interp = get_interpreter(ReverseMode, dynamic_rule.world)
         rule = build_rrule(
             interp, sig; debug_mode=dynamic_rule.debug_mode, skip_world_age_check=true
@@ -2866,7 +2853,6 @@ mutable struct LazyDerivedRule{primal_sig,Trule}
     end
 end
 
-# Create new lazy rule with same method instance, debug mode, and prediction world
 _copy(x::P) where {P<:LazyDerivedRule} = P(x.mi, x.debug_mode, x.world)
 
 # On Julia 1.10, the generic __call_rule fallback is @stable-checked and returns Any for
@@ -2895,8 +2881,7 @@ end
     return isdefined(rule, :rule) ? __call_rule(rule.rule, args) : _build_rule!(rule, args)
 end
 
-# Build at the world `Trule` was predicted at, not the current world. See the LazyFRule
-# analogue in forward_mode.jl and the world-advance bug #1218.
+# Build at `Trule`'s prediction world, not the current one; see LazyFRule and issue #1218.
 @noinline function _build_rule!(rule::LazyDerivedRule{sig,Trule}, args) where {sig,Trule}
     interp = get_interpreter(ReverseMode, rule.world)
     rule.rule = build_rrule(

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -831,8 +831,8 @@ end
 @inline function Base.cosh(a::NDual{T,N}) where {T,N}
     return NDual{T,N}(cosh(a.value), _pt_scale(a.partials, sinh(a.value)))
 end
-# `1 - tanh(x)^2` flushes to exactly `0` once `tanh(x)` rounds to `1.0`, while the true
-# derivative is still normal (Float64 `|x| ≳ 19.5`, Float32 `≳ 9`).
+# `4u / (1 + u)^2` with `u = exp(-2|x|)`: `1 - tanh(x)^2` is exactly `0` once `tanh(x)` rounds
+# to `1.0`, while the true derivative is still normal (Float64 `|x| ≳ 19.5`, Float32 `≳ 9`).
 @inline function Base.tanh(a::NDual{T,N}) where {T,N}
     u = exp(-2 * abs(a.value))
     return NDual{T,N}(tanh(a.value), _pt_scale(a.partials, 4u / (one(T) + u)^2))

--- a/src/nfwd/Nfwd.jl
+++ b/src/nfwd/Nfwd.jl
@@ -831,9 +831,8 @@ end
 @inline function Base.cosh(a::NDual{T,N}) where {T,N}
     return NDual{T,N}(cosh(a.value), _pt_scale(a.partials, sinh(a.value)))
 end
-# `4u / (1 + u)^2` with `u = exp(-2|x|)`: `1 - tanh(x)^2` returns exactly `0` once `tanh(x)`
-# rounds to `1.0`, while the true derivative is still normal (Float64 `|x| ≳ 19.5`, Float32
-# `≳ 9`).
+# `1 - tanh(x)^2` flushes to exactly `0` once `tanh(x)` rounds to `1.0`, while the true
+# derivative is still normal (Float64 `|x| ≳ 19.5`, Float32 `≳ 9`).
 @inline function Base.tanh(a::NDual{T,N}) where {T,N}
     u = exp(-2 * abs(a.value))
     return NDual{T,N}(tanh(a.value), _pt_scale(a.partials, 4u / (one(T) + u)^2))
@@ -1563,9 +1562,8 @@ for _WrapType in (:Symmetric, :Hermitian)
         # the ambiguity with LinearAlgebra's *(AbstractMatrix, AbstractMatrix) when B
         # is a plain Matrix (LinearAlgebra wins on B, we win on A — ambiguous without
         # a more specific method that wins on both).
-        # `Matrix`, not `AbstractMatrix`: these are a direct-call surface for hand-built
-        # `NDual` matrices, and a wider bound claimed device- and sparse-backed parents that
-        # they cannot serve, colliding with cuSPARSE's and cuSOLVER's methods.
+        # `Matrix`, not `AbstractMatrix`: a wider bound claimed device- and sparse-backed
+        # parents these methods cannot serve, colliding with cuSPARSE and cuSOLVER.
         function Base.:*(
             A::LinearAlgebra.$_WrapType{NDual{T,N},<:Matrix{NDual{T,N}}},
             B::Union{StridedVector,StridedMatrix},

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -12,8 +12,7 @@ using PrecompileTools: @setup_workload, @compile_workload
 # `prepare_derivative_cache` → `value_and_derivative!!` pipelines (which internally call
 # `build_rrule`/`build_frule`, `generate_ir`, and all the IR-transformation infrastructure)
 # for both a simple scalar and a simple vector function.  Because the IR-manipulation
-# methods (`normalise!`, `_ircode_to_cfg_blocks`, `make_ad_stmts!`, …) work on `IRCode` /
-# `Vector{CFGBlock}` objects
+# methods (`normalise!`, `make_ad_stmts!`, …) work on `IRCode`/`Vector{CFGBlock}` objects
 # whose *Julia type* is the same regardless of which function is being differentiated, one
 # call through the pipeline is enough to pre-warm the bulk of the compilation work.
 

--- a/src/rules/avoiding_non_differentiable_code.jl
+++ b/src/rules/avoiding_non_differentiable_code.jl
@@ -99,7 +99,7 @@ end
     }
 end
 
-# Also dead on 1.12+: @invokelatest no longer expands to Core._call_latest.
+# The kwargs variant is dead on 1.12+ for the same reason.
 @static if VERSION < v"1.12-"
     @zero_derivative(
         MinimalCtx,

--- a/src/rules/avoiding_non_differentiable_code.jl
+++ b/src/rules/avoiding_non_differentiable_code.jl
@@ -61,8 +61,7 @@ import Base.CoreLogging as CoreLogging
     Symbol,
 }
 
-# On 1.12+, @invokelatest no longer expands to Core._call_latest, it uses
-# Base.invokelatest/Base.invokelatest_gr instead.
+# On 1.12+, @invokelatest uses Base.invokelatest/invokelatest_gr, not Core._call_latest.
 @static if VERSION < v"1.12-"
     @zero_derivative MinimalCtx Tuple{
         typeof(Core._call_latest),
@@ -100,8 +99,7 @@ end
     }
 end
 
-# On 1.12+, @invokelatest no longer expands to Core._call_latest, so this kwargs
-# variant is also dead code on 1.12+.
+# Also dead on 1.12+: @invokelatest no longer expands to Core._call_latest.
 @static if VERSION < v"1.12-"
     @zero_derivative(
         MinimalCtx,

--- a/src/rules/builtins.jl
+++ b/src/rules/builtins.jl
@@ -250,9 +250,8 @@ function rrule!!(::CoDual{typeof(atomic_pointerref)}, x, order)
     _x = primal(x)
     _order = primal(order)
     dx = tangent(x)
-    # Tangent bookkeeping uses :monotonic throughout: the primal ordering may be valid
-    # for loads only (e.g. :acquire), so reusing it for the pullback's store would
-    # throw a ConcurrencyViolationError. Only the primal load keeps the user's ordering.
+    # Tangent bookkeeping uses :monotonic: a load-only primal ordering (e.g. :acquire) would
+    # throw ConcurrencyViolationError if reused for the pullback's store.
     a = CoDual(atomic_pointerref(_x, _order), fdata(atomic_pointerref(dx, :monotonic)))
     if Mooncake.rdata_type(tangent_type(Mooncake._typeof(primal(a)))) == NoRData
         return a, NoPullback((NoRData(), NoRData(), NoRData()))
@@ -276,10 +275,8 @@ end
 function rrule!!(::CoDual{typeof(atomic_pointerset)}, p::CoDual{<:Ptr}, x::CoDual, order)
     _p = primal(p)
     _order = primal(order)
-    # Bookkeeping loads/stores use :monotonic throughout: the primal ordering may be
-    # valid for stores only (e.g. :release), so reusing it for the save/restore loads
-    # would throw a ConcurrencyViolationError. Only the primal store keeps the user's
-    # ordering.
+    # Bookkeeping loads/stores use :monotonic: a store-only primal ordering (e.g. :release)
+    # would throw ConcurrencyViolationError if reused for these save/restore loads.
     old_value = atomic_pointerref(_p, :monotonic)
     old_tangent = atomic_pointerref(tangent(p), :monotonic)
     dp = tangent(p)

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -28,8 +28,8 @@
 #     shared by multiple LazyDerivedRule instances (different inner functions), so a
 #     single-slot cache would serve the wrong rule — see DynamicFoRRule for key design.
 #
-# Despite the shared `FoRRule` suffix, none of the three is rule-callable like reverse-mode
-# `DerivedRule`: `DerivedFoRRule` is a carrier, extracted via `get_inner_rrule`.
+# The shared `FoRRule` suffix is a family label, not a contract: unlike reverse-mode
+# `DerivedRule`, none of the three is called with primal args to return AD output.
 mutable struct LazyFoRRule{Trule,Tfwd,Trvs}
     rule::Trule
     fwd_dual_callable::Tfwd

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -9,25 +9,14 @@
     typeof(build_derived_rrule),MooncakeInterpreter{C},Any,Any,Bool
 } where {C}
 
-# This file defines three forward-over-reverse (FoR) types organised into two layers.
-# Big-picture context: reverse mode has `DerivedRule` / `LazyDerivedRule` /
-# `DynamicDerivedRule` (`src/interpreter/reverse_mode.jl`); forward mode has
-# `DerivedFRule` / `LazyFRule` / `DynamicFRule` (`src/interpreter/forward_mode.jl`).
-# The FoR triplet below mirrors them — with the layer caveat described at the end
-# of this block.
-#
-# Value layer — `DerivedFoRRule{D}` (defined below, near `compile_for_rule`): a FoR
-# rule (or its absence) held as a value and reused across many calls. `D <: Dual`
-# carries a pre-built `Dual(rule, rule_tangent)` for HVP / Hessian; `D === Nothing`
-# is the primitive-passthrough sentinel. Reuse is safe because the rule's Stacks
-# self-reset within each forward+reverse pass.
-#
-# Frule layer — `LazyFoRRule` / `DynamicFoRRule` (this section): callable caches
-# dispatched as the frule for `build_derived_rrule`. Each call returns a fresh
-# `Dual(rule, rule_tangent)`, with Stacks cloned via `_for_rule_cached_dual` —
-# defensive against nested AD where the rule may be re-entered before the
-# previous call's Stacks have self-reset. `build_primitive_frule` selects between
-# the two via `__build_primitive_frule` (@generated):
+# `DerivedFoRRule{D}` (near `compile_for_rule`) holds one `Dual(rule, rule_tangent)` and
+# reuses it across calls, safe because the rule's Stacks self-reset within each
+# forward+reverse pass; `D === Nothing` is the primitive-passthrough sentinel.
+# `LazyFoRRule` / `DynamicFoRRule` are the frule for `build_derived_rrule`, returning a
+# fresh `Dual` per call with Stacks cloned via `_for_rule_cached_dual`, since nested AD can
+# re-enter the rule before the previous call's Stacks have self-reset.
+# `build_primitive_frule` selects between those two via `__build_primitive_frule`
+# (@generated):
 #
 #   • Concrete Trule → LazyFoRRule{Trule,Tfwd,Trvs}: fully-typed single-slot cache.
 #     Zero virtual dispatch on cache hits. Safe because each instance lives at exactly
@@ -39,23 +28,8 @@
 #     shared by multiple LazyDerivedRule instances (different inner functions), so a
 #     single-slot cache would serve the wrong rule — see DynamicFoRRule for key design.
 #
-# The trio mirrors reverse-mode `DerivedRule` / `LazyDerivedRule` / `DynamicDerivedRule`
-# at a slight angle: reverse mode's three types are all *rule-callable*
-# (`(rule)(args...)` with primal args, returning AD output). None of the three
-# FoR types here is rule-callable in that sense:
-#   • `DerivedFoRRule` is a *carrier* of a pre-built `Dual(rule, rule_tangent)`;
-#     callers extract via `get_inner_rrule`, they do not invoke it directly.
-#   • `LazyFoRRule` / `DynamicFoRRule` are *constructors* — their call shape is
-#     `(::Dual{typeof(build_derived_rrule)}, …)`, returning a fresh Dual rule
-#     per invocation (the frule for `build_derived_rrule`, not for user code).
-# Mooncake has no top-level "FoR rule" type — the user entry point
-# `value_and_hvp!!` dispatches through a regular `DerivedFRule`. The shared
-# `FoRRule` suffix is a family label (= "lives in the FoR machinery"), not a
-# contract suffix.
-#
-# TODO: rename to make the role honest — e.g. carrier → `FoRRuleDual` /
-# `RRuleDualBox`, constructors → `Lazy` / `DynamicBuildRRuleFRule`. Kept as-is
-# for now to minimise diff while wiring HVP through `DerivedFoRRule`.
+# Despite the shared `FoRRule` suffix, none of the three is rule-callable like reverse-mode
+# `DerivedRule`: `DerivedFoRRule` is a carrier, extracted via `get_inner_rrule`.
 mutable struct LazyFoRRule{Trule,Tfwd,Trvs}
     rule::Trule
     fwd_dual_callable::Tfwd
@@ -305,15 +279,11 @@ function rrule!!(
     )
 end
 
-# Wrapper around a pre-built `Dual(rule, rule_tangent)` so forward AD sees the
-# rule with its forward-mode-compiled dual callables instead of `zero_tangent`
-# re-deriving them over the reverse-mode-optimised primal IR (which would
-# reintroduce the bug `_compile_for_rule` exists to avoid). `tangent_type` is
-# `NoTangent`; the tangent rides inside the cached `Dual`. The type parameter
-# `D` discriminates: `D <: Dual` for derived rrules, `D === Nothing` for
-# primitives — callers branch via `for_rule isa DerivedFoRRule{Nothing}`.
-# Stale-rule caveat: the cached `Dual` is pinned to world age at prep; rebuild
-# the `HVPCache` if methods change after prep.
+# Holds a pre-built `Dual(rule, rule_tangent)` so forward AD sees the forward-mode-compiled
+# dual callables; `zero_tangent` would re-derive them over the reverse-mode-optimised primal
+# IR, reintroducing the bug `_compile_for_rule` exists to avoid.
+# `tangent_type` is `NoTangent` because the tangent rides inside the cached `Dual`, which is
+# pinned to the world age at prep: rebuild the `HVPCache` if methods change afterwards.
 struct DerivedFoRRule{D}
     rule_dual::D
 end

--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -156,9 +156,8 @@ function rrule!!(::CoDual{typeof(setindex!)}, d::CoDual{IdDict{K,V}}, val, key) 
     end
 
     setindex!(primal(d), primal(val), k)
-    # `setindex!` above stored `convert(V, val)`, so the slot is `tangent_type(V)`. For a
-    # matched/abstract `V` the two-argument `zero_tangent` reuses `val`'s fdata to preserve
-    # aliasing for mutable values; a non-diff slot/value takes a fresh slot-typed zero.
+    # `setindex!` above stored `convert(V, val)`, so the slot is `tangent_type(V)`. The
+    # two-arg `zero_tangent` reuses `val`'s fdata to preserve aliasing for mutable values.
     dslot = if tangent_type(V) == NoTangent
         NoTangent()
     elseif tangent_type(typeof(primal(val))) == NoTangent

--- a/src/tangents/codual.jl
+++ b/src/tangents/codual.jl
@@ -76,11 +76,9 @@ end
 The type of the `CoDual` which contains instances of `P` and associated tangents.
 """
 @unstable function codual_type(::Type{P}) where {P}
-    # `@isdefined(P)` is false when the static parameter couldn't be bound at
-    # dispatch — e.g. for `UnionAll(A, AbstractArray{T, A})` whose body has a
-    # free `TypeVar` `T`. Without this check, touching `P` would throw
-    # `UndefVarError(:P, :static_parameter)`. Same check guards the overloads
-    # below and `dual_type` in `src/tangents/dual.jl`.
+    # The static parameter is unbound for e.g. `UnionAll(A, AbstractArray{T, A})`, whose
+    # body has a free `TypeVar` `T`; touching `P` would then throw
+    # `UndefVarError(:P, :static_parameter)`. `dual_type` needs the same guard.
     @isdefined(P) || return CoDual
     return _codual_internal(P, codual_type, tangent_type)
 end

--- a/src/tangents/codual.jl
+++ b/src/tangents/codual.jl
@@ -78,7 +78,7 @@ The type of the `CoDual` which contains instances of `P` and associated tangents
 @unstable function codual_type(::Type{P}) where {P}
     # The static parameter is unbound for e.g. `UnionAll(A, AbstractArray{T, A})`, whose
     # body has a free `TypeVar` `T`; touching `P` would then throw
-    # `UndefVarError(:P, :static_parameter)`. `dual_type` needs the same guard.
+    # `UndefVarError(:P, :static_parameter)`. The overloads below and `dual_type` need it too.
     @isdefined(P) || return CoDual
     return _codual_internal(P, codual_type, tangent_type)
 end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -273,8 +273,7 @@ function has_equal_data_internal(
     return all(map((a, b) -> has_equal_data_internal(a, b, equal_undefs, d), x, y))
 end
 
-# `Method`, `CodeInstance`, and `MethodInstance` reference one another; recursing
-# into their fields traverses the runtime's method graph and overflows the stack.
+# Field descent through these walks the runtime's method graph and overflows the stack.
 for T in (:(Core.Method), :(Core.CodeInstance), :(Core.MethodInstance))
     @eval function has_equal_data_internal(
         x::$T, y::$T, equal_undefs::Bool, d::IdDict{Any,Bool}

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -273,7 +273,8 @@ function has_equal_data_internal(
     return all(map((a, b) -> has_equal_data_internal(a, b, equal_undefs, d), x, y))
 end
 
-# Field descent through these walks the runtime's method graph and overflows the stack.
+# `Method`, `CodeInstance` and `MethodInstance` reference one another, so field descent
+# walks the runtime's method graph and overflows the stack.
 for T in (:(Core.Method), :(Core.CodeInstance), :(Core.MethodInstance))
     @eval function has_equal_data_internal(
         x::$T, y::$T, equal_undefs::Bool, d::IdDict{Any,Bool}

--- a/test/ext/bfloat16s/bfloat16s.jl
+++ b/test/ext/bfloat16s/bfloat16s.jl
@@ -15,8 +15,7 @@ end
 const sr = StableRNG
 const P = Core.BFloat16
 
-# The shape NNlib gives `sigmoid`: `exp(-abs(x))` selected by an `ifelse`. Smooth at zero
-# even though `abs` is not, because the kink cancels between the two branches.
+# NNlib's `sigmoid` shape; smooth at zero unlike `abs`: the kink cancels between branches.
 function sigmoid_shaped(x)
     (t=exp(-abs(x)); ifelse(x >= zero(x), inv(one(x) + t), t / (one(x) + t)))
 end
@@ -77,18 +76,16 @@ end
         test_rule(sr(123), f, xs...; is_primitive=true, atol=0.2, rtol=0.4)
     end
 
-    # Right at zero for BFloat16 where it is not for the IEEEFloat types, because this
-    # repo's `abs` rules branch on `x >= zero(P)` and take the positive side, never reaching
-    # the `abs_float` intrinsic's `sign(x)`. Pinned by calling the rule, since `test_rule`
-    # passes when any one step agrees and a collapsed 0 matches six of the seven exactly:
-    # below ε = 1e-2, `sigmoid_shaped(±ε)` rounds back to `0.5`. `abs` itself is absent
-    # above because a central difference returns 0 at its kink against the rule's 1.
+    # Right at zero for BFloat16 but not the IEEEFloat types: this repo's `abs` rules branch
+    # on `x >= zero(P)`, never reaching the `abs_float` intrinsic's `sign(x)`. Pinned by
+    # calling the rule, since `test_rule` passes when any one step agrees and a collapsed 0
+    # matches six of the seven: below ε = 1e-2, `sigmoid_shaped(±ε)` rounds back to `0.5`.
+    # `abs` is absent above: its central difference returns 0 at the kink, the rule's 1.
     @testset "sigmoid_shaped at zero" begin
         rule = Mooncake.build_rrule(sigmoid_shaped, P(0))
         _, pb = rule(Mooncake.zero_fcodual(sigmoid_shaped), Mooncake.zero_fcodual(P(0)))
         @test Float64(pb(one(P))[2]) ≈ 0.25 rtol = 1e-2
-        # `test_rule` still earns its place either side of zero: its value-agreement,
-        # interface and caching checks are unaffected by the finite-difference blind spot.
+        # `test_rule`'s value, interface and caching checks survive that blind spot.
         for x in (P(0), P(0.5))
             test_rule(sr(123), sigmoid_shaped, x; is_primitive=false, atol=0.2, rtol=0.4)
         end

--- a/test/ext/bfloat16s/bfloat16s.jl
+++ b/test/ext/bfloat16s/bfloat16s.jl
@@ -15,7 +15,8 @@ end
 const sr = StableRNG
 const P = Core.BFloat16
 
-# NNlib's `sigmoid` shape; smooth at zero unlike `abs`: the kink cancels between branches.
+# NNlib's `sigmoid` shape: `exp(-abs(x))` under an `ifelse`, smooth at zero even though
+# `abs` is not, because the kink cancels between the two branches.
 function sigmoid_shaped(x)
     (t=exp(-abs(x)); ifelse(x >= zero(x), inv(one(x) + t), t / (one(x) + t)))
 end
@@ -80,7 +81,7 @@ end
     # on `x >= zero(P)`, never reaching the `abs_float` intrinsic's `sign(x)`. Pinned by
     # calling the rule, since `test_rule` passes when any one step agrees and a collapsed 0
     # matches six of the seven: below ε = 1e-2, `sigmoid_shaped(±ε)` rounds back to `0.5`.
-    # `abs` is absent above: its central difference returns 0 at the kink, the rule's 1.
+    # `abs` is absent above: its central difference returns 0 at the kink, the rule 1.
     @testset "sigmoid_shaped at zero" begin
         rule = Mooncake.build_rrule(sigmoid_shaped, P(0))
         _, pb = rule(Mooncake.zero_fcodual(sigmoid_shaped), Mooncake.zero_fcodual(P(0)))

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -216,33 +216,26 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _vcat_cu_sum(xs...) = sum(vcat(xs...))  # vararg: reused for 2-arg and N-arg tests
         _hcat_cu_sum(xs...) = sum(hcat(xs...))  # vararg: reused for 2-arg and N-arg tests
         _cat_cu_sum(d) = (xs...) -> sum(cat(xs...; dims=d))  # vararg: reused for 2-arg and N-arg tests
-        _permutedims_sum(perm) = x -> sum(permutedims(x, perm))                                   # sum after permute → scalar output
+        _permutedims_sum(perm) = x -> sum(permutedims(x, perm))
         # Wrappers for Statistics.varm GPU rule tests.
         _varm_sum_d1(x, m) = sum(varm(x, m; dims=1, corrected=false))
         _varm_sum_d2(x, m) = sum(varm(x, m; dims=2, corrected=true))
-        # no-dims path: varm(x, m_scalar; corrected); reused for real, complex, and
-        # mixed real/complex scalar means.
+        # no-dims path; reused for real, complex, and mixed real/complex scalar means.
         _varm_nodims_scalar(x, m) = varm(x, m; corrected=true)
-        # Tuple dims: what GroupNorm/InstanceNorm/BatchNorm actually pass (ntuple(static,
-        # N-1)), not covered by the single-Int tests above.
+        # Tuple dims: what GroupNorm/InstanceNorm/BatchNorm pass (ntuple(static, N-1)).
         _varm_sum_dtuple(x, m) = sum(varm(x, m; dims=(1, 2), corrected=false))
         # UnitRange dims: default LayerNorm(shape) passes `1:(N-M)` here, not a Tuple.
         _varm_sum_drange(x, m) = sum(varm(x, m; dims=1:2, corrected=false))
-        # dims=: with an array m (not scalar, unlike _varm_nodims_scalar above): the only
-        # test that hits the array-mean rule's own Colon branch.
+        # Array m with `dims=:`: the only test hitting the array-mean rule's Colon branch.
         _varm_sum_dcolon_arraymean(x, m) = sum(varm(x, m; dims=:, corrected=false))
-        # Repeated dims (dims=(1,1), which a careless ntuple could produce e.g. in
-        # GroupNorm): denominator must count dim 1 once, not twice.
+        # Repeated dims (a careless ntuple could produce them): count dim 1 once, not twice.
         _varm_sum_ddup(x, m) = sum(varm(x, m; dims=(1, 1), corrected=false))
-        # Empty dims collection: the primal reduces over nothing and returns the full
-        # array; the rule's denominator must mirror _mean_denom's `init=1`.
+        # Empty dims: the rule's denominator must mirror _mean_denom's `init=1`.
         _varm_sum_dempty(x, m) = sum(varm(x, m; dims=(), corrected=false))
-        # Bare 2-arg spelling (no keyword syntax at all): bypasses Core.kwcall entirely,
-        # exercising the dedicated bare-call primitive rather than the kwcall one above.
+        # Bare 2-arg spelling: bypasses Core.kwcall, hitting the dedicated bare-call rule.
         _varm_bare_nodims_scalar(x, m) = varm(x, m)
-        # Kwarg sets the real function rejects must throw identically under AD (the
-        # rules call the real method for their primal): array-m without the required
-        # dims kwarg, and scalar-m with a dims kwarg its method doesn't have.
+        # Kwarg sets the real function rejects must throw identically under AD (the rules
+        # call the real method for their primal).
         _varm_arraymean_missing_dims(x, m) = varm(x, m; corrected=false)
         _varm_scalarmean_stray_dims(x, m) = varm(x, m; dims=1)
         # Wrappers for Statistics.mean GPU rule tests.
@@ -695,8 +688,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _rand(rng, Float64, 3, 2),
                 _rand(rng, Float64, 5, 4),
             ),
-            # cat on CuArrays (Tuple dims, N-arg: block-diagonal with 3 arrays, checking
-            # the running-offsets tuple in _cu_concat_pb! beyond the 2-arg case)
+            # Tuple dims, N-arg: exercises the running-offsets tuple in _cu_concat_pb!.
             (
                 false,
                 :none,
@@ -706,8 +698,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _rand(rng, Float32, 2, 5),
                 _rand(rng, Float32, 3, 2),
             ),
-            # vcat/hcat/cat/permutedims on ComplexF32/ComplexF64 CuArrays (CuMaybeWrappedArray
-            # includes complex element types via CuFloatOrComplex).
+            # Complex CuArrays: CuMaybeWrappedArray covers them via CuFloatOrComplex.
             (
                 false,
                 :none,
@@ -732,9 +723,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _rand(rng, ComplexF64, 3, 2),
                 _rand(rng, ComplexF64, 5, 4),
             ),
-            # vcat/hcat/cat on Adjoint/Transpose/SubArray wrapping a CuArray, and on
-            # mixes of these with each other and with bare CuArrays. Each argument is
-            # canonicalised independently via `arrayify`, so any combination works.
+            # Wrapped and mixed arguments: each is canonicalised independently via
+            # `arrayify`, so any combination works.
             (
                 false,
                 :none,
@@ -767,9 +757,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 transpose(_rand(rng, Float32, 3, 4)),
                 view(_rand(rng, Float32, 4, 2), :, :),
             ),
-            # N-arg cat/hcat mixing three different wrapper types (plus a bare CuArray
-            # for cat) in one call. Exercises Vararg{CuMaybeWrappedArray} matching each
-            # argument independently rather than requiring a uniform type.
+            # N-arg: Vararg{CuMaybeWrappedArray} matches each argument independently
+            # rather than requiring a uniform type.
             (
                 false,
                 :none,
@@ -1131,10 +1120,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
 
         @testset "all-scalar nested broadcast leaves keep scalar gradients" begin
             # Regression for the differentiable-scalar guard in _premat_nondiff_args:
-            # (s .+ 1.0) is a nested Broadcasted whose fdata is NoFData (scalars carry
-            # their gradient in rdata), but it has one differentiable DOF. Collapsing
-            # it to a constant dropped s from flat_pargs, crashing the reverse pass
-            # with UndefRefError; d/ds sum(x .* (s .+ 1.0)) = sum(x).
+            # (s .+ 1.0) is a nested Broadcasted with NoFData fdata (scalar gradients live
+            # in rdata) but one differentiable DOF; collapsing it to a constant dropped s
+            # from flat_pargs, crashing the reverse pass with UndefRefError.
             x = CuArray(randn(rng, 4))
             s = 0.75
             cache = prepare_gradient_cache(_bcast_all_scalar_leaf, x, s)
@@ -1356,10 +1344,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             end
 
             @testset "regression: pure-CPU splatted vcat/hcat/cat with CUDA loaded" begin
-                # Regression for a review finding: `_is_primitive` used to be
-                # `@generated`, which crashed/misclassified splatted calls (unknown
-                # arity -> `Vararg` type) as needing this guard even with no GPU
-                # arrays involved; fixed calls here need a fixed arity, so they don't.
+                # Regression: `_is_primitive` used to be `@generated`, which crashed or
+                # misclassified splatted calls (unknown arity -> `Vararg` type) as needing
+                # the guard even with no GPU arrays involved.
                 _splat_vcat_sum(xs) = sum(vcat(xs...))
                 _splat_hcat_sum(xs) = sum(hcat(xs...))
                 _splat_cat_sum(xs) = sum(cat(xs...; dims=1))
@@ -1374,8 +1361,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             end
 
             @testset "Float16 support" begin
-                # Bare Float16 CuArrays are supported; checks the analytic gradient
-                # (ones) rather than finite differences, unreliable at this precision.
+                # Analytic gradient (ones), not finite differences: unreliable at Float16.
                 x16 = _rand(rng, Float16, 4)
                 y16 = _rand(rng, Float16, 4)
                 val, (_, dx, dy) = value_and_gradient!!(
@@ -1385,12 +1371,11 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 @test all(==(one(Float16)), Array(dx))
                 @test all(==(one(Float16)), Array(dy))
 
-                # Float16 SubArrays are excluded from CuMaybeWrappedArray (Finding 3). A
-                # strided view stays a genuine SubArray (unlike the contiguous 1-D view
-                # above, which CUDA.jl collapses to a plain CuArray), and since it isn't
-                # a primitive here, the N-arg mixed-device guard doesn't recognise it as
-                # GPU either, so this errors there with "mix of GPU" instead of falling
-                # through to the interpreter's untraceable `cufunction` try/finally.
+                # Float16 SubArrays are excluded from CuMaybeWrappedArray. A strided view
+                # stays a genuine SubArray (unlike the contiguous 1-D view above, which
+                # CUDA.jl collapses to a plain CuArray) and the N-arg mixed-device guard
+                # does not count it as GPU either, so it errors with "mix of GPU" rather
+                # than reaching the interpreter's untraceable `cufunction` try/finally.
                 x16_mat = _rand(rng, Float16, 4, 3)
                 y16_mat = _rand(rng, Float16, 2, 3)
                 f_view(x, y) = sum(vcat(view(x, 1:2, :), y))
@@ -1403,17 +1388,15 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             end
 
             @testset "_unwrap_cat_dim rejects unsupported dims types" begin
-                # dims must be an Integer, Val{N}, or Tuple{Vararg{Integer}} — anything
-                # else should fail loudly rather than silently misbehave.
+                # dims must be an Integer, Val{N}, or Tuple{Vararg{Integer}}.
                 @test_throws ArgumentError _MooncakeCUDAExt._unwrap_cat_dim(1.0)
                 @test_throws ArgumentError _MooncakeCUDAExt._unwrap_cat_dim((1, 2.0))
             end
         end
 
         @testset "Statistics.varm GPU rule" begin
-            # varm(x, m; dims, corrected) : used by LayerNorm / GroupNorm / InstanceNorm
-            # via LuxLib.Impl.mean_var → var → varm. Test both frule!! and rrule!! through
-            # wrapper functions; is_primitive=false because the wrapper is not a primitive.
+            # varm(x, m; dims, corrected): used by LayerNorm / GroupNorm / InstanceNorm via
+            # LuxLib.Impl.mean_var → var → varm. is_primitive=false: the wrapper is not one.
             @testset "dims=1, corrected=false (Float32)" begin
                 x = _rand(rng, Float32, 4, 3)
                 m = _rand(rng, Float32, 1, 3)
@@ -1549,18 +1532,14 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                     )
                 end
             end
-            # NOTE: no complex or mixed real/complex *array*-mean tests here (unlike
-            # scalar-mean above). GPUArrays' accelerated varm requires Real eltypes on
-            # both arguments; anything else falls through to a generic scalar-indexing
-            # path that can't run on GPU at all, so there's no ground truth to test
-            # against. The array-m rules are restricted to real eltypes to match — a
-            # wider signature would make AD succeed where the primal throws — and the
-            # norm layers never produce these combinations anyway (x and its own mean
-            # always share a real eltype).
+            # No complex/mixed array-mean tests: GPUArrays' accelerated varm needs Real
+            # eltypes on both arguments, and anything else falls to a generic
+            # scalar-indexing path that cannot run on GPU, so there is no ground truth.
+            # The array-m rules are restricted to match rather than succeed where the
+            # primal throws; the norm layers only ever pass x and its own real mean.
             @testset "m broadcast against x: full-shape m, dims=1 (Float32)" begin
-                # Regression: the primal broadcasts m against x, so m need not have
-                # the reduced shape; m's gradient must reduce the elementwise gradient
-                # over exactly the dims m is broadcast along (none, here) rather than
+                # Regression: the primal broadcasts m against x, so m's gradient must
+                # reduce over exactly the dims m is broadcast along (none, here) rather than
                 # over `dims`, which used to column-sum it.
                 x = _rand(rng, Float32, 4, 3)
                 m = _rand(rng, Float32, 4, 3)
@@ -1578,9 +1557,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 )
             end
             @testset "x broadcast against m: (1,3) x, full m, dims=1 (Float32)" begin
-                # Regression: x can be the broadcast-expanded operand too, not just m;
-                # the pullback must unbroadcast the elementwise gradient to BOTH
-                # operand shapes (dx used to throw DimensionMismatch here).
+                # Regression: x can be the broadcast-expanded operand too, so the pullback
+                # must unbroadcast to BOTH shapes (dx used to throw DimensionMismatch here).
                 x = _rand(rng, Float32, 1, 3)
                 m = _rand(rng, Float32, 4, 3)
                 test_rule(
@@ -1626,13 +1604,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 )
             end
             @testset "empty array, scalar mean, corrected=true (Float32)" begin
-                # Regression: an empty input must give NaN, matching
-                # Statistics._varm(A, m, corrected, ::Colon) (not 0/(0-1) = -0.0). This
-                # is Statistics.jl's generic method (scalar m isn't overridden by
-                # GPUArrays), the one where the NaN guard lives. NaN is a convention
-                # override, not a true singularity (x is empty, so the unguarded value
-                # is a constant 0 regardless of m), so the gradient must be 0, not NaN;
-                # checked explicitly since frule!! and rrule!! must agree here too.
+                # Regression: an empty input must give NaN, matching the guard in
+                # Statistics._varm(A, m, corrected, ::Colon) — scalar m is not overridden
+                # by GPUArrays — not 0/(0-1) = -0.0. The unguarded value is a constant 0
+                # regardless of m, so the gradient must be 0, not NaN.
                 x = CuArray(Float32[])
                 m = 0.0f0
                 @test isnan(_varm_nodims_scalar(x, m))
@@ -1645,10 +1620,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 @test dm == 0.0f0
             end
             @testset "empty array, array mean, dims=: (Float32)" begin
-                # Regression: unlike scalar-mean above, GPUArrays' own
-                # `varm(A::AbstractGPUArray, M::AbstractArray; dims, corrected)` has no
-                # empty-input guard and gives 0, not NaN; the scalar-mean NaN guard
-                # above must not be applied here.
+                # Regression: GPUArrays' array-m `varm` has no empty-input guard and gives
+                # 0, not NaN; the scalar-mean NaN guard above must not be applied here.
                 x = CuArray(Float32[])
                 m = CuArray(Float32[])
                 @test _varm_sum_dcolon_arraymean(x, m) == 0.0f0
@@ -1659,9 +1632,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 @test out == 0.0f0
             end
             @testset "empty x, non-empty m, dims=:, corrected=false (Float32)" begin
-                # Regression: coeff = 2/(0-0) = Inf; multiplying it into a pre-reduced
-                # sum_diff gave Inf * 0 = NaN in dm. The elementwise gradient is formed
-                # first now (an empty array), so its unbroadcast reduction is a clean 0.
+                # Regression: coeff = 2/(0-0) = Inf times a pre-reduced sum_diff gave
+                # Inf * 0 = NaN in dm; forming the elementwise gradient first reduces to 0.
                 x = CuArray(Float32[])
                 m = CuArray(Float32[0.0f0])
                 rule = Mooncake.build_rrule(_varm_sum_dcolon_arraymean, x, m)
@@ -1672,11 +1644,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 @test Array(dm) == [0.0f0]
             end
             @testset "scalar m must match x's underlying precision" begin
-                # Mixed precision (Float32 data, Float64 mean) makes Statistics'
-                # scalar-m varm infer Union{Float32,Float64} (its n==0 branch types
-                # σ² off x alone, while its main branch promotes with m), which
-                # Mooncake's rule builder cannot handle (zero(::Type{Union{...}}));
-                # such combinations are deliberately not claimed as primitives.
+                # Mixed precision makes Statistics' scalar-m varm infer
+                # Union{Float32,Float64} (its n==0 branch types σ² off x alone, its main
+                # branch promotes with m), which Mooncake's rule builder cannot handle
+                # (zero(::Type{Union{...}})).
                 x = _rand(rng, Float32, 4, 3)
                 world = Base.get_world_counter()
                 kwsig = @NamedTuple{corrected::Bool}
@@ -1696,10 +1667,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 )
             end
             @testset "empty x forward tangent is the zero map" begin
-                # frule!! counterpart of the reverse-mode empty test above: the
-                # primal is a constant NaN at n==0, so the JVP must be 0 — the
-                # divide-after arithmetic would otherwise give 0/0 = NaN, which is
-                # inconsistent with the rrule's zero (empty/zero-rdata) gradient map.
+                # frule!! counterpart of the empty test above: the primal is a constant
+                # NaN at n==0, so the JVP must be 0, not the divide-after 0/0 = NaN.
                 x = CuArray(Float32[])
                 d = Mooncake.frule!!(
                     Mooncake.Dual(Core.kwcall, Mooncake.NoTangent()),
@@ -1722,10 +1691,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 @test out == Float16(1)
             end
             @testset "Float16 large n keeps λ finite in gradients" begin
-                # Regression: `one(T) / n` converts n to Float16 first, so for
-                # n > 65504 λ became 1/Inf16 = 0 and every gradient silently
-                # collapsed to zero while the primal (which inverts in Float64 and
-                # then converts, as GPUArrays does) stayed healthy.
+                # Regression: `one(T) / n` converts n to Float16 first, so at n > 65504 λ
+                # became 1/Inf16 = 0 and every gradient collapsed to zero, while the primal
+                # (inverting in Float64 first, as GPUArrays does) stayed healthy.
                 x = CUDA.ones(Float16, 70000)
                 m = CUDA.zeros(Float16, 1)
                 rule = Mooncake.build_rrule(_varm_sum_d1, x, m)
@@ -1745,11 +1713,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 @test only(Array(Mooncake.tangent(d))) > Float16(1.5)
             end
             @testset "scalar m: Float16 huge n matches the generic primal" begin
-                # Unlike the GPUArrays array-m method above, Statistics' scalar-m
-                # varm divides the sum by the Int denominator in Float16 arithmetic,
-                # so at n > 65504 the denominator promotes to Inf16 and the primal
-                # and its CPU-traced gradient are both exactly 0; the CUDA rule must
-                # not substitute healthier arithmetic on one backend only.
+                # Unlike the GPUArrays array-m method above, Statistics' scalar-m varm
+                # divides by the Int denominator in Float16, so at n > 65504 it promotes
+                # to Inf16 and both primal and CPU-traced gradient are exactly 0; the CUDA
+                # rule must not substitute healthier arithmetic on one backend only.
                 x = CuArray(vcat(ones(Float16, 1), zeros(Float16, 69999)))
                 m = Float16(0)
                 @test _varm_nodims_scalar(x, m) == Float16(0)
@@ -1760,10 +1727,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 @test out == Float16(0)
                 @test all(iszero, Array(gx))
                 @test iszero(gm)
-                # Pin the frule's divide-after arithmetic too: the residual-weighted
-                # sum is finite (2 · 1 · 0.5 = 1) and the Inf16-promoted denominator
-                # zeroes the quotient, exactly as the CPU-traced JVP; a λ-prescaled
-                # form would give ≈1.4e-5 instead.
+                # Pin the frule's divide-after arithmetic too: the residual-weighted sum
+                # is finite (2 · 1 · 0.5 = 1) and the Inf16-promoted denominator zeroes the
+                # quotient; a λ-prescaled form would give ≈1.4e-5 instead.
                 d = Mooncake.frule!!(
                     Mooncake.Dual(Core.kwcall, Mooncake.NoTangent()),
                     Mooncake.Dual((; corrected=true), Mooncake.NoTangent()),
@@ -1794,9 +1760,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         end
 
         @testset "Statistics.mean GPU rule" begin
-            # mean(x; dims) on CuArrays. GPUArrays._mean calls sum(Fix1(*,λ), x; dims)
-            # which Mooncake cannot trace; the rule calls it natively for the value and
-            # hand-rolls only the derivative.
+            # GPUArrays._mean calls sum(Fix1(*,λ), x; dims), which Mooncake cannot trace;
+            # the rule calls it natively for the value and hand-rolls the derivative.
             @testset "dims=1 (Float32)" begin
                 x = _rand(rng, Float32, 4, 3)
                 test_rule(
@@ -1851,8 +1816,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             @testset "empty array, dims=: gives NaN (Float32)" begin
                 # Regression: the primal is sum/length = 0/0 = NaN; the rule takes its
                 # value from the real function, so it must agree (a hand-rolled
-                # sum(λ .* x) sums zero terms and gives 0 instead). The gradient is
-                # empty, so there is no tangent to check beyond shape.
+                # sum(λ .* x) sums zero terms and gives 0 instead).
                 x = CuArray(Float32[])
                 @test isnan(_mean_nodims(x))
                 rule = Mooncake.build_rrule(_mean_nodims, x)
@@ -1882,9 +1846,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _, (_, g_colon) = Mooncake.value_and_gradient!!(rule_c, _mean_nodims, x)
                 @test Array(g_colon) == Array(g_bare)
                 @test all(iszero, Array(g_colon))
-                # Pin the frule's divide-after arithmetic too: sum(0.5-tangents) is
-                # finite (35000 < 65504) and / Float16(70000) = / Inf16 gives exactly
-                # 0; a λ-prescaled form would give ≈ 0.5.
+                # Pin the frule's divide-after arithmetic too: sum(0.5-tangents) is finite
+                # (35000) and / Float16(70000) = / Inf16 gives exactly 0; λ-prescaled ≈ 0.5.
                 d = Mooncake.frule!!(
                     Mooncake.Dual(Core.kwcall, Mooncake.NoTangent()),
                     Mooncake.Dual((; dims=:), Mooncake.NoTangent()),
@@ -1896,8 +1859,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         end
 
         @testset "Statistics.varm GPU rule (complex)" begin
-            # m::Complex{IEEEFloat} scalar with a complex array: the same-precision
-            # scalar-m rule. σ² = sum(abs2(x-m))/n is always real (Float32).
+            # Complex scalar m of matching precision: σ² = sum(abs2(x-m))/n is always real.
             @testset "no dims, scalar mean (ComplexF32)" begin
                 x = _rand(rng, ComplexF32, 4, 3)
                 m_cx = randn(StableRNG(10), ComplexF32)
@@ -1913,8 +1875,6 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         end
 
         @testset "Statistics.mean GPU rule (complex)" begin
-            # mean(x::CuArray{ComplexF32}; dims=:) → ComplexF32 scalar;
-            # mean(x::CuArray{ComplexF32}; dims=1) → CuArray{ComplexF32}.
             @testset "dims=: scalar output (ComplexF32)" begin
                 x = _rand(rng, ComplexF32, 4, 3)
                 test_rule(

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -228,7 +228,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _varm_sum_drange(x, m) = sum(varm(x, m; dims=1:2, corrected=false))
         # Array m with `dims=:`: the only test hitting the array-mean rule's Colon branch.
         _varm_sum_dcolon_arraymean(x, m) = sum(varm(x, m; dims=:, corrected=false))
-        # Repeated dims (a careless ntuple could produce them): count dim 1 once, not twice.
+        # Repeated dims (a careless ntuple could produce them): the denominator must count
+        # dim 1 once, not twice.
         _varm_sum_ddup(x, m) = sum(varm(x, m; dims=(1, 1), corrected=false))
         # Empty dims: the rule's denominator must mirror _mean_denom's `init=1`.
         _varm_sum_dempty(x, m) = sum(varm(x, m; dims=(), corrected=false))
@@ -1535,8 +1536,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             # No complex/mixed array-mean tests: GPUArrays' accelerated varm needs Real
             # eltypes on both arguments, and anything else falls to a generic
             # scalar-indexing path that cannot run on GPU, so there is no ground truth.
-            # The array-m rules are restricted to match rather than succeed where the
-            # primal throws; the norm layers only ever pass x and its own real mean.
+            # The array-m rules are restricted to real eltypes to match, since a wider
+            # signature would make AD succeed where the primal throws; the norm layers only
+            # ever pass x and its own real mean.
             @testset "m broadcast against x: full-shape m, dims=1 (Float32)" begin
                 # Regression: the primal broadcasts m against x, so m's gradient must
                 # reduce over exactly the dims m is broadcast along (none, here) rather than
@@ -1604,10 +1606,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 )
             end
             @testset "empty array, scalar mean, corrected=true (Float32)" begin
-                # Regression: an empty input must give NaN, matching the guard in
-                # Statistics._varm(A, m, corrected, ::Colon) — scalar m is not overridden
-                # by GPUArrays — not 0/(0-1) = -0.0. The unguarded value is a constant 0
-                # regardless of m, so the gradient must be 0, not NaN.
+                # Regression: an empty input must give NaN, not 0/(0-1) = -0.0, matching the
+                # guard in Statistics._varm(A, m, corrected, ::Colon) — scalar m is not
+                # overridden by GPUArrays. The unguarded value is a constant 0 regardless of
+                # m, so the gradient must be 0, not NaN.
                 x = CuArray(Float32[])
                 m = 0.0f0
                 @test isnan(_varm_nodims_scalar(x, m))
@@ -1847,7 +1849,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 @test Array(g_colon) == Array(g_bare)
                 @test all(iszero, Array(g_colon))
                 # Pin the frule's divide-after arithmetic too: sum(0.5-tangents) is finite
-                # (35000) and / Float16(70000) = / Inf16 gives exactly 0; λ-prescaled ≈ 0.5.
+                # (35000 < 65504) and / Float16(70000) = / Inf16 gives 0; λ-prescaled ≈ 0.5.
                 d = Mooncake.frule!!(
                     Mooncake.Dual(Core.kwcall, Mooncake.NoTangent()),
                     Mooncake.Dual((; dims=:), Mooncake.NoTangent()),

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -27,8 +27,7 @@ function dropout_alias_tester_dims(Trng, x)
     return sum(x)
 end
 
-# TODO: CUDA version bound when
-#  https://github.com/JuliaGPU/CUDA.jl/issues/2886 is fixed and released
+# TODO: drop the CUDA version bound once https://github.com/JuliaGPU/CUDA.jl/issues/2886 ships
 cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
 
 @testset "nnlib" begin
@@ -182,8 +181,7 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
         # also need the `materialize!` rule for the forward broadcast. Both fail on `main`.
         (false, :none, false, dropout_alias_tester, Trng, _rand(rng, 2, 2)'),
         (false, :none, false, dropout_alias_tester, Trng, transpose(_rand(rng, 2, 2))),
-        # ... and through the other arm, `p > 0`, where the rule adds ChainRules' cotangent
-        # through `arrayify`'s wrapper because the wrapper's fdata is the parent's.
+        # ... and the other arm, `p > 0`, where the cotangent goes via `arrayify`'s wrapper.
         (true, :none, false, dropout_tester_1, Trng, _rand(rng, 2, 2)', float(0.5)),
         (
             true,
@@ -343,9 +341,7 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
         (false, :none, true, NNlib.scatter, +, _rand(rng, 2), [1, 3]),
         (false, :none, true, Core.kwcall, (;), NNlib.scatter, +, _rand(rng, 2), [1, 3]),
 
-        # scatter(max/min, ...) with sources tied for one destination. The tie is the point,
-        # so the values are equal by construction rather than random: ChainRules gives each
-        # tied entry the whole cotangent, summing to the tie multiplicity.
+        # `scatter(max/min, ...)` with sources tied for one destination, hence `_ones`.
         (false, :none, true, NNlib.scatter, max, _ones(3), [1, 1, 2]),
         (false, :none, true, NNlib.scatter, min, _ones(3), [1, 1, 2]),
         (false, :none, true, Core.kwcall, (;), NNlib.scatter, max, _ones(3), [1, 1, 2]),
@@ -355,9 +351,8 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
         (false, :none, true, NNlib.scatter, max, _ones(2, 3), [1, 1, 2]),
 
         # `init` is differentiable, so the keyword NamedTuple's rdata is not NoRData. The
-        # three cases put it below every source, above every source, and tied with exactly
-        # one — the tie a central difference can express, since its mean of the one-sided
-        # derivatives is the symmetric split.
+        # cases put it below every source, above every source, and tied with one — a tie whose
+        # symmetric split is the mean of the one-sided derivatives a central difference takes.
         (
             false,
             :none,
@@ -403,8 +398,7 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
             [1, 1, 2],
         ),
 
-        # An `init` with no rdata, which used to throw. It wins outright here, so nothing ties
-        # it, and whether it counts towards the tie total makes no difference to this case.
+        # An `init` with no rdata, which used to throw. It wins outright, so nothing ties it.
         (
             false,
             :none,
@@ -417,10 +411,8 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
             [1, 1, 2],
         ),
 
-        # Dropping `max(total, 1)` made a `NaN` in `src` propagate into the gradient instead
-        # of being silenced to zero, which is the whole point of removing it, and it has to
-        # do so in both arms — the two disagreeing on the same input is what the removal
-        # fixed. `interface_only`, since a `NaN` gradient is not finite-differenceable.
+        # A `NaN` in `src` must propagate into the gradient rather than be silenced to zero,
+        # in both arms. `interface_only`, since a `NaN` gradient is not finite-differenceable.
         (true, :none, true, NNlib.scatter, max, [NaN, 1.0, 2.0], [1, 1, 2]),
         (
             true,
@@ -434,9 +426,8 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
             [1, 1, 2],
         ),
 
-        # `init` over a multi-dim `src`, where the tie count and the `init` indicator have
-        # to agree on the extra leading dimension. Winning `init` takes the whole cotangent,
-        # so `dsrc` is zero and `dinit` is the destination count.
+        # `init` over a multi-dim `src`, where the tie count and the `init` indicator have to
+        # agree on the extra leading dimension.
         (
             false,
             :none,
@@ -463,9 +454,8 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
         ),
 
         # `dstsize` past the largest index leaves destinations no index reaches, holding
-        # `scatter_empty` with no tied source. Nothing gathers them, so they take no part in
-        # the gradient; summing only the reachable ones keeps the primal finite, the others
-        # being -Inf.
+        # `scatter_empty`; nothing gathers them, so they take no part in the gradient, and the
+        # slice keeps their `-Inf`s out of the sum.
         (
             false,
             :none,
@@ -672,16 +662,14 @@ end
             StableRNG(123), x -> sum(f.(x)), cu([0.0f0, 0.5f0, -0.5f0]); is_primitive=false
         )
     end
-    # Saturated inputs. These cover NaN, Inf and type stability, not the precision itself —
-    # see the Limitations section of `test_rule`'s docstring.
+    # Saturated inputs: NaN, Inf and stability, not precision — see `test_rule`'s Limitations.
     test_rule(StableRNG(123), f, 37.0; perf_flag=:stability)
     test_rule(StableRNG(123), f, 17.0f0; perf_flag=:stability)
 
-    # Float16 collapses first, at x >= 8, where `test_rule` fails whichever formula is in
-    # place: both terms of its `ȳ·ẏ + x̄·ẋ` check are unusable, `ẏ` being exactly 0 for
-    # every step (spacing 4.88e-4 against a true change of 3.35e-6) and `ẋ` 2.3% off at
-    # best. So compare against a wider-precision reference. `Ω * (1 - Ω)` returns exactly 0
-    # here, so these are the only tests pinning σ's precision, once per copy of the formula.
+    # Float16 collapses first, at x >= 8, where `test_rule` fails whichever formula is in place:
+    # in its `ȳ·ẏ + x̄·ẋ` check `ẏ` is exactly 0 for every step (spacing 4.88e-4 against a true
+    # change of 3.35e-6) and `ẋ` 2.3% off at best, so compare against a wider-precision reference.
+    # `Ω * (1 - Ω)` returns exactly 0 here, so these are the only tests pinning σ's precision.
     ref16 = (b=big(8.0); y=inv(1 + exp(-b)); Float64(y * (1 - y)))
     x16 = NDual{Float16,1}(Float16(8), (one(Float16),))
     @test Float64(ndual_partial(f(x16), 1)) ≈ ref16 rtol = 1e-2
@@ -693,9 +681,8 @@ end
     @test Float64(pb16(one(Float16))[2]) ≈ ref16 rtol = 1e-2
 end
 
-# `tanh_fast`'s primal discards an `ifelse` branch that overflows to `NaN`; reverse mode
-# picked that branch up as `0 * Inf`, which poisoned `gelu`/`gelu_tanh` from `|x| ≈ 21`
-# upwards.
+# `tanh_fast`'s primal discards an `ifelse` branch that overflows to `NaN`, which reverse mode
+# picked up as `0 * Inf`, poisoning `gelu`/`gelu_tanh` from `|x| ≈ 21` upwards.
 @testset "tanh_fast across NNlib's branches" begin
     test_rule(StableRNG(123), tanh_fast, 0.5; perf_flag=:stability)
     test_rule(StableRNG(123), tanh_fast, 400.0; perf_flag=:stability)
@@ -705,15 +692,12 @@ end
     test_rule(
         StableRNG(123), x -> sum(NNlib.gelu_tanh.(x)), [1.0, 25.0]; is_primitive=false
     )
-    # NNlib's `tanh_fast(::Float32)` is a different body from the `Float64` one — a Remez
-    # rational whose discarded branch overflows, rather than an `exp` quotient — so none of
-    # the cases above reach it, and the rule kept working for `Float64` with `Float32`
-    # removed from it. Through `gelu_tanh` the Float32 gradient goes `NaN` from |x| ≈ 258.8,
-    # so a scalar there fails without the rule and passes with it.
+    # NNlib's `tanh_fast(::Float32)` is a different body, so none of the cases above reach it:
+    # the rule kept working for `Float64` with `Float32` removed from it. Through `gelu_tanh`
+    # the Float32 gradient goes `NaN` from |x| ≈ 258.8, so a scalar fails without the rule.
     test_rule(StableRNG(123), NNlib.gelu_tanh, 300.0f0; is_primitive=false)
-    # As for σ, the saturated derivative's precision is beyond finite differences, and both
-    # rules carry their own copy of `4u / (1 + u)^2`. `1 - Ω^2` returns exactly 0 at
-    # Float16(6), against a true 2.46e-5, so this separates the two forms outright.
+    # As for σ, the saturated derivative's precision is beyond finite differences. `1 - Ω^2`
+    # returns exactly 0 at Float16(6), against a true 2.46e-5, so it separates the two forms.
     ref16 = Float64(1 - tanh(big(6.0))^2)
     d16 = Mooncake.frule!!(
         Mooncake.Dual(tanh_fast, Mooncake.NoTangent()),
@@ -726,17 +710,14 @@ end
     @test Float64(pb16(one(Float16))[2]) ≈ ref16 rtol = 1e-2
 end
 
-# Each rule below exists only in reverse mode, so its `@is_primitive` says so; declared for
-# both, forward mode finds a primitive with no `frule!!` and raises instead of tracing. CPU
-# arrays only: on a GPU array the traced primal reaches a kernel launch, a foreigncall, and
-# raises `MissingForeigncallRuleError`. `gather` took the process down, hence its own rule
-# below.
+# The rules below are reverse-only primitives, so forward mode traces the primal; declared for
+# both modes it would find no `frule!!` and raise. CPU arrays only: a traced GPU kernel launch
+# is a foreigncall, raising `MissingForeigncallRuleError`, and `gather` took the process down.
 @testset "forward mode traces reverse-only rules" begin
     x = randn(StableRNG(123), 3)
     for f in (
-        # `softmax` is returned whole rather than summed: its outputs sum to 1 identically,
-        # so `1ᵀJ = 0` and a summed case is blind to every error inside that kernel.
-        # `logsoftmax` does not sum to a constant, so summing it stays a real check.
+        # `softmax` is returned whole: its outputs sum to 1, so `1ᵀJ = 0` and a summed case is
+        # blind to every error in it. `logsoftmax` does not, so summing it stays a real check.
         x -> softmax(x),
         x -> softmax(x; dims=1),
         x -> sum(logsoftmax(x)),
@@ -749,9 +730,8 @@ end
     end
 end
 
-# `gather`'s GPU kernel launch does not survive the forward transform — an illegal
-# instruction no test can catch — so its rule raises instead, which this pins where a device
-# is available.
+# `gather`'s GPU kernel launch does not survive the forward transform — an illegal instruction
+# no test can catch — so its rule raises, which this pins where a device is available.
 if cuda
     @testset "forward mode over gather on a GPU array raises" begin
         gather_sum(z) = sum(NNlib.gather(z, [1, 3]))

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -27,7 +27,8 @@ function dropout_alias_tester_dims(Trng, x)
     return sum(x)
 end
 
-# TODO: drop the CUDA version bound once https://github.com/JuliaGPU/CUDA.jl/issues/2886 ships
+# TODO: drop the CUDA version bound once the fix for
+# https://github.com/JuliaGPU/CUDA.jl/issues/2886 is released.
 cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
 
 @testset "nnlib" begin
@@ -411,8 +412,9 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
             [1, 1, 2],
         ),
 
-        # A `NaN` in `src` must propagate into the gradient rather than be silenced to zero,
-        # in both arms. `interface_only`, since a `NaN` gradient is not finite-differenceable.
+        # A `NaN` in `src` must reach the gradient in both arms rather than be silenced to
+        # zero by a `max(total, 1)` — removing that guard is what made the arms agree.
+        # `interface_only`, since a `NaN` gradient is not finite-differenceable.
         (true, :none, true, NNlib.scatter, max, [NaN, 1.0, 2.0], [1, 1, 2]),
         (
             true,
@@ -666,10 +668,11 @@ end
     test_rule(StableRNG(123), f, 37.0; perf_flag=:stability)
     test_rule(StableRNG(123), f, 17.0f0; perf_flag=:stability)
 
-    # Float16 collapses first, at x >= 8, where `test_rule` fails whichever formula is in place:
-    # in its `ȳ·ẏ + x̄·ẋ` check `ẏ` is exactly 0 for every step (spacing 4.88e-4 against a true
-    # change of 3.35e-6) and `ẋ` 2.3% off at best, so compare against a wider-precision reference.
-    # `Ω * (1 - Ω)` returns exactly 0 here, so these are the only tests pinning σ's precision.
+    # Float16 collapses first, at x >= 8, where `test_rule` fails whichever formula is in
+    # place: in its `ȳ·ẏ + x̄·ẋ` check `ẏ` is exactly 0 for every step (spacing 4.88e-4
+    # against a true change of 3.35e-6) and `ẋ` 2.3% off at best, so compare against a
+    # wider-precision reference. `Ω * (1 - Ω)` returns exactly 0 here, so these are the only
+    # tests pinning σ's precision.
     ref16 = (b=big(8.0); y=inv(1 + exp(-b)); Float64(y * (1 - y)))
     x16 = NDual{Float16,1}(Float16(8), (one(Float16),))
     @test Float64(ndual_partial(f(x16), 1)) ≈ ref16 rtol = 1e-2

--- a/test/integration_testing/flux/flux.jl
+++ b/test/integration_testing/flux/flux.jl
@@ -167,8 +167,7 @@ const TEST_MODELS = [
         rand(Float32, 5, 5, 3, 1),
         "ConvTranspose((3, 3), 3 => 2)",
     ),
-    # LayerNorm calls varm via LuxLib.Impl.mean_var → var → varm. Enabled by the
-    # Statistics.varm GPU rrule!! in MooncakeCUDAExt.
+    # LayerNorm needs MooncakeCUDAExt's Statistics.varm GPU rrule!! (via LuxLib mean_var).
     (_gpu_enabled, LayerNorm(2), randn(Float32, 2, 10), "LayerNorm(2)"),
     (_gpu_enabled, BatchNorm(2), randn(Float32, 2, 10), "BatchNorm(2)"),  # NNlib.batchnorm rrule!! (NNlibMooncakeCUDAExt, FluxML/NNlib.jl#727)
     (

--- a/test/integration_testing/lux/lux.jl
+++ b/test/integration_testing/lux/lux.jl
@@ -22,8 +22,7 @@ const _gpu_disabled = false
 #   1. COVERAGE — some GPU operations are not differentiable by Mooncake without
 #      explicit rules:
 #        • cuDNN operators (batchnorm_cudnn!, …) — need an rrule!!
-#        • Base.permutedims(::CuArray) — fixed in MooncakeCUDAExt; MHA now enabled
-#        • SkipConnection with vcat — fixed in MooncakeCUDAExt; now enabled
+#        • Base.permutedims(::CuArray), SkipConnection+vcat — rules in MooncakeCUDAExt
 #        • GroupNorm / InstanceNorm — call Statistics.varm; needs an rrule!! for varm
 #        • StatefulRecurrentCell (RNN/LSTM/GRU) — state mutation (setfield! on cell)
 #          not yet differentiable on GPU
@@ -57,8 +56,7 @@ _model_name(f::MultiHeadAttention) = "MultiHeadAttention($(f.q_proj.in_dims))"
 const TEST_MODELS = Any[
     (false, _gpu_enabled, Dense(2, 4), randn(sr(1), P, 2, 3)),
     # tests for https://github.com/chalk-lab/Mooncake.jl/issues/563
-    # MooncakeCUDAExt now has an explicit rrule!! for Base.permutedims(::CuArray),
-    # which is called by LuxLib.batched_matmul in the MultiHeadAttention path.
+    # MHA needs MooncakeCUDAExt's Base.permutedims(::CuArray) rule (LuxLib.batched_matmul).
     (
         true,
         _gpu_enabled,
@@ -178,11 +176,9 @@ const TEST_MODELS = Any[
         Chain(Conv((3, 3), 2 => 6, tanh), BatchNorm(6)),
         randn(sr(28), P, 6, 6, 2, 2),
     ),
-    # GroupNorm calls varm via LuxLib.Impl.mean_var → var → varm. 2D inputs (sr(29),
-    # sr(30)) are disabled on GPU: LuxLib's groupnorm_affine_normalize_internal! CUDA
-    # kernel calls rsqrt which does not support the complex-valued perturbations used by
-    # Mooncake's correctness checker, causing a DomainError during the Correctness test.
-    # 4D spatial inputs (sr(31), sr(32)) use a different kernel path and are unaffected.
+    # GroupNorm needs the Statistics.varm GPU rrule!! (via LuxLib mean_var). 2D is disabled:
+    # its groupnorm_affine_normalize_internal! kernel calls rsqrt, which DomainErrors on the
+    # correctness checker's complex perturbations; 4D takes another kernel path.
     (
         false,
         _gpu_disabled,
@@ -202,16 +198,14 @@ const TEST_MODELS = Any[
         Chain(Conv((3, 3), 2 => 6, tanh), GroupNorm(6, 3)),
         randn(sr(32), P, 6, 6, 2, 2),
     ),
-    # LayerNorm calls varm via LuxLib.Impl.mean_var → var → varm. Enabled by the
-    # Statistics.varm GPU rrule!! in MooncakeCUDAExt.
+    # LayerNorm needs MooncakeCUDAExt's Statistics.varm GPU rrule!! (via LuxLib mean_var).
     (
         false,
         _gpu_enabled,
         Chain(Conv((3, 3), 2 => 3, gelu), LayerNorm((1, 1, 3))),
         randn(sr(33), P, 4, 4, 2, 2),
     ),
-    # InstanceNorm calls varm via the same path as GroupNorm and LayerNorm. Enabled by
-    # the Statistics.varm GPU rrule!! in MooncakeCUDAExt.
+    # InstanceNorm needs the Statistics.varm GPU rrule!! too, via the same LuxLib path.
     (false, _gpu_enabled, InstanceNorm(6), randn(sr(34), P, 6, 6, 2, 2)),
     (
         false,
@@ -227,8 +221,6 @@ const TEST_MODELS = Any[
     ),
     # From Flux TEST_MODELS: Scale with non-default activation (abs2)
     (false, _gpu_enabled, Scale(4, abs2), randn(sr(37), P, 4, 3)),
-    # LayerNorm calls varm via LuxLib.Impl.mean_var → var → varm. Enabled by the
-    # Statistics.varm GPU rrule!! in MooncakeCUDAExt.
     (false, _gpu_enabled, LayerNorm(2), randn(sr(38), P, 2, 10)),
     # From Flux TEST_MODELS: standalone BatchNorm — same batchnorm_cudnn! issue.
     (true, _gpu_disabled, BatchNorm(2), randn(sr(39), P, 2, 10)),

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -587,9 +587,7 @@ end
             oc = Base.Experimental.@opaque x -> x + 1
             @test Mooncake._copy_output(oc) === oc
 
-            # End-to-end: friendly forward-over-reverse over an array function builds
-            # a gradient closure that captures the compiled reverse rule. Copying it
-            # must not StackOverflow at prepare time.
+            # The gradient closure captures the compiled rule; copying it StackOverflowed.
             f = x -> sum(abs2, x)
             @test Mooncake.prepare_hvp_cache(
                 f, [1.0, 2.0, 3.0]; config=Mooncake.Config(; friendly_tangents=true)

--- a/test/interpreter/contexts.jl
+++ b/test/interpreter/contexts.jl
@@ -35,10 +35,8 @@ end
         @test !Mooncake.is_primitive(MinimalCtx, mode, Tuple{Tf,Real}, world)
     end
 
-    # `is_primitive` must not specialise per signature: it is called once per call-node
-    # signature during the AD transform, so specialising would make compile time scale with
-    # the number of distinct signatures (issue #1222). Distinct signatures must add no new
-    # specialisation.
+    # `is_primitive` is called once per call-node signature during the AD transform, so
+    # specialising on the signature would make compile time scale with their count (#1222).
     @testset "no per-signature specialisation" begin
         nspecialisations(f) =
             sum(methods(f); init=0) do m

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -11,10 +11,8 @@ function foo(x)
     return y
 end
 
-# Helpers for the world-advance rule-staleness regression test (issue #1218;
-# see `_build_rule!` in forward_mode.jl for the scope caveat). Defining `stale_fwd_inner(::Float64)`
-# later tightens `stale_fwd_callee`'s return type Float32->Float64 via a mid-pass world advance.
-# `stale_fwd_lazy` reaches the callee statically (LazyFRule), `stale_fwd_dyn` dynamically (DynamicFRule).
+# Helpers for the world-advance staleness test below (issue #1218; scope caveat at
+# `_build_rule!`). `stale_fwd_lazy` reaches the callee via LazyFRule, `stale_fwd_dyn` via DynamicFRule.
 stale_fwd_inner(x) = Float32(x) * 2.0f0
 @noinline stale_fwd_callee(x) = stale_fwd_inner(x)
 stale_fwd_lazy(x) = stale_fwd_callee(x)
@@ -62,9 +60,8 @@ stale_fwd_dyn(x) = (STALE_FWD_FNS[1])(x)
         )
     end
 
-    # Without the fix the lazy path throws a `convert` MethodError in _build_rule! after the
-    # world advance; both lazy and dynamic must return the build-world result (Float32), not
-    # the post-advance world's (Float64).
+    # Without the fix the lazy path throws a `convert` MethodError in _build_rule!; both
+    # paths must return the build-world result (Float32), not the post-advance (Float64).
     @testset "stale rule build-world after world advance (issue #1218)" begin
         lazy = Mooncake.build_frule(stale_fwd_lazy, 1.5)
         dyn = Mooncake.build_frule(stale_fwd_dyn, 1.5)

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -24,9 +24,8 @@ end
 # (PR #1099).
 rule_type_nonreturning(e::Exception) = throw(e)
 
-# Helpers for the world-advance rule-staleness regression test (reverse mode); see the
-# forward-mode analogue for the scope note. `stale_rvs_lazy` reaches the callee statically
-# (LazyDerivedRule), `stale_rvs_dyn` dynamically (DynamicDerivedRule).
+# Helpers for the world-advance staleness test below (scope note in the forward-mode
+# analogue). `stale_rvs_lazy` uses LazyDerivedRule, `stale_rvs_dyn` DynamicDerivedRule.
 stale_rvs_inner(x) = Float32(x) * 2.0f0
 @noinline stale_rvs_callee(x) = stale_rvs_inner(x)
 stale_rvs_lazy(x) = stale_rvs_callee(x)
@@ -518,9 +517,8 @@ stale_rvs_dyn(x) = (STALE_RVS_FNS[1])(x)
         @test rule_debug_args == rule_debug_sig
     end
 
-    # Without the fix the lazy path throws a `convert` MethodError in _build_rule! after the
-    # world advance; both lazy and dynamic must return the build-world result (Float32), not
-    # the post-advance world's (Float64).
+    # Without the fix the lazy path throws a `convert` MethodError in _build_rule!; both
+    # paths must return the build-world result (Float32), not the post-advance (Float64).
     @testset "stale rule build-world after world advance (issue #1218)" begin
         lazy = Mooncake.build_rrule(stale_rvs_lazy, 1.5)
         dyn = Mooncake.build_rrule(stale_rvs_dyn, 1.5)
@@ -537,8 +535,7 @@ stale_rvs_dyn(x) = (STALE_RVS_FNS[1])(x)
 end
 
 # --- Working-IR layer (CFGBlock etc.) ---
-# The working IR lives in src/interpreter/reverse_mode.jl (shared primitives in
-# ir_utils.jl), so its tests live here too (merged from the former bbcode.jl).
+# Working IR lives in src/interpreter/reverse_mode.jl; shared primitives in ir_utils.jl.
 module CFGBlocksTestCases
 test_phi_node(x::Ref{Union{Float32,Float64}}) = sin(x[])
 end
@@ -571,13 +568,11 @@ end
 
         @test Mooncake.terminator(bb) === nothing
 
-        # CFGBlock is immutable: its fields cannot be reassigned.
         @test_throws ErrorException (bb.id = ID())
 
         # The constructor enforces inst_ids and insts having equal length.
         @test_throws AssertionError CFGBlock(ID(), ID[ID()], CC.NewInstruction[])
 
-        # terminator returns the final statement when it is a Terminator.
         bb2 = CFGBlock(ID(), Mooncake.IDInstPair[(ID(), new_inst(ReturnNode(5)))])
         @test Mooncake.terminator(bb2) === bb2.insts[end].stmt
     end
@@ -605,7 +600,6 @@ end
         @test out[end] == ret
         @test out[end - 1] == extra[1]
 
-        # Empty `extra` returns the input untouched.
         @test Mooncake.insert_before_terminator(insts, Mooncake.IDInstPair[]) === insts
 
         # Block led by a phi node: `extra` splices before the terminator, phi left in place.
@@ -640,7 +634,6 @@ end
     @testset "lower_cfg_blocks_to_ir argtypes coercion" begin
         ir = Base.code_ircode(sin, Tuple{Float64})[1][1]
         blocks = _ircode_to_cfg_blocks(ir)
-        # A non-`Vector{Any}` argtypes override must be coerced to `Vector{Any}`.
         custom = DataType[typeof(sin), Float64]
         out = lower_cfg_blocks_to_ir(blocks, ir; argtypes=custom)
         @test out.argtypes isa Vector{Any}
@@ -648,9 +641,8 @@ end
     end
     @static if VERSION > v"1.12-"
         @testset "codelocs consistent after instruction insertion" begin
-            # In 1.12+, codelocs (and stmts.line) pack 3 Int32 per instruction, so an
-            # n-instruction IRCode has 3n entries that must stay aligned across the round-trip
-            # even when instructions are inserted (regression test for Mooncake.jl#1216).
+            # In 1.12+ codelocs and stmts.line pack 3 Int32 per instruction, so an n-stmt
+            # IRCode has 3n entries which must stay aligned (Mooncake.jl#1216).
             ir = Base.code_ircode(sin, Tuple{Float64})[1][1]
             n_orig = length(ir.stmts)
             orig_ir_codelocs = copy(ir.debuginfo.codelocs)
@@ -869,8 +861,7 @@ end
         blocks = _ircode_to_cfg_blocks(ir)
         new_blocks = Mooncake._remove_unreachable_cfg_blocks!(blocks)
 
-        # The returned vector is fresh and the input vector is not resized; surviving blocks
-        # are the same objects shared with the input (the phi edges are mutated in place).
+        # Surviving blocks are shared with the input; their phi edges are mutated in place.
         @test new_blocks !== blocks
         @test length(blocks) == 3
         @test blocks[3] === new_blocks[2]
@@ -912,8 +903,6 @@ end
         # A Switch block has all dests plus the fallthrough as successors.
         @test Mooncake._compute_cfg_successors(blks)[blk_id] == ID[d1, d2, fallthrough]
 
-        # Lowering replaces the Switch with a base block (Switch stripped), one IDGotoIfNot
-        # block per (cond, dest), and a final IDGotoNode fallthrough block.
         lowered = Mooncake._cfg_lower_switch_statements(blks)
         @test length(lowered) == length(blks) + 3
         @test lowered[1].id == blk_id
@@ -960,8 +949,7 @@ end
         @test out[2].id == c                    # reachable (distance 1) before unreachables
         @test Set([out[3].id, out[4].id]) == Set([a, b])  # both unreachable blocks land last
 
-        # Reachable chain with distinct distances, presented out of order (y before x):
-        # ordering must follow increasing distance-from-entry, not input position.
+        # Ordering must follow increasing distance-from-entry, not input position.
         e2, x, y = ID(), ID(), ID()
         chain = CFGBlock[
             CFGBlock(e2, Mooncake.IDInstPair[(ID(), new_inst(IDGotoNode(x)))]),  # distance 0

--- a/test/nfwd/nfwd.jl
+++ b/test/nfwd/nfwd.jl
@@ -213,8 +213,7 @@ using Mooncake.Nfwd
                 ],
             ),
             (
-                # Saturated: `1 - tanh(x)^2` returns exactly 0 out here, since `tanh(x)` has
-                # rounded to `1.0`, so the reference has to come from wider precision.
+                # `tanh(20)` rounds to `1.0`, so `1 - tanh(x)^2` is exactly 0 in Float64.
                 20.0,
                 [(tanh, x -> Float64(1 - tanh(big(x))^2))],
             ),

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -220,9 +220,7 @@ end
     end
 
     @testset "cache reuse across multiple HVP calls" begin
-        # The `DerivedFoRRule`'s cached `Dual` is reused across calls without copying;
-        # verify the cache produces consistent results when called repeatedly with
-        # different directions.
+        # The `DerivedFoRRule`'s cached `Dual` is reused across calls without copying.
         f(x) = sum(x .* x)  # H = 2I
         x = [1.0, 2.0, 3.0]
         cache = prepare_hvp_cache(f, x)
@@ -252,9 +250,8 @@ end
     end
 
     @testset "primitive f (DerivedFoRRule{Nothing} path)" begin
-        # When `f` is itself a reverse-mode primitive, `compile_for_rule` returns
-        # `DerivedFoRRule{Nothing}` and `grad_f` routes through `value_and_gradient!!`
-        # rather than an inner derived rrule.
+        # Primitive `f` ⇒ `compile_for_rule` returns `DerivedFoRRule{Nothing}`, so `grad_f`
+        # routes through `value_and_gradient!!`, not an inner derived rrule.
         @testset "single argument" begin
             f = sum  # linear ⇒ zero Hessian
             x = [1.0, 2.0, 3.0]
@@ -279,7 +276,6 @@ end
         end
     end
 
-    # Regression for https://github.com/chalk-lab/Mooncake.jl/issues/1193.
     @testset "Ref-capture under NoTangent wrapper (issue #1193)" begin
         f = _RefCaptureWrap(
             let r = Ref(3.0);

--- a/test/tangents/codual.jl
+++ b/test/tangents/codual.jl
@@ -73,11 +73,9 @@
     end
 
     @testset "(f)codual_type/dual_type with phantom TypeVar (#1191)" begin
-        # `UnionAll(A, AbstractArray{T, A})` normalises to a DataType whose body
-        # still references the free `T`; the generic `(f)codual_type(::Type{P})`
-        # and `dual_type(::Type{P})` binders can't bind `P` for such shapes and
-        # throw `UndefVarError`. The Tuple variant blocks a future fix that only
-        # special-cases AbstractArray.
+        # Both shapes normalise to a DataType whose body still references the free `T`, so
+        # the generic `::Type{P}` binders can't bind `P` and throw `UndefVarError`. The
+        # Tuple variant blocks a future fix that only special-cases AbstractArray.
         phantom = UnionAll(TypeVar(:A), AbstractArray{TypeVar(:T),TypeVar(:A)})
         phantom_tuple = UnionAll(TypeVar(:A), Tuple{TypeVar(:T),TypeVar(:A)})
         @test codual_type(phantom) === CoDual

--- a/test/tangents/tangents.jl
+++ b/test/tangents/tangents.jl
@@ -391,8 +391,7 @@ using DispatchDoctor: allow_unstable
             Mooncake.FriendlyTangentCache{Mooncake.AsRaw}
     end
 
-    # Adjoint and Transpose relabel their parent's entries without loss, so the friendly
-    # gradient keeps the wrapper rather than falling back to the raw Tangent (#1250).
+    # The wrapper relabels its parent's entries without loss, so no raw-Tangent fallback.
     @testset "$W friendly gradient keeps the wrapper (#1250)" for W in (Adjoint, Transpose)
         x = W([1.0 2.0; 3.0 4.0; 5.0 6.0])
         tx_parent = [0.5 1.5; 2.5 3.5; 4.5 5.5]

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -61,7 +61,6 @@
             (b=make_indirect_circular_reference_array(); b[1][1]=2.0; b),
         )
 
-        # Test that has_equal_data works on Method and MethodInstance objects
         m = only(methods(sin, (Float64,)))
         @test has_equal_data(m, m)
         mi = first(m.specializations)


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1267 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1267/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 180.0 ns │     1.78 │         1.5 │   0.667 │        3.23 │   6.23 │
│                  _sum_1000 │ 972.0 ns │     6.68 │        1.01 │  3590.0 │        36.6 │   1.06 │
│               sum_sin_1000 │  7.09 μs │     3.54 │        1.33 │    1.51 │        11.2 │   1.81 │
│              _sum_sin_1000 │  5.68 μs │     3.68 │        1.98 │   286.0 │        14.5 │   2.34 │
│                   kron_sum │ 215.0 μs │     12.7 │        3.19 │    23.9 │       334.0 │   20.6 │
│              kron_view_sum │ 295.0 μs │     10.9 │        5.11 │    25.3 │       326.0 │   12.4 │
│      naive_map_sin_cos_exp │  2.32 μs │     2.92 │        1.53 │ missing │        7.58 │   2.13 │
│            map_sin_cos_exp │  2.25 μs │     3.58 │        1.59 │     1.6 │        6.91 │   2.75 │
│      broadcast_sin_cos_exp │  2.37 μs │     3.14 │        1.54 │     4.5 │        1.43 │    2.1 │
│                 simple_mlp │ 369.0 μs │     4.73 │        2.64 │     2.3 │        9.01 │   2.95 │
│                     gp_lml │ 172.0 μs │     11.6 │        2.59 │    5.35 │     missing │    5.5 │
│ turing_broadcast_benchmark │  1.66 ms │     6.88 │        3.56 │ missing │        38.8 │   2.37 │
│         large_single_block │ 416.0 ns │     5.48 │        1.93 │  4490.0 │        32.2 │   2.07 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->