### PR TITLE
Bugfix for broadcasts on in MooncakeCUDA extension. 

### DIFF
--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -2361,9 +2361,9 @@ end
 )
 # A non-contiguous view stays a SubArray (a contiguous one collapses to a plain CuArray);
 # `arrayify` rebuilds its tangent as a SubArray over the parent's tangent, same indices.
-@inline _leaf_effective_tangent(
-    pa::SubArray{P,N,A}, t
-) where {P<:CuFloatOrComplex,N,A<:CuMaybeComplexArray} = arrayify(pa, t)[2]
+@inline _leaf_effective_tangent(pa::SubArray{P,N,A}, t) where {P<:CuFloatOrComplex,N,A<:CuMaybeComplexArray} = arrayify(
+    pa, t
+)[2]
 # Scalar variables broadcast as a uniform constant; their tangent is the scalar itself.
 @inline _leaf_effective_tangent(::IEEEFloat, t) = t
 @inline _leaf_effective_tangent(::Complex{<:IEEEFloat}, t) = t

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -2359,6 +2359,11 @@ end
 @inline _leaf_effective_tangent(::Transpose{<:CuFloatOrComplex,<:CuMaybeComplexArray}, t) = transpose(
     _fields(t).parent
 )
+# A non-contiguous view stays a SubArray (a contiguous one collapses to a plain CuArray);
+# `arrayify` rebuilds its tangent as a SubArray over the parent's tangent, same indices.
+@inline _leaf_effective_tangent(
+    pa::SubArray{P,N,A}, t
+) where {P<:CuFloatOrComplex,N,A<:CuMaybeComplexArray} = arrayify(pa, t)[2]
 # Scalar variables broadcast as a uniform constant; their tangent is the scalar itself.
 @inline _leaf_effective_tangent(::IEEEFloat, t) = t
 @inline _leaf_effective_tangent(::Complex{<:IEEEFloat}, t) = t
@@ -2414,6 +2419,13 @@ end
     pa::Transpose{<:CuFloatOrComplex,<:CuMaybeComplexArray}, fd, contrib
 )
     return _fields(fd).parent .+= transpose(_unbroadcast(contrib, size(pa)))
+end
+@inline function _leaf_accum_fdata!(
+    pa::SubArray{P,N,A}, fd, contrib
+) where {P<:CuFloatOrComplex,N,A<:CuMaybeComplexArray}
+    _, dpa = arrayify(pa, fd)
+    dpa .+= _unbroadcast(contrib, size(pa))
+    return dpa
 end
 @inline function _leaf_accum_fdata!(_, diff::_GpuBroadcastCastDiff, contrib)
     return _leaf_accum_fdata!(

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -99,6 +99,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _bcast_adj_lit_add(x) = sum(x' .+ 1.0)        # real adjoint
         _bcast_adj_cx_abs2(x) = sum(abs2.(x'))         # complex adjoint, non-holomorphic
         _bcast_tp_lit_add(x) = sum(transpose(x) .+ 1.0) # real transpose
+        # Non-contiguous SubArray leaf: rows 1:2 of a column-major matrix are strided, so the
+        # view stays a SubArray (a contiguous view collapses to a plain CuArray).
+        _bcast_noncontig_view(x) = sum(exp.(view(x, 1:2, :)))
         # Shape-broadcasting: vector broadcast against matrix — tests _unbroadcast
         _bcast_vec_mat_add(v, m) = sum(v .+ m)     # v:(n,) broadcast to (n,p)
         _bcast_vec_mat_mul(v, m) = sum(v .* m)     # v:(n,) broadcast to (n,p)
@@ -404,6 +407,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _bcast_adj_lit_add, _rand(rng, 16)),
             (false, :none, false, _bcast_adj_cx_abs2, _rand(rng, ComplexF64, 16)),
             (false, :none, false, _bcast_tp_lit_add, _rand(rng, 16)),
+            # Non-contiguous SubArray broadcast leaf (rows 1:2 of a 4x3 stay a SubArray)
+            (false, :none, false, _bcast_noncontig_view, _rand(rng, 4, 3)),
             # Shape-broadcasting: vector vs matrix — exercises _unbroadcast in pullback
             (false, :none, false, _bcast_vec_mat_add, _rand(rng, 8), _rand(rng, 8, 4)),
             (false, :none, false, _bcast_vec_mat_mul, _rand(rng, 8), _rand(rng, 8, 4)),


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1270 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1270/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 210.0 ns │     1.52 │        1.58 │   0.571 │        2.77 │    5.3 │
│                  _sum_1000 │ 982.0 ns │     6.67 │        1.01 │  3630.0 │        36.5 │   1.05 │
│               sum_sin_1000 │   7.1 μs │      3.5 │        1.34 │     1.5 │        11.2 │   1.77 │
│              _sum_sin_1000 │  6.17 μs │     3.58 │        1.84 │   226.0 │        13.0 │   2.18 │
│                   kron_sum │ 213.0 μs │     12.8 │        3.24 │    14.0 │       351.0 │   18.6 │
│              kron_view_sum │ 289.0 μs │     11.0 │        5.15 │    25.3 │       323.0 │   12.3 │
│      naive_map_sin_cos_exp │   2.4 μs │     3.04 │        1.48 │ missing │        7.37 │   2.06 │
│            map_sin_cos_exp │  2.19 μs │     3.67 │        1.74 │    1.61 │        6.96 │   2.78 │
│      broadcast_sin_cos_exp │  2.38 μs │     3.16 │        1.56 │    4.28 │        1.42 │   2.08 │
│                 simple_mlp │ 235.0 μs │     5.68 │        2.66 │    1.57 │        11.7 │   2.96 │
│                     gp_lml │ 219.0 μs │     9.12 │        2.16 │    7.99 │     missing │   4.69 │
│ turing_broadcast_benchmark │  1.67 ms │      6.9 │        3.54 │ missing │        40.5 │    2.4 │
│         large_single_block │ 421.0 ns │     5.57 │        2.02 │  4800.0 │        37.3 │   2.05 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->