### PR TITLE
Some fixes for rules and typos. 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.42"
+version = "0.5.43"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1441,10 +1441,13 @@ end
 _unwrap_cat_dim(d::Integer) = d
 _unwrap_cat_dim(::Val{N}) where {N} = N
 _unwrap_cat_dim(d::Tuple{Vararg{Integer}}) = d
+# `Base.dims2cat` takes any iterable, so `cat(A, B; dims=1:2)` and `dims=[1, 2]` are valid
+# calls the primal and the frule both accept; normalise to the Tuple the pullback needs.
+_unwrap_cat_dim(d::Union{AbstractRange{<:Integer},AbstractVector{<:Integer}}) = Tuple(d)
 function _unwrap_cat_dim(d)
     return throw(
         ArgumentError(
-            "Mooncake: cat requires dims to be an Integer, Val{N}, or a Tuple of " *
+            "Mooncake: cat requires dims to be an Integer, Val{N}, or an iterable of " *
             "Integers; got dims=$(d).",
         ),
     )

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1424,12 +1424,16 @@ end
     nd = Val(ndims(dy_out))
     for i in eachindex(fdatas)
         fi = fdatas[i]
-        ranges = ntuple(nd) do d
-            k = findfirst(==(d), dims)
-            k === nothing ? Colon() : (offsets[k] + 1):(offsets[k] + size(fi, d))
+        # `let`, so the closure below captures a binding that is never reassigned:
+        # capturing `offsets` itself boxes it and costs the loop its zero-allocation.
+        offsets = let offs = offsets
+            ranges = ntuple(nd) do d
+                k = findfirst(==(d), dims)
+                k === nothing ? Colon() : (offs[k] + 1):(offs[k] + size(fi, d))
+            end
+            fi .+= view(dy_out, ranges...)
+            ntuple(k -> offs[k] + size(fi, dims[k]), Val(K))
         end
-        fi .+= view(dy_out, ranges...)
-        offsets = ntuple(k -> offsets[k] + size(fi, dims[k]), Val(K))
     end
     return nothing
 end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1443,12 +1443,12 @@ _unwrap_cat_dim(::Val{N}) where {N} = N
 _unwrap_cat_dim(d::Tuple{Vararg{Integer}}) = d
 # `Base.dims2cat` takes any iterable, so `cat(A, B; dims=1:2)` and `dims=[1, 2]` are valid
 # calls the primal and the frule both accept; normalise to the Tuple the pullback needs.
-_unwrap_cat_dim(d::Union{AbstractRange{<:Integer},AbstractVector{<:Integer}}) = Tuple(d)
+_unwrap_cat_dim(d::AbstractVector{<:Integer}) = Tuple(d)
 function _unwrap_cat_dim(d)
     return throw(
         ArgumentError(
-            "Mooncake: cat requires dims to be an Integer, Val{N}, or an iterable of " *
-            "Integers; got dims=$(d).",
+            "Mooncake: cat requires dims to be an Integer, Val{N}, or a Tuple or vector " *
+            "of Integers; got dims=$(d).",
         ),
     )
 end

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -450,7 +450,15 @@ function Mooncake.rrule!!(
     res = zero_fcodual(NNlib.gather(primal(src), pidx))
     function gather_pb!!(::NoRData)
         _, dsrc = arrayify(src)
-        NNlib.scatter!(+, dsrc, tangent(res), pidx)
+        if dsrc isa Union{Array,AbstractGPUArray}
+            NNlib.scatter!(+, dsrc, tangent(res), pidx)
+        else
+            # `arrayify` keeps the wrapper and `scatter!` takes only a dense destination: a
+            # wrapped one compiles to invalid IR on the GPU and finds no method on the CPU.
+            # `similar` on an `Adjoint` re-wraps, so the buffer comes from the parent.
+            buf = fill!(similar(parent(dsrc), size(dsrc)), 0)
+            dsrc .+= NNlib.scatter!(+, buf, tangent(res), pidx)
+        end
         return NoRData(), NoRData(), NoRData()
     end
     return res, gather_pb!!

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -75,6 +75,14 @@ const SupportedArray{P,N} = Union{
     Adjoint{P,<:Union{Array{P,N},AbstractGPUArray{P,N}}},
     Transpose{P,<:Union{Array{P,N},AbstractGPUArray{P,N}}},
 }
+# The GPU-backed members of `SupportedArray`. `Adjoint`/`Transpose` of a GPU array are
+# `AnyGPUArray`, which is what NNlib dispatches its kernels on, so a bound of bare
+# `AbstractGPUArray` does not cover everything that reaches a kernel.
+const GPUBackedArray{P,N} = Union{
+    AbstractGPUArray{P,N},
+    Adjoint{P,<:AbstractGPUArray{P,N}},
+    Transpose{P,<:AbstractGPUArray{P,N}},
+}
 # `@from_rrule` does not honour the wrapper members: it adds ChainRules' cotangent into a view's
 # fdata, which is the parent's, so those signatures throw — hence `dropout`'s hand-written rule.
 
@@ -416,20 +424,19 @@ end
     MinimalCtx,
     ForwardMode,
     Tuple{
-        typeof(NNlib.gather),AbstractGPUArray{P,N},SupportedArray{<:Union{Integer,Tuple},M}
+        typeof(NNlib.gather),GPUBackedArray{P,N},SupportedArray{<:Union{Integer,Tuple},M}
     } where {P<:IEEEFloat,N,M},
 )
 function Mooncake.frule!!(
     ::Dual{typeof(NNlib.gather)},
-    ::Dual{<:AbstractGPUArray{P,N}},
+    ::Dual{<:GPUBackedArray{P,N}},
     ::Dual{<:SupportedArray{<:Union{Integer,Tuple},M}},
 ) where {P<:IEEEFloat,N,M}
     throw(
         ArgumentError(
             "forward mode over `NNlib.gather` is not supported for GPU arrays: " *
             "differentiating the traced kernel launch crashes the process. Reverse mode " *
-            "has a rule for this signature and does work; on the CPU, so does forward " *
-            "mode.",
+            "works for an unwrapped GPU array; on the CPU, so does forward mode.",
         ),
     )
 end

--- a/ext/MooncakeNNlibExt.jl
+++ b/ext/MooncakeNNlibExt.jl
@@ -436,7 +436,8 @@ function Mooncake.frule!!(
         ArgumentError(
             "forward mode over `NNlib.gather` is not supported for GPU arrays: " *
             "differentiating the traced kernel launch crashes the process. Reverse mode " *
-            "works for an unwrapped GPU array; on the CPU, so does forward mode.",
+            "has a rule for this signature and does work; on the CPU, so does forward " *
+            "mode.",
         ),
     )
 end

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -454,7 +454,13 @@ function modify_fwd_ad_stmts!(
             end
         else
             dm = info.debug_mode
-            push!(captures, isexpr(stmt, :invoke) ? LazyFRule(mi, dm) : DynamicFRule(dm))
+            # Predict at the world this transform runs in: inside a pinned rebuild
+            # (`_build_rule!`) the current world is later, which would reintroduce the
+            # `Trule` mismatch of #1218 one level down.
+            w = interp.world
+            push!(
+                captures, isexpr(stmt, :invoke) ? LazyFRule(mi, dm, w) : DynamicFRule(dm, w)
+            )
             get_rule = Expr(:call, get_capture, Argument(1), length(captures))
             rule_ssa = CC.insert_node!(dual_ir, ssa, new_inst(get_rule), ATTACH_BEFORE)
             replace_call!(dual_ir, ssa, Expr(:call, rule_ssa, dual_args...))
@@ -508,11 +514,13 @@ mutable struct LazyFRule{primal_sig,Trule}
     mi::Core.MethodInstance
     world::UInt
     rule::Trule
-    function LazyFRule(mi::Core.MethodInstance, debug_mode::Bool)
-        interp = get_interpreter(ForwardMode)
-        return new{mi.specTypes,frule_type(interp, mi;debug_mode)}(
-            debug_mode, mi, interp.world
-        )
+    function LazyFRule(
+        mi::Core.MethodInstance,
+        debug_mode::Bool,
+        world::UInt=get_interpreter(ForwardMode).world,
+    )
+        interp = get_interpreter(ForwardMode, world)
+        return new{mi.specTypes,frule_type(interp, mi;debug_mode)}(debug_mode, mi, world)
     end
     function LazyFRule{Tprimal_sig,Trule}(
         mi::Core.MethodInstance, debug_mode::Bool, world::UInt
@@ -591,8 +599,8 @@ struct DynamicFRule{V}
     world::UInt
 end
 
-function DynamicFRule(debug_mode::Bool)
-    return DynamicFRule(Dict{Any,Any}(), debug_mode, get_interpreter(ForwardMode).world)
+function DynamicFRule(debug_mode::Bool, world::UInt=get_interpreter(ForwardMode).world)
+    return DynamicFRule(Dict{Any,Any}(), debug_mode, world)
 end
 
 _copy(x::P) where {P<:DynamicFRule} = P(Dict{Any,Any}(), x.debug_mode, x.world)

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -514,11 +514,7 @@ mutable struct LazyFRule{primal_sig,Trule}
     mi::Core.MethodInstance
     world::UInt
     rule::Trule
-    function LazyFRule(
-        mi::Core.MethodInstance,
-        debug_mode::Bool,
-        world::UInt=get_interpreter(ForwardMode).world,
-    )
+    function LazyFRule(mi::Core.MethodInstance, debug_mode::Bool, world::UInt)
         interp = get_interpreter(ForwardMode, world)
         return new{mi.specTypes,frule_type(interp, mi;debug_mode)}(debug_mode, mi, world)
     end
@@ -599,7 +595,7 @@ struct DynamicFRule{V}
     world::UInt
 end
 
-function DynamicFRule(debug_mode::Bool, world::UInt=get_interpreter(ForwardMode).world)
+function DynamicFRule(debug_mode::Bool, world::UInt)
     return DynamicFRule(Dict{Any,Any}(), debug_mode, world)
 end
 

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -1517,9 +1517,10 @@ function make_ad_stmts!(stmt::Expr, line::ID, info::ADInfo)
             build_primitive_rrule(sig) # intrinsic / builtin / thing we provably have rule for
         elseif is_invoke
             mi = get_mi(stmt.args[1])
-            LazyDerivedRule(mi, info.debug_mode) # Static dispatch
+            # `interp.world` rather than the current world; see `modify_fwd_ad_stmts!`.
+            LazyDerivedRule(mi, info.debug_mode, interp.world) # Static dispatch
         else
-            DynamicDerivedRule(info.debug_mode)  # Dynamic dispatch
+            DynamicDerivedRule(info.debug_mode, interp.world)  # Dynamic dispatch
         end
 
         # Wrap the raw rule in a struct which ensures that any `ZeroRData`s are stripped
@@ -2744,10 +2745,10 @@ struct DynamicDerivedRule{V}
     world::UInt
 end
 
-function DynamicDerivedRule(debug_mode::Bool)
-    return DynamicDerivedRule(
-        Dict{Any,Any}(), debug_mode, get_interpreter(ReverseMode).world
-    )
+function DynamicDerivedRule(
+    debug_mode::Bool, world::UInt=get_interpreter(ReverseMode).world
+)
+    return DynamicDerivedRule(Dict{Any,Any}(), debug_mode, world)
 end
 
 _copy(x::P) where {P<:DynamicDerivedRule} = P(Dict{Any,Any}(), x.debug_mode, x.world)
@@ -2840,11 +2841,13 @@ mutable struct LazyDerivedRule{primal_sig,Trule}
     mi::Core.MethodInstance
     world::UInt
     rule::Trule
-    function LazyDerivedRule(mi::Core.MethodInstance, debug_mode::Bool)
-        interp = get_interpreter(ReverseMode)
-        return new{mi.specTypes,rule_type(interp, mi;debug_mode)}(
-            debug_mode, mi, interp.world
-        )
+    function LazyDerivedRule(
+        mi::Core.MethodInstance,
+        debug_mode::Bool,
+        world::UInt=get_interpreter(ReverseMode).world,
+    )
+        interp = get_interpreter(ReverseMode, world)
+        return new{mi.specTypes,rule_type(interp, mi;debug_mode)}(debug_mode, mi, world)
     end
     function LazyDerivedRule{Tprimal_sig,Trule}(
         mi::Core.MethodInstance, debug_mode::Bool, world::UInt

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -2730,7 +2730,7 @@ Helper function emitted by `make_switch_stmts`.
 __switch_case(id::Int32, predecessor_id::Int32) = !(id === predecessor_id)
 
 """
-    DynamicDerivedRule(interp::MooncakeInterpreter, debug_mode::Bool)
+    DynamicDerivedRule(debug_mode::Bool, world::UInt)
 
 For internal use only.
 
@@ -2745,9 +2745,7 @@ struct DynamicDerivedRule{V}
     world::UInt
 end
 
-function DynamicDerivedRule(
-    debug_mode::Bool, world::UInt=get_interpreter(ReverseMode).world
-)
+function DynamicDerivedRule(debug_mode::Bool, world::UInt)
     return DynamicDerivedRule(Dict{Any,Any}(), debug_mode, world)
 end
 
@@ -2775,7 +2773,7 @@ function (dynamic_rule::DynamicDerivedRule)(args::Vararg{Any,N}) where {N}
 end
 
 """
-    LazyDerivedRule(interp, mi::Core.MethodInstance, debug_mode::Bool)
+    LazyDerivedRule(mi::Core.MethodInstance, debug_mode::Bool, world::UInt)
 
 For internal use only.
 
@@ -2841,11 +2839,7 @@ mutable struct LazyDerivedRule{primal_sig,Trule}
     mi::Core.MethodInstance
     world::UInt
     rule::Trule
-    function LazyDerivedRule(
-        mi::Core.MethodInstance,
-        debug_mode::Bool,
-        world::UInt=get_interpreter(ReverseMode).world,
-    )
+    function LazyDerivedRule(mi::Core.MethodInstance, debug_mode::Bool, world::UInt)
         interp = get_interpreter(ReverseMode, world)
         return new{mi.specTypes,rule_type(interp, mi;debug_mode)}(debug_mode, mi, world)
     end

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -2150,7 +2150,7 @@ function generate_ir(
                 unhandled_feature(
                     "Mooncake.jl does not support differentiating code that assigns to " *
                     "non-const global variables. Pass the state explicitly, return the " *
-                    "updated value, or provide a custom rrule!!. See the Known Limitations" *
+                    "updated value, or provide a custom rrule!!. See the Known Limitations " *
                     "documentation for more context.",
                 )
             end

--- a/src/rules/builtins.jl
+++ b/src/rules/builtins.jl
@@ -393,13 +393,13 @@ end
 @intrinsic copysign_float
 function frule!!(::Dual{typeof(copysign_float)}, x, y)
     z = copysign_float(primal(x), primal(y))
-    dz = sign(primal(x)) * sign(primal(y)) * tangent(x)
+    dz = flipsign(sign(primal(x)), primal(y)) * tangent(x)
     return Dual(z, dz)
 end
 function rrule!!(::CoDual{typeof(copysign_float)}, x, y)
     _x = primal(x)
     _y = primal(y)
-    copysign_float_pullback!!(dz) = NoRData(), dz * sign(_x) * sign(_y), zero_rdata(_y)
+    copysign_float_pullback!!(dz) = NoRData(), dz * flipsign(sign(_x), _y), zero_rdata(_y)
     z = copysign_float(_x, _y)
     return CoDual(z, NoFData()), copysign_float_pullback!!
 end

--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -180,7 +180,8 @@ function rrule!!(::CoDual{typeof(setindex!)}, d::CoDual{IdDict{K,V}}, val, key) 
             increment!!(instantiate(dval), rdata(tangent(d)[k]))
         else
             # The slot holds `convert(V, val)`, a fresh object, so what accumulates there
-            # reaches `val`'s fdata only by an explicit copy-back.
+            # reaches `val`'s fdata only by an explicit copy-back. The result is discarded
+            # because every gradient carrier in fdata is mutable, so this lands in place.
             increment!!(tangent(val), convert(fdata_type(S), fdata(tangent(d)[k])))
             increment!!(instantiate(dval), convert(rdata_type(S), rdata(tangent(d)[k])))
         end

--- a/src/rules/iddict.jl
+++ b/src/rules/iddict.jl
@@ -179,6 +179,9 @@ function rrule!!(::CoDual{typeof(setindex!)}, d::CoDual{IdDict{K,V}}, val, key) 
         elseif S <: tangent_type(V)
             increment!!(instantiate(dval), rdata(tangent(d)[k]))
         else
+            # The slot holds `convert(V, val)`, a fresh object, so what accumulates there
+            # reaches `val`'s fdata only by an explicit copy-back.
+            increment!!(tangent(val), convert(fdata_type(S), fdata(tangent(d)[k])))
             increment!!(instantiate(dval), convert(rdata_type(S), rdata(tangent(d)[k])))
         end
 
@@ -285,6 +288,16 @@ function hand_written_rule_test_cases(rng_ctor, ::Val{:iddict})
         (false, :none, nothing, setindex!, IdDict{Symbol,Any}(:a => 1.0), 2.0, :b),
         (false, :none, nothing, setindex!, IdDict{Symbol,Any}(:a => [1.0]), [2.0, 3.0], :b),
         (false, :none, nothing, setindex!, IdDict{Symbol,Float64}(:a => 1.0), 2.0f0, :b),
+        # the same width change for an array, where the gradient rides fdata, not rdata
+        (
+            false,
+            :none,
+            nothing,
+            setindex!,
+            IdDict{Symbol,Vector{Float64}}(:a => [1.0, 2.0]),
+            Float32[3.0, 4.0],
+            :b,
+        ),
         (false, :none, nothing, get, IdDict(true => 5.0, false => 4.0), false, 2.0),
         (false, :none, nothing, get, IdDict(true => 5.0), false, 2.0),
         # `get` returning a default (absent key) whose rdata type differs from its tangent type.

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -236,7 +236,7 @@ function has_equal_data_internal(
     return x === y
 end
 function has_equal_data_internal(
-    x::GlobalRef, y::GlobalRef; equal_undefs=true, d::IdDict{Any,Bool}
+    x::GlobalRef, y::GlobalRef, equal_undefs::Bool, d::IdDict{Any,Bool}
 )
     return x.mod == y.mod && x.name == y.name
 end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -228,6 +228,13 @@ function has_equal_data_internal(
 )
     return x == y
 end
+# `Symbol` is neither primitive nor has fields, so the generic method below descends into
+# nothing and reports every pair as equal.
+function has_equal_data_internal(
+    x::Symbol, y::Symbol, equal_undefs::Bool, d::IdDict{Any,Bool}
+)
+    return x === y
+end
 function has_equal_data_internal(
     x::GlobalRef, y::GlobalRef; equal_undefs=true, d::IdDict{Any,Bool}
 )

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -689,6 +689,15 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _rand(rng, Float64, 3, 2),
                 _rand(rng, Float64, 5, 4),
             ),
+            # UnitRange dims: a spelling Base accepts, as for `varm` above.
+            (
+                false,
+                :none,
+                false,
+                _cat_cu_sum(1:2),
+                _rand(rng, Float32, 4, 3),
+                _rand(rng, Float32, 2, 5),
+            ),
             # Tuple dims, N-arg: exercises the running-offsets tuple in _cu_concat_pb!.
             (
                 false,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -1083,13 +1083,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         @testset "nested GPU broadcast gradients keep tree alignment" begin
             x = CuArray(randn(rng, 4))
             y = CuArray(randn(rng, 4))
-            cache = prepare_gradient_cache(
-                _bcast_nested_sin_add,
-                x,
-                y;
-                config=Mooncake.Config(; friendly_tangents=true),
+            rule = Mooncake.build_rrule(_bcast_nested_sin_add, x, y)
+            val, grads = value_and_gradient!!(
+                rule, _bcast_nested_sin_add, x, y; friendly_tangents=true
             )
-            val, grads = value_and_gradient!!(cache, _bcast_nested_sin_add, x, y)
             @test val ≈ sum(Array(sin.(x .+ y)))
             expected = Array(cos.(x .+ y))
             @test Array(grads[2]) ≈ expected
@@ -1098,12 +1095,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
 
         @testset "differentiable nested float casts still propagate gradients" begin
             x = CuArray(randn(rng, Float32, 4))
-            cache = prepare_gradient_cache(
-                _bcast_nested_float_cast_sin,
-                x;
-                config=Mooncake.Config(; friendly_tangents=true),
+            rule = Mooncake.build_rrule(_bcast_nested_float_cast_sin, x)
+            val, grads = value_and_gradient!!(
+                rule, _bcast_nested_float_cast_sin, x; friendly_tangents=true
             )
-            val, grads = value_and_gradient!!(cache, _bcast_nested_float_cast_sin, x)
             expected_val = sum(sin.(Float64.(Array(x))))
             expected_grad = Float32.(cos.(Float64.(Array(x))))
             @test val ≈ expected_val
@@ -1115,14 +1110,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             c = 2.5
             b = CuArray(Float64[-2.0, 1.0, -3.0, 4.0])
             mask = Float64.(Array(b) .> 0)
-            cache = prepare_gradient_cache(
-                _bcast_zero_dof_nested,
-                x,
-                c,
-                b;
-                config=Mooncake.Config(; friendly_tangents=true),
+            rule = Mooncake.build_rrule(_bcast_zero_dof_nested, x, c, b)
+            val, grads = value_and_gradient!!(
+                rule, _bcast_zero_dof_nested, x, c, b; friendly_tangents=true
             )
-            val, grads = value_and_gradient!!(cache, _bcast_zero_dof_nested, x, c, b)
             @test val ≈ sum(Array(x) .+ c .* mask)
             @test Array(grads[2]) ≈ ones(length(mask))
             @test grads[3] ≈ sum(mask)
@@ -1135,8 +1126,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             # from flat_pargs, crashing the reverse pass with UndefRefError.
             x = CuArray(randn(rng, 4))
             s = 0.75
-            cache = prepare_gradient_cache(_bcast_all_scalar_leaf, x, s)
-            val, grads = value_and_gradient!!(cache, _bcast_all_scalar_leaf, x, s)
+            rule = Mooncake.build_rrule(_bcast_all_scalar_leaf, x, s)
+            val, grads = value_and_gradient!!(rule, _bcast_all_scalar_leaf, x, s)
             @test val ≈ sum(Array(x) .* (s + 1.0))
             @test Array(grads[2]) ≈ fill(s + 1.0, 4)
             @test grads[3] ≈ sum(Array(x))
@@ -1148,16 +1139,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             c = -1.25
             b = CuArray(Float64[-2.0, 1.0, -3.0, 4.0])
             mask = Float64.(Array(b) .> 0)
-            cache = prepare_gradient_cache(
-                _inplace_zero_dof_nested!,
-                dest,
-                x,
-                c,
-                b;
-                config=Mooncake.Config(; friendly_tangents=true),
-            )
+            rule = Mooncake.build_rrule(_inplace_zero_dof_nested!, dest, x, c, b)
             val, grads = value_and_gradient!!(
-                cache, _inplace_zero_dof_nested!, dest, x, c, b
+                rule, _inplace_zero_dof_nested!, dest, x, c, b; friendly_tangents=true
             )
             @test val ≈ sum(Array(x) .+ c .* mask)
             @test Array(grads[3]) ≈ ones(length(mask))
@@ -1178,7 +1162,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 x = _rand(rng, Float32, 4)
                 y = CuArray(randn(rng, ComplexF32, 4))
                 @test_throws r"GPU broadcast over arrays with mixed element types" value_and_gradient!!(
-                    prepare_gradient_cache(f, x, y), f, x, y
+                    Mooncake.build_rrule(f, x, y), f, x, y
                 )
             end
 
@@ -1187,14 +1171,14 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 f = x -> x[1]
                 x = _rand(rng, Float32, 4)
                 @test_throws r"scalar indexing of CuArray is not differentiable" value_and_gradient!!(
-                    prepare_gradient_cache(f, x), f, x
+                    Mooncake.build_rrule(f, x), f, x
                 )
             end
             @testset "scalar setindex! CuArray not differentiable" begin
                 f = x -> (x[1]=0.0f0; sum(x))
                 x = _rand(rng, Float32, 4)
                 @test_throws r"scalar indexing of CuArray is not differentiable" value_and_gradient!!(
-                    prepare_gradient_cache(f, x), f, x
+                    Mooncake.build_rrule(f, x), f, x
                 )
             end
 
@@ -1203,7 +1187,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 f = x -> sum(accumulate(*, x))
                 x = _rand(rng, Float32, 4)
                 @test_throws r"accumulate on CuArray only supports op=\+" value_and_gradient!!(
-                    prepare_gradient_cache(f, x), f, x
+                    Mooncake.build_rrule(f, x), f, x
                 )
             end
 
@@ -1215,7 +1199,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 x = _host_rand(rng, ComplexF64, 3, 3)
                 cy = _rand(rng, ComplexF64, 3, 3)
                 @test_throws r"GPU gemv with mismatched element types" value_and_gradient!!(
-                    prepare_gradient_cache(f, x, cy), f, x, cy
+                    Mooncake.build_rrule(f, x, cy), f, x, cy
                 )
             end
 
@@ -1238,19 +1222,19 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 wc = Base.get_world_counter()
 
                 @test_throws r"mix of GPU" value_and_gradient!!(
-                    prepare_gradient_cache(_vcat_cu_sum, gpu1, cpu_vec),
+                    Mooncake.build_rrule(_vcat_cu_sum, gpu1, cpu_vec),
                     _vcat_cu_sum,
                     gpu1,
                     cpu_vec,
                 )
                 @test_throws r"mix of GPU" value_and_gradient!!(
-                    prepare_gradient_cache(_hcat_cu_sum, gpu2, cpu_mat),
+                    Mooncake.build_rrule(_hcat_cu_sum, gpu2, cpu_mat),
                     _hcat_cu_sum,
                     gpu2,
                     cpu_mat,
                 )
                 @test_throws r"mix of GPU" value_and_gradient!!(
-                    prepare_gradient_cache(_cat_cu_sum(1), gpu1, s), _cat_cu_sum(1), gpu1, s
+                    Mooncake.build_rrule(_cat_cu_sum(1), gpu1, s), _cat_cu_sum(1), gpu1, s
                 )
 
                 @test Mooncake.is_primitive(
@@ -1362,9 +1346,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _splat_cat_sum(xs) = sum(cat(xs...; dims=1))
                 xs = [_host_rand(rng, 3) for _ in 1:3]
                 for f in (_splat_vcat_sum, _splat_hcat_sum, _splat_cat_sum)
-                    val, (_, dxs) = value_and_gradient!!(
-                        prepare_gradient_cache(f, xs), f, xs
-                    )
+                    val, (_, dxs) = value_and_gradient!!(Mooncake.build_rrule(f, xs), f, xs)
                     @test val ≈ f(xs)
                     @test length(dxs) == length(xs)
                 end
@@ -1375,7 +1357,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 x16 = _rand(rng, Float16, 4)
                 y16 = _rand(rng, Float16, 4)
                 val, (_, dx, dy) = value_and_gradient!!(
-                    prepare_gradient_cache(_vcat_cu_sum, x16, y16), _vcat_cu_sum, x16, y16
+                    Mooncake.build_rrule(_vcat_cu_sum, x16, y16), _vcat_cu_sum, x16, y16
                 )
                 @test val ≈ sum(vcat(x16, y16))
                 @test all(==(one(Float16)), Array(dx))
@@ -1390,10 +1372,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 y16_mat = _rand(rng, Float16, 2, 3)
                 f_view(x, y) = sum(vcat(view(x, 1:2, :), y))
                 @test_throws r"mix of GPU" value_and_gradient!!(
-                    prepare_gradient_cache(f_view, x16_mat, y16_mat),
-                    f_view,
-                    x16_mat,
-                    y16_mat,
+                    Mooncake.build_rrule(f_view, x16_mat, y16_mat), f_view, x16_mat, y16_mat
                 )
             end
 

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -756,4 +756,17 @@ if cuda
             )
         end
     end
+
+    # `arrayify` hands the pullback a wrapped fdata, and NNlib's CUDA `scatter!` kernel
+    # cannot take one: it compiled to invalid LLVM IR. Reverse mode has to keep working for
+    # a wrapper built inside the function, which is how `SupportedArray`'s members arise.
+    @testset "reverse mode over gather on a wrapped GPU array: $wrap" for wrap in (
+        adjoint, transpose
+    )
+        g(x) = sum(NNlib.gather(wrap(x), [1, 3]))
+        xv = cu(randn(StableRNG(123), Float32, 4))
+        cache = Mooncake.prepare_gradient_cache(g, xv)
+        @test Array(Mooncake.value_and_gradient!!(cache, g, xv)[2][2]) ==
+            Float32[1, 0, 1, 0]
+    end
 end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -746,5 +746,14 @@ if cuda
         cache = Mooncake.prepare_gradient_cache(gather_sum, xg)
         @test Array(Mooncake.value_and_gradient!!(cache, gather_sum, xg)[2][2]) ==
             Float32[1, 0, 1, 0]
+        # `Adjoint`/`Transpose` of a GPU array are `AnyGPUArray`, so NNlib sends them to the
+        # same kernel: they have to hit the guard, not slip past a bare `AbstractGPUArray`.
+        @testset "$wrap" for wrap in (adjoint, transpose)
+            w = wrap(copy(xg))
+            r = Mooncake.build_frule(gather_sum, w)
+            @test_throws ArgumentError r(
+                Mooncake.zero_dual(gather_sum), Mooncake.zero_dual(w)
+            )
+        end
     end
 end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -468,6 +468,11 @@ cuda = CUDA.functional() && pkgversion(CUDA) > v"5.9.6"
 
         # gather
         (false, :none, true, NNlib.gather, _rand(rng, 2, 4), [1, 3, 1]),
+        # Wrapped `src`: the pullback scatters into `arrayify`'s fdata, which keeps the
+        # wrapper, and NNlib's `scatter!` takes only a dense destination. Square, so the
+        # wrapped trailing size still admits the indices.
+        (false, :none, true, NNlib.gather, _rand(rng, 4, 4)', [1, 3, 1]),
+        (false, :none, true, NNlib.gather, transpose(_rand(rng, 4, 4)), [1, 3, 1]),
 
         # conv
         (false, :none, true, Core.kwcall, (;), conv, x, w, dense_cdims),
@@ -601,14 +606,16 @@ end
 
 @testset "logsumexp Inf/NaN stability" begin
     function test_logsumexp_inf(x, dims)
-        seed = ones(eltype(x), size(logsumexp(x; dims=dims)))
-        cache = Mooncake.prepare_pullback_cache(
-            Core.kwcall, NamedTuple{(:dims,)}((dims=dims,)), logsumexp, x
+        cdx = Mooncake.zero_fcodual(copy(x))
+        y, pb = Mooncake.rrule!!(
+            Mooncake.zero_fcodual(Core.kwcall),
+            Mooncake.zero_fcodual(NamedTuple{(:dims,)}((dims=dims,))),
+            Mooncake.zero_fcodual(logsumexp),
+            cdx,
         )
-        y, (_, _, _, dx) = Mooncake.value_and_pullback!!(
-            cache, seed, Core.kwcall, NamedTuple{(:dims,)}((dims=dims,)), logsumexp, x
-        )
-        return y, dx
+        Mooncake.tangent(y) .= 1
+        pb(Mooncake.NoRData())
+        return Mooncake.primal(y), Mooncake.tangent(cdx)
     end
 
     # All Inf inputs
@@ -743,9 +750,14 @@ if cuda
         @test_throws ArgumentError rule(
             Mooncake.zero_dual(gather_sum), Mooncake.Dual(copy(xg), CUDA.ones(Float32, 4))
         )
-        cache = Mooncake.prepare_gradient_cache(gather_sum, xg)
-        @test Array(Mooncake.value_and_gradient!!(cache, gather_sum, xg)[2][2]) ==
-            Float32[1, 0, 1, 0]
+        # Reverse mode does work here, which is what the raise above directs users to.
+        cdx = Mooncake.zero_fcodual(copy(xg))
+        y, pb = Mooncake.rrule!!(
+            Mooncake.zero_fcodual(NNlib.gather), cdx, Mooncake.zero_fcodual([1, 3])
+        )
+        Mooncake.tangent(y) .= 1
+        pb(Mooncake.NoRData())
+        @test Array(Mooncake.tangent(cdx)) == Float32[1, 0, 1, 0]
         # `Adjoint`/`Transpose` of a GPU array are `AnyGPUArray`, so NNlib sends them to the
         # same kernel: they have to hit the guard, not slip past a bare `AbstractGPUArray`.
         @testset "$wrap" for wrap in (adjoint, transpose)
@@ -755,18 +767,5 @@ if cuda
                 Mooncake.zero_dual(gather_sum), Mooncake.zero_dual(w)
             )
         end
-    end
-
-    # `arrayify` hands the pullback a wrapped fdata, and NNlib's CUDA `scatter!` kernel
-    # cannot take one: it compiled to invalid LLVM IR. Reverse mode has to keep working for
-    # a wrapper built inside the function, which is how `SupportedArray`'s members arise.
-    @testset "reverse mode over gather on a wrapped GPU array: $wrap" for wrap in (
-        adjoint, transpose
-    )
-        g(x) = sum(NNlib.gather(wrap(x), [1, 3]))
-        xv = cu(randn(StableRNG(123), Float32, 4))
-        cache = Mooncake.prepare_gradient_cache(g, xv)
-        @test Array(Mooncake.value_and_gradient!!(cache, g, xv)[2][2]) ==
-            Float32[1, 0, 1, 0]
     end
 end

--- a/test/ext/nnlib/nnlib.jl
+++ b/test/ext/nnlib/nnlib.jl
@@ -750,14 +750,8 @@ if cuda
         @test_throws ArgumentError rule(
             Mooncake.zero_dual(gather_sum), Mooncake.Dual(copy(xg), CUDA.ones(Float32, 4))
         )
-        # Reverse mode does work here, which is what the raise above directs users to.
-        cdx = Mooncake.zero_fcodual(copy(xg))
-        y, pb = Mooncake.rrule!!(
-            Mooncake.zero_fcodual(NNlib.gather), cdx, Mooncake.zero_fcodual([1, 3])
-        )
-        Mooncake.tangent(y) .= 1
-        pb(Mooncake.NoRData())
-        @test Array(Mooncake.tangent(cdx)) == Float32[1, 0, 1, 0]
+        # Reverse mode, which the raise directs users to, is covered by the `gather` cases
+        # in `test_cases`: under `cuda` those run on `CuArray`s.
         # `Adjoint`/`Transpose` of a GPU array are `AnyGPUArray`, so NNlib sends them to the
         # same kernel: they have to hit the guard, not slip past a bare `AbstractGPUArray`.
         @testset "$wrap" for wrap in (adjoint, transpose)

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -15,8 +15,11 @@ end
 # `_build_rule!`). `stale_fwd_lazy` reaches the callee via LazyFRule, `stale_fwd_dyn` via DynamicFRule.
 stale_fwd_inner(x) = Float32(x) * 2.0f0
 @noinline stale_fwd_callee(x) = stale_fwd_inner(x)
-stale_fwd_lazy(x) = stale_fwd_callee(x)
-const STALE_FWD_FNS = Function[stale_fwd_callee]
+# Two `:invoke` levels: one for the pinned rebuild, one for the rules that rebuild itself
+# constructs, which predicted at the current world until they were given the pinned one.
+@noinline stale_fwd_mid(x) = stale_fwd_callee(x)
+stale_fwd_lazy(x) = stale_fwd_mid(x)
+const STALE_FWD_FNS = Function[stale_fwd_mid]
 stale_fwd_dyn(x) = (STALE_FWD_FNS[1])(x)
 
 @testset "s2s_forward_mode_ad" begin

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -28,8 +28,10 @@ rule_type_nonreturning(e::Exception) = throw(e)
 # analogue). `stale_rvs_lazy` uses LazyDerivedRule, `stale_rvs_dyn` DynamicDerivedRule.
 stale_rvs_inner(x) = Float32(x) * 2.0f0
 @noinline stale_rvs_callee(x) = stale_rvs_inner(x)
-stale_rvs_lazy(x) = stale_rvs_callee(x)
-const STALE_RVS_FNS = Function[stale_rvs_callee]
+# Two `:invoke` levels; see the forward-mode analogue for why one is not enough.
+@noinline stale_rvs_mid(x) = stale_rvs_callee(x)
+stale_rvs_lazy(x) = stale_rvs_mid(x)
+const STALE_RVS_FNS = Function[stale_rvs_mid]
 stale_rvs_dyn(x) = (STALE_RVS_FNS[1])(x)
 
 @testset "s2s_reverse_mode_ad" begin

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -475,7 +475,7 @@ stale_rvs_dyn(x) = (STALE_RVS_FNS[1])(x)
         @benchmark Mooncake.value_and_gradient!!($rule, $f, $(Ref(0.0))[])
 
         # 660 -- ensure that the correct signature is used to construct DynamicDerivedRules
-        rule = Mooncake.DynamicDerivedRule(false)
+        rule = Mooncake.DynamicDerivedRule(false, Base.get_world_counter())
         args = (zero_fcodual(identity), zero_fcodual((v=S2SGlobals.MakeAUnionAll,)))
         @test rule(args...) isa Tuple{CoDual,Any}
     end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -13,6 +13,8 @@
         @test has_equal_data(ones(5), ones(5))
         @test has_equal_data(Base, Base)
         @test !has_equal_data(Base, Core)
+        @test has_equal_data(:a, :a)
+        @test !has_equal_data(:a, :b)
         @test has_equal_data(GlobalRef(Base, :sin), GlobalRef(Base, :sin))
         @test !has_equal_data(GlobalRef(Base, :sin), GlobalRef(Base, :cos))
         @test !has_equal_data(GlobalRef(Base, :sin), GlobalRef(Core, :sin))

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -65,7 +65,9 @@
 
         m = only(methods(sin, (Float64,)))
         @test has_equal_data(m, m)
-        mi = first(m.specializations)
+        # `m.specializations` is a bare `MethodInstance` or an svec with `#undef` slots;
+        # `Base.specializations` normalises both.
+        mi = first(Base.specializations(m))
         @test has_equal_data(mi, mi)
     end
     @testset "populate_address_map" begin


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1268 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1268/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 395.0 ns │     1.71 │        1.64 │    0.22 │       0.833 │   1.28 │
│                  _sum_1000 │ 800.0 ns │     7.32 │       0.944 │  3190.0 │        42.8 │   1.32 │
│               sum_sin_1000 │  5.96 μs │     3.22 │         1.3 │    1.81 │        10.8 │   1.86 │
│              _sum_sin_1000 │  5.51 μs │     3.03 │         1.9 │   282.0 │        10.9 │   2.23 │
│                   kron_sum │ 379.0 μs │     6.35 │         2.5 │    15.0 │       231.0 │   11.0 │
│              kron_view_sum │ 344.0 μs │     8.57 │        4.32 │    20.7 │       254.0 │   11.9 │
│      naive_map_sin_cos_exp │  2.78 μs │     2.27 │        1.29 │ missing │        5.41 │    1.4 │
│            map_sin_cos_exp │  2.77 μs │     2.88 │        1.57 │    1.12 │        4.41 │    1.6 │
│      broadcast_sin_cos_exp │  2.76 μs │     2.91 │        1.78 │    2.59 │        1.05 │   1.32 │
│                 simple_mlp │ 341.0 μs │     4.44 │        2.82 │    1.86 │        8.44 │   3.31 │
│                     gp_lml │ 243.0 μs │     7.18 │        2.24 │    7.01 │     missing │   3.51 │
│ turing_broadcast_benchmark │   1.7 ms │     4.41 │        2.68 │ missing │        35.0 │   1.41 │
│         large_single_block │ 575.0 ns │     5.86 │         1.7 │  3100.0 │        18.9 │   1.51 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->