### PR TITLE
CUDA: `CuMatrix` `+`/`-`, `repeat`, Cartesian gather, and index/mask arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.45"
+version = "0.5.46"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1328,6 +1328,11 @@ function _scan_pullback(dy, d)
     d > ndims(dy) && return dy
     return reverse(cumsum(reverse(dy; dims=d); dims=d); dims=d)
 end
+# Same boundary seen from `init`: on that identity path CUDA's scan copies the input and
+# returns before applying `init`, so the primal does not depend on it and neither may the
+# derivative.
+_scan_applies_init(px, ::Nothing) = true
+_scan_applies_init(px, d) = d <= ndims(px)
 
 # Rules for `accumulate(+, x)` — identical to cumsum but via the accumulate interface.
 # Other operators are not supported and throw an informative error (catch-all below).
@@ -1386,9 +1391,12 @@ function frule!!(
 )
     pkw = primal(kw)
     px, dx = arrayify(x)
+    d = get(pkw, :dims, nothing)
     y = accumulate(+, px; pkw...)
-    dy = eltype(y).(_scan_jvp(dx, get(pkw, :dims, nothing)))
-    return Dual(y, _kw_init_jvp(dy, _kw_init_tangent(tangent(kw)), true))
+    dy = eltype(y).(_scan_jvp(dx, d))
+    return Dual(
+        y, _kw_init_jvp(dy, _kw_init_tangent(tangent(kw)), _scan_applies_init(px, d))
+    )
 end
 function rrule!!(
     ::CoDual{typeof(Core.kwcall)},
@@ -1405,9 +1413,8 @@ function rrule!!(
     d = get(pkw, :dims, nothing)
     function accumulate_plus_kw_pb!!(::NoRData)
         dx .+= _scan_pullback(dy_out, d)
-        return NoRData(),
-        _kw_init_rdata(kw_rdata, dy_out, true), NoRData(), NoRData(),
-        NoRData()
+        dkw = _kw_init_rdata(kw_rdata, dy_out, _scan_applies_init(px, d))
+        return NoRData(), dkw, NoRData(), NoRData(), NoRData()
     end
     return CoDual(y, dy_out), accumulate_plus_kw_pb!!
 end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -612,6 +612,22 @@ end
 # stays inside the buffer, and writing into whatever the pool handed out next once it does
 # not. The derived tangent shares the source tangent's DataRef, so accumulation into a view
 # reaches the parent's tangent and the pullback has nothing to do.
+# `derive` also backs both `reinterpret` spellings, which may change the element type. The
+# tangent is derived the same way, which is right exactly when the underlying real field is
+# unchanged: same eltype for a view or reshape, and Complex{T} against T for a reinterpret
+# that interleaves the parts, whose tangent interleaves identically. Anything else -- Float64
+# read as Float32 pairs, a float read as an integer -- hands back a tangent whose elements are
+# bit-halves of the real one, which accumulates into the parent as silent corruption.
+function _check_derive_eltype(::Type{T}, pa) where {T}
+    real(T) === real(eltype(pa)) && return nothing
+    return _throw_gpu_argument_error(
+        "Mooncake: reinterpreting a CuArray of $(eltype(pa)) as $T is not differentiable. " *
+        "The tangent would be reinterpreted the same way, so its elements would no longer " *
+        "line up with the primal's. Reinterpreting between a complex eltype and its own " *
+        "real part is supported. " *
+        _UNIMPL_MSG,
+    )
+end
 @is_primitive(MinimalCtx, Tuple{typeof(derive),Type,CuMaybeComplexArray,Dims,Int})
 function frule!!(
     ::Dual{typeof(derive)},
@@ -621,6 +637,7 @@ function frule!!(
     offset::Dual,
 ) where {T}
     pa, da = arrayify(a)
+    _check_derive_eltype(T, pa)
     d, o = primal(dims), primal(offset)
     return Dual(derive(T, pa, d, o), derive(T, da, d, o))
 end
@@ -632,6 +649,7 @@ function rrule!!(
     offset::CoDual,
 ) where {T}
     pa, da = arrayify(a)
+    _check_derive_eltype(T, pa)
     d, o = primal(dims), primal(offset)
     return CoDual(derive(T, pa, d, o), derive(T, da, d, o)), _nopb(Val(5))
 end
@@ -1577,6 +1595,7 @@ for _n_args in (0, 1)
     )
         pkw = primal(kw)
         _check_reduction_identity(count, pkw)
+        _check_reduction_init(tangent(kw))
         y = count($(_pred_v...), primal(x); pkw...)
         return Dual(y, zero_tangent(y))
     end
@@ -1589,8 +1608,13 @@ for _n_args in (0, 1)
     )
         pkw = primal(kw)
         _check_reduction_identity(count, pkw)
+        # The keyword slot owes `zero_rdata(pkw)`, not `NoRData()`: a float `init` makes the
+        # count a float, and its rdata is then a NamedTuple the caller increments into.
+        kw_rdata = zero_rdata(pkw)
         y = count($(_pred_v...), primal(x); pkw...)
-        count_kw_pb!!(::Any) = ntuple(_ -> NoRData(), $(_n_args + 4))
+        function count_kw_pb!!(::Any)
+            return NoRData(), kw_rdata, $(fill(:(NoRData()), _n_args + 2)...)
+        end
         return zero_fcodual(y), count_kw_pb!!
     end
 end
@@ -3633,6 +3657,11 @@ end
 @inline _gpu_bcast_has_nondiff_result(::typeof(isfinite)) = true
 @inline _gpu_bcast_has_nondiff_result(::typeof(isinf)) = true
 @inline _gpu_bcast_has_nondiff_result(::typeof(isnan)) = true
+# `map(>(0.5f0), x)` reaches the kernel as a `Fix2` carrying its threshold. The comparison
+# still decides the result, which is a Bool, so the capture's derivative is genuinely zero and
+# the state guard below has nothing to protect.
+@inline _gpu_bcast_has_nondiff_result(f::Base.Fix2) = _gpu_bcast_has_nondiff_result(f.f)
+@inline _gpu_bcast_has_nondiff_result(f::Base.Fix1) = _gpu_bcast_has_nondiff_result(f.f)
 @inline _gpu_bcast_has_nondiff_result(::Any) = false
 @inline _gpu_is_simple_cast_broadcast(::Any) = false
 @inline function _gpu_is_simple_cast_broadcast(bc::Broadcasted)
@@ -3897,7 +3926,9 @@ function _check_gpu_bcast_captures(args::Tuple)
     return _check_gpu_bcast_captures(Base.tail(args))
 end
 function _check_gpu_bcast_captures(bc::Broadcasted)
-    _check_gpu_captured_state(bc.f, "broadcasting")
+    # A function whose result carries no derivative cannot silently zero one, so its own
+    # state is not the hazard this guard exists for.
+    _gpu_bcast_has_nondiff_result(bc.f) || _check_gpu_captured_state(bc.f, "broadcasting")
     return _check_gpu_bcast_captures(bc.args)
 end
 

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -764,12 +764,18 @@ function _gpu_scatter_add_complex_kernel!(rdx, lin, rdy)
     return nothing
 end
 function _gpu_scatter_add!(dx, pidx, dy)
-    n = length(pidx)
+    # A logical mask is a claimed spelling as well, since Bool <: Integer, but it names its
+    # positions by where it sits rather than by value: scattering it as written would send
+    # every selected element to index 1 or to one slot before the buffer. Base converts it
+    # for the primal and for the frule's indexing; the kernel needs it done here.
+    idx = eltype(pidx) === Bool ? findall(pidx) : pidx
+    # The output is what sets the launch size — a mask is longer than the gather it selects.
+    n = length(dy)
     iszero(n) && return dx
     # The complex kernel indexes the reinterpreted halves arithmetically, so both paths take
     # linear indices; a Cartesian index vector is converted once, on the device.
     li = LinearIndices(size(dx))
-    idx_lin = eltype(pidx) <: Integer ? pidx : map(I -> li[I], pidx)
+    idx_lin = eltype(idx) <: Integer ? idx : map(I -> li[I], idx)
     # The index vector may live on the host — `x[[1, 2, 3]]` is a perfectly ordinary
     # spelling — and a kernel argument has to be on the device.
     lin = idx_lin isa CuArray ? idx_lin : CuArray(idx_lin)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1708,6 +1708,8 @@ function _repeat_reduce(
 end
 
 _repeat_pad(t, ::Val{N}) where {N} = ntuple(d -> d <= length(t) ? Int(t[d]) : 1, N)
+# `inner`/`outer` default to `nothing` in Base.repeat, so callers may pass it explicitly.
+_repeat_pad(::Nothing, v::Val) = _repeat_pad((), v)
 
 @is_primitive(MinimalCtx, Tuple{typeof(repeat),CuMaybeComplexArray,Vararg{Integer}})
 function frule!!(

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -3795,6 +3795,12 @@ function rrule!!(
     # shared NDual-value extraction): eltype(pout) is always IEEEFloat for CuMaybeComplexArray.
     if !decoded.is_diff
         function materialize!_nodiff_pb!!(::NoRData)
+            # dest was overwritten by a result that does not depend on its old value, so the
+            # cotangent standing in dest's fdata belongs to that result and is consumed here
+            # — there is nothing to redistribute it to.  Leaving it would hand it back to
+            # dest's own history, as if the broadcast had passed dest through.  The
+            # differentiable branch below consumes it the same way, after distributing it.
+            fill!(dout, zero(eltype(dout)))
             copyto!(pout, old_pout)
             return NoRData(), NoRData(), zero_rdata(bc_primal)
         end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -876,8 +876,10 @@ function _minmax_init_rdata(kw_rdata::NamedTuple, dy, won)
     (haskey(kw_rdata, :init) && !(kw_rdata.init isa NoRData)) || return kw_rdata
     return merge(kw_rdata, (; init=oftype(kw_rdata.init, sum(dy .* .!won))))
 end
+# findmax answers `dims` and nothing else, so those calls keep the plain argmax path.
+_minmax_kw_is_plain(::NamedTuple{K}) where {K} = K === () || K === (:dims,)
 
-for (_fn, _find) in ((:maximum, :findmax), (:minimum, :findmin))
+for (_fn, _find, _beat) in ((:maximum, :findmax, :<), (:minimum, :findmin, :>))
     @eval @is_primitive(MinimalCtx, Tuple{typeof($_fn),CuFloatArray})
     @eval @is_primitive(
         MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof($_fn),CuFloatArray}
@@ -898,9 +900,11 @@ for (_fn, _find) in ((:maximum, :findmax), (:minimum, :findmin))
         return CoDual(y, NoFData()), minmax_pb!!
     end
 
-    # The value comes from the primal call, not from findmax, which reads only `dims`: an
-    # `init` that beats every element leaves the result independent of x, and an unsupported
-    # keyword has to raise the primal's own MethodError.  findmax supplies just the argmax.
+    # Any keyword beyond `dims` needs the value from the primal call: `init` can beat every
+    # element, leaving the result independent of x, and it also fixes the output eltype, so
+    # the tangent is converted to follow it.  A keyword the primal rejects then still raises
+    # its MethodError.  `won` is a negated comparison so that a slice whose max is NaN keeps
+    # the argmax gradient, where the keyword-free rule puts it.
     @eval function frule!!(
         ::Dual{typeof(Core.kwcall)},
         kw::Dual{<:NamedTuple},
@@ -910,11 +914,17 @@ for (_fn, _find) in ((:maximum, :findmax), (:minimum, :findmin))
         pkw = primal(kw)
         px, dx = arrayify(x)
         dims = get(pkw, :dims, :)
-        y = $_fn(px; pkw...)
         m, ind = $_find(px; dims=dims)
-        won = m .== y
-        dy = sum(dx .* (CartesianIndices(px) .== _winner(ind)); dims=dims) .* won
-        return Dual(y, _minmax_init_jvp(dy, _minmax_init_tangent(tangent(kw)), won))
+        if _minmax_kw_is_plain(pkw)
+            return Dual(m, sum(dx .* (CartesianIndices(px) .== _winner(ind)); dims=dims))
+        end
+        y = $_fn(px; pkw...)
+        won = .!broadcast($_beat, m, y)
+        dy = sum(dx .* (CartesianIndices(px) .== _winner(ind)); dims=dims)
+        return Dual(
+            y,
+            _minmax_init_jvp(eltype(y).(dy) .* won, _minmax_init_tangent(tangent(kw)), won),
+        )
     end
     @eval function rrule!!(
         ::CoDual{typeof(Core.kwcall)},
@@ -926,9 +936,13 @@ for (_fn, _find) in ((:maximum, :findmax), (:minimum, :findmin))
         kw_rdata = zero_rdata(pkw)
         px, dx = arrayify(x)
         dims = get(pkw, :dims, :)
-        y = $_fn(px; pkw...)
         m, ind = $_find(px; dims=dims)
-        won = m .== y
+        y, won = if _minmax_kw_is_plain(pkw)
+            m, true
+        else
+            y_kw = $_fn(px; pkw...)
+            y_kw, .!broadcast($_beat, m, y_kw)
+        end
         if dims isa Colon
             function minmax_kw_scalar_pb!!(dy)
                 dx .+= dy .* (CartesianIndices(px) .== _winner(ind)) .* won
@@ -1015,7 +1029,11 @@ function frule!!(
     px, dx = arrayify(x)
     y = prod(px; pkw...)
     inv_px = nan_tangent_guard.(px, inv.(px))
-    return Dual(y, y .* sum(dx .* inv_px; dims=get(pkw, :dims, :)))
+    # `init` fixes the output eltype, and the tangent has to follow it.  Converting after
+    # the reduction rather than seeding it: a widening seed over a broadcast fails to
+    # compile a kernel.
+    dy = eltype(y).(sum(dx .* inv_px; dims=get(pkw, :dims, :)))
+    return Dual(y, y .* dy)
 end
 function rrule!!(
     ::CoDual{typeof(Core.kwcall)},
@@ -1268,8 +1286,9 @@ end
 # frules can check it: reverse mode sees no tangent, and cannot tell a constant `init` from
 # one the caller wants a gradient for, so a guard there rejects correct programs.
 #
-# sum, prod, maximum and minimum all accept `init`; diff/sort/sortperm do not, so the guard
-# is a no-op for those three and one path covers all seven.
+# This covers sum and prod, whose `init` folding is what makes the derivative undefined, and
+# diff/sort/sortperm, which take no `init` at all.  maximum and minimum are idempotent, so
+# their `init` derivative survives the folding exactly; they get it below.
 function _check_reduction_init(dkw)
     dinit = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
     (dinit isa NoTangent || iszero(dinit)) && return nothing
@@ -1281,7 +1300,7 @@ function _check_reduction_init(dkw)
     )
 end
 
-for _fn in (:sum, :prod, :maximum, :minimum, :diff, :sort, :sortperm)
+for _fn in (:sum, :prod, :diff, :sort, :sortperm)
     @eval @is_primitive(
         MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof($_fn),CuNonDiffArray}
     )
@@ -1308,6 +1327,56 @@ for _fn in (:sum, :prod, :maximum, :minimum, :diff, :sort, :sortperm)
         # incoming rdata is NoRData or a number depending on the call.
         nodiff_reduction_kw_pb!!(::Any) = (NoRData(), kw_rdata, NoRData(), NoRData())
         return zero_fcodual(y), nodiff_reduction_kw_pb!!
+    end
+end
+
+# maximum/minimum over an index or mask array: the array carries no derivative, but a float
+# `init` competes with its elements and takes the whole derivative of every slice it beats.
+# The array's own max, which decides that, needs a second reduction, so plain `dims` calls
+# keep the zero-derivative path.
+for (_fn, _beat) in ((:maximum, :<), (:minimum, :>))
+    @eval @is_primitive(
+        MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof($_fn),CuNonDiffArray}
+    )
+    @eval function frule!!(
+        ::Dual{typeof(Core.kwcall)},
+        kw::Dual{<:NamedTuple},
+        ::Dual{typeof($_fn)},
+        x::Dual{<:CuNonDiffArray},
+    )
+        pkw = primal(kw)
+        px = primal(x)
+        y = $_fn(px; pkw...)
+        won = if _minmax_kw_is_plain(pkw)
+            true
+        else
+            .!broadcast($_beat, $_fn(px; dims=get(pkw, :dims, :)), y)
+        end
+        dinit = _minmax_init_tangent(tangent(kw))
+        return Dual(y, _minmax_init_jvp(zero_tangent(y), dinit, won))
+    end
+    @eval function rrule!!(
+        ::CoDual{typeof(Core.kwcall)},
+        kw::CoDual{<:NamedTuple},
+        ::CoDual{typeof($_fn)},
+        x::CoDual{<:CuNonDiffArray},
+    )
+        pkw = primal(kw)
+        kw_rdata = zero_rdata(pkw)
+        px = primal(x)
+        out = zero_fcodual($_fn(px; pkw...))
+        won = if _minmax_kw_is_plain(pkw)
+            true
+        else
+            .!broadcast($_beat, $_fn(px; dims=get(pkw, :dims, :)), primal(out))
+        end
+        # `::Any`: a `dims` reduction carries its cotangent in the output's fdata, a scalar
+        # one in the incoming rdata.
+        function nodiff_minmax_kw_pb!!(dy::Any)
+            dkw = _minmax_init_rdata(kw_rdata, dy isa NoRData ? tangent(out) : dy, won)
+            return NoRData(), dkw, NoRData(), NoRData()
+        end
+        return out, nodiff_minmax_kw_pb!!
     end
 end
 

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -95,6 +95,7 @@ import Mooncake.TestUtils:
 const CuFloatArray = CuArray{<:IEEEFloat}
 const CuComplexArray = CuArray{<:Complex{<:IEEEFloat}}
 const CuMaybeComplexArray = Union{CuFloatArray,CuComplexArray}
+const CuMaybeComplexVector = Union{CuArray{<:IEEEFloat,1},CuArray{<:Complex{<:IEEEFloat},1}}
 # Index and mask arrays. Deliberately a whitelist rather than a predicate on
 # tangent_type(eltype), which cannot be written as a dispatch signature without also
 # capturing the differentiable eltypes handled above. An eltype outside it whose
@@ -3292,11 +3293,16 @@ end
 _cu_pullback_like(::AbstractArray, dy) = Array(dy)
 _cu_pullback_like(::CuArray, dy) = dy
 
-@is_primitive(MinimalCtx, Tuple{typeof(cu),AbstractArray{<:CuFloatOrComplex}})
-function frule!!(::Dual{typeof(cu)}, x::Dual{<:AbstractArray{<:CuFloatOrComplex}})
+# Claimed for the two shapes whose fdata is the array itself. An `Adjoint`, `Transpose` or
+# `Diagonal` argument has an `FData{@NamedTuple{parent::…}}` instead, which the body would
+# accumulate into as though it were a bare array; those spellings decompose through the
+# wrapper's own rules.
+const _CuTransferable = Union{Array{<:CuFloatOrComplex},CuArray{<:CuFloatOrComplex}}
+@is_primitive(MinimalCtx, Tuple{typeof(cu),_CuTransferable})
+function frule!!(::Dual{typeof(cu)}, x::Dual{<:_CuTransferable})
     return Dual(cu(primal(x)), cu(tangent(x)))
 end
-function rrule!!(::CoDual{typeof(cu)}, x::CoDual{<:AbstractArray{<:CuFloatOrComplex}})
+function rrule!!(::CoDual{typeof(cu)}, x::CoDual{<:_CuTransferable})
     dx = tangent(x)
     dy_gpu = cu(zero(primal(x)))  # output fdata, accumulated into by downstream
     function cu_pb!!(::NoRData)
@@ -3335,12 +3341,16 @@ end
 # Diagonal is a thin wrapper: its only differentiable field is `.diag`.
 # frule:    d(Diagonal(v)) = Diagonal(dv)
 # pullback: dv += diag(dD)  (i.e. extract the diagonal from the output cotangent)
-@is_primitive(MinimalCtx, Tuple{Type{<:Diagonal},CuMaybeComplexArray})
-function frule!!(::Dual{<:Type{<:Diagonal}}, v::Dual{<:CuMaybeComplexArray})
+# Vectors only: `Diagonal(A::CuMatrix)` is `Diagonal(diag(A))`, whose `.diag` is a length-n
+# vector, while these rules put the argument's own fdata in that slot and the pullback
+# returns nothing on the assumption `.diag === v`. The matrix spelling decomposes through
+# `diag`, which carries the gradient back to the right elements.
+@is_primitive(MinimalCtx, Tuple{Type{<:Diagonal},CuMaybeComplexVector})
+function frule!!(::Dual{<:Type{<:Diagonal}}, v::Dual{<:CuMaybeComplexVector})
     # Diagonal is a non-mutable struct; its tangent type is Tangent{(; diag::CuArray)}.
     return Dual(Diagonal(primal(v)), Tangent((; diag=tangent(v))))
 end
-function rrule!!(::CoDual{<:Type{<:Diagonal}}, v::CoDual{<:CuMaybeComplexArray})
+function rrule!!(::CoDual{<:Type{<:Diagonal}}, v::CoDual{<:CuMaybeComplexVector})
     pv, dv = arrayify(v)
     # `Diagonal(v).diag === v`, so the aliasing invariant — primal(a) === primal(b) implies
     # fdata(a) === fdata(b) — requires the output's `.diag` fdata to *be* v's.  Accumulating a

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1992,7 +1992,10 @@ function rrule!!(::CoDual{typeof(fill!)}, a::CoDual{<:CuMaybeWrappedArray}, x::C
         dx = if tangent_type(typeof(primal(x))) == NoTangent
             NoRData()
         else
-            rdata_type(typeof(primal(x)))(sum(da))
+            # A real `x` filling a complex array is owed only dL/dRe, so the sum is
+            # projected onto x's own field before it is narrowed to x's type — narrowing a
+            # complex sum to a real would throw instead.
+            rdata_type(typeof(primal(x)))(_project_cotangent(primal(x), sum(da)))
         end
         fill!(da, zero(eltype(da)))
         return NoRData(), NoRData(), dx

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -820,7 +820,13 @@ end
 const _UNIMPL_MSG = "Add a new rule or open an issue at https://github.com/chalk-lab/Mooncake.jl."
 # NB: `$_fn` inside a string literal under @eval is runtime interpolation of a
 # global that never exists, so build each message here and splice it whole.
-for _fn in (:maximum, :minimum, :diff, :sort, :sortperm)
+# sortperm is not in this list: it returns a permutation of Int indices, so it has no
+# derivative for any element type, and the program that uses those indices to gather is
+# differentiable through the gather rule.  sort and diff return values and do belong here.
+@zero_derivative MinimalCtx Tuple{typeof(sortperm),CuArray}
+@zero_derivative MinimalCtx Tuple{typeof(Core.kwcall),NamedTuple,typeof(sortperm),CuArray}
+
+for _fn in (:maximum, :minimum, :diff, :sort)
     _msg = "Mooncake: $_fn on CuArray is not yet differentiable. " * _UNIMPL_MSG
     @eval @is_primitive(MinimalCtx, Tuple{typeof($_fn),CuArray})
     @eval @is_primitive(
@@ -1324,7 +1330,7 @@ end
 # same way lets the narrower array type decide, leaving those rules to report float arrays.
 @zero_derivative MinimalCtx Tuple{typeof(sum),CuNonDiffArray}
 @zero_derivative MinimalCtx Tuple{typeof(prod),CuNonDiffArray}
-for _fn in (:maximum, :minimum, :diff, :sort, :sortperm)
+for _fn in (:maximum, :minimum, :diff, :sort)
     @eval @is_primitive(MinimalCtx, Tuple{typeof($_fn),CuNonDiffArray})
     @eval frule!!(f::Dual{typeof($_fn)}, x::Dual{<:CuNonDiffArray}) = zero_derivative(f, x)
     @eval rrule!!(f::CoDual{typeof($_fn)}, x::CoDual{<:CuNonDiffArray}) = zero_adjoint(f, x)
@@ -1381,7 +1387,7 @@ function _check_reduction_init(dkw)
     )
 end
 
-for _fn in (:sum, :prod, :diff, :sort, :sortperm)
+for _fn in (:sum, :prod, :diff, :sort)
     @eval @is_primitive(
         MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof($_fn),CuNonDiffArray}
     )

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -2879,13 +2879,15 @@ function frule!!(::Dual{<:Type{<:Diagonal}}, v::Dual{<:CuMaybeComplexArray})
 end
 function rrule!!(::CoDual{<:Type{<:Diagonal}}, v::CoDual{<:CuMaybeComplexArray})
     pv, dv = arrayify(v)
-    dD = zero(pv)  # fdata for .diag of the Diagonal output
-    function diagonal_pb!!(::NoRData)
-        dv .+= dD
-        return NoRData(), NoRData()
-    end
+    # `Diagonal(v).diag === v`, so the aliasing invariant — primal(a) === primal(b) implies
+    # fdata(a) === fdata(b) — requires the output's `.diag` fdata to *be* v's.  Accumulating a
+    # separate zero(pv) into dv at the end of the pullback instead credits v with the
+    # wrapper's cotangent as of the wrong moment, which a mutation of v in between makes
+    # visible.  Sharing the buffer leaves the pullback nothing to do: downstream rules
+    # accumulate into dv directly, and the frule already aliases the same way.
     # fdata_type(Diagonal{T, CuArray{T,1}}) = FData{(; diag::CuArray{T,1})}
-    return CoDual(Diagonal(pv), FData((; diag=dD))), diagonal_pb!!
+    diagonal_pb!!(::NoRData) = (NoRData(), NoRData())
+    return CoDual(Diagonal(pv), FData((; diag=dv))), diagonal_pb!!
 end
 
 # ===== GPU broadcasting rule (materialize-level, NDual-based forward pass) =====

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -830,8 +830,9 @@ function frule!!(::Dual{typeof(norm)}, x::Dual{<:CuMaybeComplexArray})
     s = real(dot(px, dx))
     # dot overflows once norm(px)*norm(dx) leaves the eltype's range, while the JVP it
     # divides down to is still representable — reachable in Float16, whose dot saturates
-    # at 65504. Rescaling costs a temporary, so only fall back to it from a non-finite
-    # dot, matching the core `BLAS.nrm2` frule.
+    # at 65504. The core `BLAS.nrm2` frule scales every element as it accumulates, which
+    # here would mean either a temporary or a fused mapreduce costing 25x a cuBLAS dot,
+    # so this one pays for the rescale only when the dot has already overflowed.
     if !isfinite(s) && isfinite(y)
         return Dual(y, real(dot(px ./ y, dx)))
     end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1114,8 +1114,10 @@ end
 # The keyword spellings cannot be zero-derivative outright: a float `init` makes the output
 # differentiable, so dropping its derivative would be silently wrong.  Nor is it 1 —
 # GPUArrays folds `init` into a backend-defined number of partial reductions, so `init=1.0`
-# over `[1,2,3]` gives 101.0 — so a nonzero `init` tangent is rejected instead.  Only the
-# frules can check it; reverse mode has no incoming `init` tangent.
+# over `[1,2,3]` gives 101.0 — so a nonzero `init` tangent is rejected instead.  Reverse
+# mode has no incoming `init` tangent, and detects the same case from the far side: over a
+# non-differentiable array `init` is the only path a gradient can take, so a nonzero
+# cotangent on the output means the zero rdata would be wrong, not merely conservative.
 #
 # sum, prod, maximum and minimum all accept `init`; diff/sort/sortperm do not, so the guard
 # is a no-op for those three and one path covers all seven.
@@ -1125,6 +1127,17 @@ function _check_reduction_init(dkw)
     return _throw_gpu_argument_error(
         "Mooncake: keyword reductions over CuArray treat `init` as a constant, but it " *
         "received a nonzero tangent. Differentiating with respect to `init` is not " *
+        "supported. " *
+        _UNIMPL_MSG,
+    )
+end
+
+function _check_reduction_init_cotangent(kw_rdata, dy)
+    (kw_rdata isa NoRData || dy isa NoFData || iszero(dy)) && return nothing
+    return _throw_gpu_argument_error(
+        "Mooncake: keyword reductions over CuArray treat `init` as a constant, but this " *
+        "reduction over a non-differentiable array has a nonzero output cotangent, which " *
+        "only `init` could carry. Differentiating with respect to `init` is not " *
         "supported. " *
         _UNIMPL_MSG,
     )
@@ -1152,11 +1165,15 @@ for _fn in (:sum, :prod, :maximum, :minimum, :diff, :sort, :sortperm)
     )
         pkw = primal(kw)
         kw_rdata = zero_rdata(pkw)
-        y = $_fn(primal(x); pkw...)
+        out = zero_fcodual($_fn(primal(x); pkw...))
         # `::Any`: the output is an Integer without `init` and a float with one, so the
-        # incoming rdata is NoRData or a number depending on the call.
-        nodiff_reduction_kw_pb!!(::Any) = (NoRData(), kw_rdata, NoRData(), NoRData())
-        return zero_fcodual(y), nodiff_reduction_kw_pb!!
+        # incoming rdata is NoRData or a number depending on the call; a `dims` reduction
+        # carries its cotangent in the output's fdata instead.
+        function nodiff_reduction_kw_pb!!(dy::Any)
+            _check_reduction_init_cotangent(kw_rdata, dy isa NoRData ? tangent(out) : dy)
+            return (NoRData(), kw_rdata, NoRData(), NoRData())
+        end
+        return out, nodiff_reduction_kw_pb!!
     end
 end
 
@@ -1781,9 +1798,11 @@ end
 # `init` is treated as a non-differentiated constant: Julia requires it to be a
 # neutral element, and GPUArrays folds it into a backend-defined number of
 # partial reductions, so a derivative through it is not well-defined; the frule
-# rejects a nonzero `init` tangent instead. `init` also sets the output eltype
-# (GPUArrays takes it from typeof(init), so init=0.0 on a Float32 array gives a
-# Float64 result), hence the output-typed zero seeding the tangent reduction.
+# rejects a nonzero `init` tangent instead. Reverse mode gets no such signal, so
+# `dx` is correct and `init`'s component is silently zero. `init` also sets the
+# output eltype (GPUArrays takes it from typeof(init), so init=0.0 on a Float32
+# array gives a Float64 result), hence the output-typed zero seeding the tangent
+# reduction.
 @is_primitive(
     MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(sum),CuMaybeComplexArray}
 )

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1138,7 +1138,12 @@ function _prod_exclusive(px, dims, kw)
     pnz = prod(nonzero; kw...)
     nzeros = sum(iszero.(px); dims=dims)
     contributes = ifelse.(iszero.(px), nzeros .== 1, iszero.(nzeros))
-    return ifelse.(contributes, pnz ./ nonzero, zero(T))
+    # `pnz` follows `init`'s type when there is one, since GPUArrays takes the output eltype
+    # from it, so the zero has to come from the quotient rather than from either side: `T`
+    # would join two eltypes into an `AbstractFloat` the kernel cannot hold, and `eltype(pnz)`
+    # would do the same the other way round when `init` is the narrower of the two.
+    q = pnz ./ nonzero
+    return ifelse.(contributes, q, zero(eltype(q)))
 end
 
 @is_primitive(MinimalCtx, Tuple{typeof(prod),CuMaybeComplexArray})

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -3271,7 +3271,10 @@ function rrule!!(
     dx = tangent(x)
     dy_cpu = Array(zero(primal(x)))  # output fdata, accumulated into by downstream
     function array_pb!!(::NoRData)
-        dx .+= cu(dy_cpu)            # transfer gradient back to GPU in-place
+        # `cu` is an adaptor, not a transfer: it narrows Float64 to Float32 and ComplexF64
+        # to ComplexF32. The primal is an exact same-eltype copy, so its adjoint has to be
+        # one too; `similar(dx)` also matches dx's memory kind.
+        dx .+= copyto!(similar(dx), dy_cpu)
         return NoRData(), NoRData()
     end
     return CoDual(Array(primal(x)), dy_cpu), array_pb!!

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1034,6 +1034,7 @@ function frule!!(
     x::Dual{<:CuMaybeComplexArray},
 )
     pkw = primal(kw)
+    _check_reduction_identity(prod, pkw)
     _check_reduction_init(tangent(kw))
     px, dx = arrayify(x)
     dims = get(pkw, :dims, :)
@@ -1050,6 +1051,7 @@ function rrule!!(
     x::CoDual{<:CuMaybeComplexArray},
 )
     pkw = primal(kw)
+    _check_reduction_identity(prod, pkw)
     kw_rdata = zero_rdata(pkw)
     px, dx = arrayify(x)
     dims = get(pkw, :dims, :)
@@ -1324,6 +1326,28 @@ end
 # This covers sum and prod, whose `init` folding is what makes the derivative undefined, and
 # diff/sort/sortperm, which take no `init` at all.  maximum and minimum are idempotent, so
 # their `init` derivative survives the folding exactly; they get it below.
+# `sum` and `prod` fold `init` into a backend-defined number of partial reductions, and + and
+# * are not idempotent, so anything but the identity changes the result itself:
+# sum(CuArray([1, 2, 3]); init=1.0) is 101.0, not 7.0, and prod(…; init=2.0) is 2.4e29, not
+# 12.  Neither that value nor a derivative through it is defined, so both modes refuse it.
+# Unlike the tangent check below, this reads the value, which reverse mode can also see.
+# maximum/minimum need no such guard: max and min are idempotent, so their fold is exact and
+# a non-identity `init` is the point of passing one.
+_reduction_identity(::typeof(sum)) = 0
+_reduction_identity(::typeof(prod)) = 1
+_reduction_identity(_) = nothing
+function _check_reduction_identity(f, pkw)
+    identity = _reduction_identity(f)
+    (identity === nothing || !haskey(pkw, :init) || pkw.init == identity) && return nothing
+    return _throw_gpu_argument_error(
+        "Mooncake: $f over CuArray was given init=$(pkw.init), which is not its identity " *
+        "($identity). GPUArrays folds `init` into a backend-defined number of partial " *
+        "reductions, so the result itself is undefined — sum(CuArray([1, 2, 3]); init=1.0) " *
+        "returns 101.0, not 7.0. Pass the identity, or add `init` to the array instead. " *
+        _UNIMPL_MSG,
+    )
+end
+
 function _check_reduction_init(dkw)
     dinit = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
     (dinit isa NoTangent || iszero(dinit)) && return nothing
@@ -1345,6 +1369,7 @@ for _fn in (:sum, :prod, :diff, :sort, :sortperm)
         ::Dual{typeof($_fn)},
         x::Dual{<:CuNonDiffArray},
     )
+        _check_reduction_identity($_fn, primal(kw))
         _check_reduction_init(tangent(kw))
         y = $_fn(primal(x); primal(kw)...)
         return Dual(y, zero_tangent(y))
@@ -1356,6 +1381,7 @@ for _fn in (:sum, :prod, :diff, :sort, :sortperm)
         x::CoDual{<:CuNonDiffArray},
     )
         pkw = primal(kw)
+        _check_reduction_identity($_fn, pkw)
         kw_rdata = zero_rdata(pkw)
         y = $_fn(primal(x); pkw...)
         # `::Any`: the output is an Integer without `init` and a float with one, so the
@@ -2051,6 +2077,7 @@ function frule!!(
     x::Dual{<:CuMaybeComplexArray},
 )
     pkw = primal(kw)
+    _check_reduction_identity(sum, pkw)
     _check_reduction_init(tangent(kw))
     px, dx = arrayify(x)
     y = sum(px; pkw...)
@@ -2063,6 +2090,7 @@ function rrule!!(
     x::CoDual{<:CuMaybeComplexArray},
 )
     pkw = primal(kw)
+    _check_reduction_identity(sum, pkw)
     kw_rdata = zero_rdata(pkw)
     px, dx = arrayify(x)
     y = sum(px; pkw...)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -29,7 +29,7 @@ using CUDA: CUDACore
 using CUDA: cuBLAS
 using CUDA: cuSPARSE
 using CUDA: cuSOLVER
-using CUDA.CUDACore.GPUArrays: unsafe_free!
+using CUDA.CUDACore.GPUArrays: derive, unsafe_free!
 using Base.Broadcast: Broadcasted
 # Statistics is a weakdep triggering this extension alongside CUDA; always loaded
 # transitively via GPUArrays anyway, just needed for Aqua's stale-deps check.
@@ -597,9 +597,42 @@ function rrule!!(
     return CoDual(reshape(primal(x), _dims), reshape(x.dx, _dims)), _nopb(Val(3))
 end
 
-# `_new_` rules for the DataRef-based inner CuArray constructor (used by views and
-# similar operations). The tangent reuses the DataRef from the input tangent so that
-# gradient accumulation propagates automatically.
+# GPUArrays.derive is the single funnel for `view`, `reshape` and both `reinterpret`
+# spellings. Claiming it keeps the derivation on the arrays, where the offset it adds is
+# relative to whichever array it is handed, so the tangent is sliced from its own base. The
+# `_new_` rules below cannot do that: they see the primal's offset already resolved against
+# the primal's allocation, while a tangent from `zero_tangent` starts at offset 0, and
+# applying one to the other lands `x.offset` bytes too far in — silently shifted while it
+# stays inside the buffer, and writing into whatever the pool handed out next once it does
+# not. The derived tangent shares the source tangent's DataRef, so accumulation into a view
+# reaches the parent's tangent and the pullback has nothing to do.
+@is_primitive(MinimalCtx, Tuple{typeof(derive),Type,CuMaybeComplexArray,Dims,Int})
+function frule!!(
+    ::Dual{typeof(derive)},
+    ::Dual{Type{T}},
+    a::Dual{<:CuMaybeComplexArray},
+    dims::Dual,
+    offset::Dual,
+) where {T}
+    pa, da = arrayify(a)
+    d, o = primal(dims), primal(offset)
+    return Dual(derive(T, pa, d, o), derive(T, da, d, o))
+end
+function rrule!!(
+    ::CoDual{typeof(derive)},
+    ::CoDual{Type{T}},
+    a::CoDual{<:CuMaybeComplexArray},
+    dims::CoDual,
+    offset::CoDual,
+) where {T}
+    pa, da = arrayify(a)
+    d, o = primal(dims), primal(offset)
+    return CoDual(derive(T, pa, d, o), derive(T, da, d, o)), _nopb(Val(5))
+end
+
+# `_new_` rules for the DataRef-based inner CuArray constructor. Correct for the offset-0
+# constructions that remain once `derive` is claimed above; see the note there for why an
+# offset resolved against the primal's allocation cannot be applied to a tangent's.
 function frule!!(
     ::Dual{typeof(_new_)},
     ::Dual{Type{P}},

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1917,11 +1917,14 @@ end
 # unsafe_free! releases GPU memory early (normally handled by GC finalizer).
 # It is a pure side-effect with no mathematical output — gradient is zero.
 #
-# The primal and its fdata are independent allocations with different lifetimes, and only
-# forward mode may free both: there the tangent travels with the primal and dies with it.  In
-# reverse mode the fdata is the accumulator that the pullbacks of *earlier* operations write
-# into, long after the forward sweep reaches this call, so freeing it hands the reverse pass a
-# freed reference.  Reverse therefore frees the primal only, and gives up half the saving.
+# Only forward mode may free anything: there the tangent travels with the primal and dies with
+# it.  Reverse mode frees neither, because the reverse sweep runs long after the forward sweep
+# reaches this call and may reference both.  The fdata is the accumulator earlier pullbacks
+# write into.  The primal is no safer: pullbacks close over it routinely — this extension's own
+# gather keeps the index array to scatter with, and the non-differentiable `unsafe_copyto!`
+# rule keeps its destination to restore — so `CuArray([1, 2, 3])` freed after use took the
+# reverse pass through `view` on released memory.  Reverse therefore gives up the saving
+# entirely; it is a memory hint, and doing nothing is the only sound reading of it here.
 @is_primitive MinimalCtx Tuple{typeof(unsafe_free!),CuArray}
 function frule!!(::Dual{typeof(unsafe_free!)}, x::Dual{<:CuArray})
     unsafe_free!(primal(x))
@@ -1932,9 +1935,8 @@ function frule!!(::Dual{typeof(unsafe_free!)}, x::Dual{<:CuArray})
     dx isa CuArray && unsafe_free!(dx)
     return Dual(nothing, NoTangent())
 end
-function rrule!!(::CoDual{typeof(unsafe_free!)}, x::CoDual{<:CuArray})
-    unsafe_free!(primal(x))
-    return CoDual(nothing, NoFData()), _nopb(Val(2))
+function rrule!!(::CoDual{typeof(unsafe_free!)}, ::CoDual{<:CuArray})
+    CoDual(nothing, NoFData()), _nopb(Val(2))
 end
 
 # Core.finalizer(f, x) registers f as a GC finalizer for x. This is a pure side-effect

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -92,8 +92,12 @@ import Mooncake.TestUtils:
 const CuFloatArray = CuArray{<:IEEEFloat}
 const CuComplexArray = CuArray{<:Complex{<:IEEEFloat}}
 const CuMaybeComplexArray = Union{CuFloatArray,CuComplexArray}
-# Index and mask arrays. A whitelist: an eltype outside it whose tangent_type is
-# NoTangent (Char, Symbol, Enum) still falls through to the struct handler.
+# Index and mask arrays. Deliberately a whitelist rather than a predicate on
+# tangent_type(eltype), which cannot be written as a dispatch signature without also
+# capturing the differentiable eltypes handled above. An eltype outside it whose
+# derivative is nonetheless structurally zero (Char, Symbol, Enum) therefore falls to the
+# generic struct handler, which fails building CuArray's inner DataRef; extend the union
+# if such a case turns up.
 const CuNonDiffArray = CuArray{<:Union{Integer,Bool,CartesianIndex}}
 
 # Without these overloads the generic struct handler would recurse into CuMaybeComplexArray's
@@ -1079,6 +1083,13 @@ function rrule!!(::CoDual{typeof(sum)}, x::CoDual{<:CuMaybeComplexArray})
     return zero_fcodual(sum(primal(x))), sum_pb!!
 end
 
+# Summing an index or mask array has no derivative at all: the array has no tangent and
+# the result is an Integer.  Without a rule it decomposes onto one of GPUArrays'
+# untraceable reduction paths, which one depending on spelling and eltype.  Both spellings
+# need claiming, as the positional claim does not cover Core.kwcall.
+@zero_derivative MinimalCtx Tuple{typeof(sum),CuNonDiffArray}
+@zero_derivative MinimalCtx Tuple{typeof(Core.kwcall),NamedTuple,typeof(sum),CuNonDiffArray}
+
 # Rule for `unsafe_copyto!(dest, doffs, src, soffs, n)` on GPU arrays.
 # This function contains try/catch blocks (UpsilonNodes) from `context!(...)` that
 # Mooncake cannot trace. It implements a GPU memcpy — the gradient is identity:
@@ -1570,15 +1581,17 @@ end
 @is_primitive(MinimalCtx, Tuple{typeof(mapreduce),Any,Any,CuArray})
 function frule!!(::Dual{typeof(mapreduce)}, f::Dual, op::Dual, x::Dual{<:CuArray})
     return _throw_gpu_argument_error(
-        "Mooncake: mapreduce on CuArray only supports op=+ or op=Base.add_sum; " *
-        "got op=$(primal(op)). " *
+        "Mooncake: mapreduce on CuArray only supports op=+ or op=Base.add_sum over " *
+        "float or complex arrays; got op=$(primal(op)) over " *
+        "$(eltype(primal(x))). " *
         _UNIMPL_MSG,
     )
 end
 function rrule!!(::CoDual{typeof(mapreduce)}, f::CoDual, op::CoDual, x::CoDual{<:CuArray})
     return _throw_gpu_argument_error(
-        "Mooncake: mapreduce on CuArray only supports op=+ or op=Base.add_sum; " *
-        "got op=$(primal(op)). " *
+        "Mooncake: mapreduce on CuArray only supports op=+ or op=Base.add_sum over " *
+        "float or complex arrays; got op=$(primal(op)) over " *
+        "$(eltype(primal(x))). " *
         _UNIMPL_MSG,
     )
 end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1342,6 +1342,52 @@ for _fn in (:maximum, :minimum, :diff, :sort)
     @eval rrule!!(f::CoDual{typeof($_fn)}, x::CoDual{<:CuNonDiffArray}) = zero_adjoint(f, x)
 end
 
+# The scans over such an array are zero-derivative for the same reason, whatever the operator
+# accumulates: the array carries no derivative, so nothing built from it does either.  Without
+# these, `x[cumsum(idx)]` decomposed onto the untraceable scan kernel, and `cumprod(idx)` —
+# which lowers to `accumulate(*, …)` — reported the accumulate rule's operator restriction as
+# though the operator were the problem.  cumsum and cumprod have no catch-all error rules to
+# be ambiguous with, so they can use the macro; accumulate does, hence the manual spelling.
+@zero_derivative MinimalCtx Tuple{typeof(cumsum),CuNonDiffArray}
+@zero_derivative MinimalCtx Tuple{typeof(cumprod),CuNonDiffArray}
+@zero_derivative MinimalCtx Tuple{
+    typeof(Core.kwcall),NamedTuple,typeof(cumsum),CuNonDiffArray
+}
+@zero_derivative MinimalCtx Tuple{
+    typeof(Core.kwcall),NamedTuple,typeof(cumprod),CuNonDiffArray
+}
+@is_primitive(MinimalCtx, Tuple{typeof(accumulate),Any,CuNonDiffArray})
+function frule!!(f::Dual{typeof(accumulate)}, op::Dual, x::Dual{<:CuNonDiffArray})
+    zero_derivative(f, op, x)
+end
+function rrule!!(f::CoDual{typeof(accumulate)}, op::CoDual, x::CoDual{<:CuNonDiffArray})
+    zero_adjoint(f, op, x)
+end
+@is_primitive(
+    MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(accumulate),Any,CuNonDiffArray}
+)
+function frule!!(
+    ::Dual{typeof(Core.kwcall)},
+    kw::Dual{<:NamedTuple},
+    ::Dual{typeof(accumulate)},
+    op::Dual,
+    x::Dual{<:CuNonDiffArray},
+)
+    y = accumulate(primal(op), primal(x); primal(kw)...)
+    return Dual(y, zero_tangent(y))
+end
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    kw::CoDual{<:NamedTuple},
+    ::CoDual{typeof(accumulate)},
+    op::CoDual,
+    x::CoDual{<:CuNonDiffArray},
+)
+    y = accumulate(primal(op), primal(x); primal(kw)...)
+    accumulate_nodiff_kw_pb!!(::Any) = ntuple(_ -> NoRData(), 5)
+    return zero_fcodual(y), accumulate_nodiff_kw_pb!!
+end
+
 # `count` returns an Integer for every array, float included, so it never has a derivative.
 # It reaches GPUArrays through `mapreduce(pred, add_sum, A; init=0)`, a Core.kwcall the
 # positional mapreduce catch-all does not claim, so claim `count` itself.

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -95,7 +95,6 @@ import Mooncake.TestUtils:
 const CuFloatArray = CuArray{<:IEEEFloat}
 const CuComplexArray = CuArray{<:Complex{<:IEEEFloat}}
 const CuMaybeComplexArray = Union{CuFloatArray,CuComplexArray}
-const CuMaybeComplexVector = Union{CuArray{<:IEEEFloat,1},CuArray{<:Complex{<:IEEEFloat},1}}
 # Index and mask arrays. Deliberately a whitelist rather than a predicate on
 # tangent_type(eltype), which cannot be written as a dispatch signature without also
 # capturing the differentiable eltypes handled above. An eltype outside it whose
@@ -2102,12 +2101,21 @@ end
 # every bit as differentiable, and `rdata_type` applied to a primal type throws inside
 # `fields_type` — which is what used to reach the user in place of this message.
 function _throw_gpu_unthreaded(T, spelling, noun)
+    # A float range is the one refusal here with an easy remedy, and the one users are most
+    # likely to hit: the range itself is usually constant, but it may be built from
+    # differentiated endpoints, and nothing at this point can tell the two apart.
+    hint = if T <: AbstractRange
+        "Materialise the range first — `x .* CuArray(collect(r))` — or, if its endpoints " *
+        "carry no derivative, use an integer range, which is threaded as a constant. "
+    else
+        "Pass captured state as an argument instead — `((t, c) -> c * t).(x, a)` " *
+        "differentiates correctly — or write a rule for the enclosing operation. "
+    end
     return _throw_gpu_argument_error(
         "Mooncake: $spelling over CuArray does not support $noun of type $T. Partials are " *
         "threaded through GPU array elements and real or complex float scalars only, so " *
-        "this one's gradient would silently be zero. Pass captured state as an argument " *
-        "instead — `((t, c) -> c * t).(x, a)` differentiates correctly — or write a rule " *
-        "for the enclosing operation. " *
+        "this one's gradient would silently be zero. " *
+        hint *
         _UNIMPL_MSG,
     )
 end
@@ -3371,12 +3379,12 @@ end
 # vector, while these rules put the argument's own fdata in that slot and the pullback
 # returns nothing on the assumption `.diag === v`. The matrix spelling decomposes through
 # `diag`, which carries the gradient back to the right elements.
-@is_primitive(MinimalCtx, Tuple{Type{<:Diagonal},CuMaybeComplexVector})
-function frule!!(::Dual{<:Type{<:Diagonal}}, v::Dual{<:CuMaybeComplexVector})
+@is_primitive(MinimalCtx, Tuple{Type{<:Diagonal},CuMaybeComplexVec})
+function frule!!(::Dual{<:Type{<:Diagonal}}, v::Dual{<:CuMaybeComplexVec})
     # Diagonal is a non-mutable struct; its tangent type is Tangent{(; diag::CuArray)}.
     return Dual(Diagonal(primal(v)), Tangent((; diag=tangent(v))))
 end
-function rrule!!(::CoDual{<:Type{<:Diagonal}}, v::CoDual{<:CuMaybeComplexVector})
+function rrule!!(::CoDual{<:Type{<:Diagonal}}, v::CoDual{<:CuMaybeComplexVec})
     pv, dv = arrayify(v)
     # `Diagonal(v).diag === v`, so the aliasing invariant — primal(a) === primal(b) implies
     # fdata(a) === fdata(b) — requires the output's `.diag` fdata to *be* v's.  Accumulating a
@@ -3619,8 +3627,12 @@ end
 @inline function _gpu_write_broadcast_primal!(dest, out, is_diff::Bool)
     if is_diff
         broadcast!(Nfwd._nfwd_dual_value, dest, out)
-    else
+    elseif out isa AbstractArray
         copyto!(dest, out)
+    else
+        # `x .= 1` seeds no dual, so the kernel hands back the scalar itself; `copyto!`
+        # would iterate it and set one element by scalar indexing.
+        fill!(dest, out)
     end
     return dest
 end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -50,7 +50,10 @@ import Mooncake:
     primal,
     tangent,
     lgetfield,
+    zero_adjoint,
+    zero_derivative,
     zero_fcodual,
+    zero_tangent,
     zero_tangent_internal,
     randn_tangent_internal,
     increment_internal!!,
@@ -1083,12 +1086,75 @@ function rrule!!(::CoDual{typeof(sum)}, x::CoDual{<:CuMaybeComplexArray})
     return zero_fcodual(sum(primal(x))), sum_pb!!
 end
 
-# Summing an index or mask array has no derivative at all: the array has no tangent and
-# the result is an Integer.  Without a rule it decomposes onto one of GPUArrays'
-# untraceable reduction paths, which one depending on spelling and eltype.  Both spellings
-# need claiming, as the positional claim does not cover Core.kwcall.
+# Reductions over an index or mask array have no derivative: the array has no tangent and
+# the result is an Integer.  Without a rule they decompose onto one of GPUArrays'
+# untraceable reduction paths, which one depending on spelling and eltype.
+#
+# `maximum`/`minimum` cannot use @zero_derivative: it generates `CoDual{<:typeof(f)}`,
+# which is equal in extent to their catch-all error rules' `CoDual{typeof(f)}` but not
+# comparable with it, so the two would be ambiguous.  Spelling the signature the same way
+# lets the narrower array type decide, leaving those rules to report float arrays.
 @zero_derivative MinimalCtx Tuple{typeof(sum),CuNonDiffArray}
-@zero_derivative MinimalCtx Tuple{typeof(Core.kwcall),NamedTuple,typeof(sum),CuNonDiffArray}
+@zero_derivative MinimalCtx Tuple{typeof(prod),CuNonDiffArray}
+for _fn in (:maximum, :minimum)
+    @eval @is_primitive(MinimalCtx, Tuple{typeof($_fn),CuNonDiffArray})
+    @eval frule!!(f::Dual{typeof($_fn)}, x::Dual{<:CuNonDiffArray}) = zero_derivative(f, x)
+    @eval rrule!!(f::CoDual{typeof($_fn)}, x::CoDual{<:CuNonDiffArray}) = zero_adjoint(f, x)
+end
+
+# `count` returns an Integer for every array, float included, so it never has a derivative.
+# It reaches GPUArrays through `mapreduce(pred, add_sum, A; init=0)`, a Core.kwcall the
+# positional mapreduce catch-all does not claim, so claim `count` itself.
+@zero_derivative MinimalCtx Tuple{typeof(count),CuArray}
+@zero_derivative MinimalCtx Tuple{typeof(count),Any,CuArray}
+@zero_derivative MinimalCtx Tuple{typeof(Core.kwcall),NamedTuple,typeof(count),CuArray}
+@zero_derivative MinimalCtx Tuple{typeof(Core.kwcall),NamedTuple,typeof(count),Any,CuArray}
+
+# The keyword spellings cannot be zero-derivative outright: a float `init` makes the output
+# differentiable, so dropping its derivative would be silently wrong.  Nor is it 1 —
+# GPUArrays folds `init` into a backend-defined number of partial reductions, so
+# `init=1.0` over `[1,2,3]` gives 101.0 — so a nonzero `init` tangent is rejected.  Only
+# the frules can check it; reverse mode has no incoming `init` tangent.
+function _check_reduction_init(dkw)
+    dinit = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
+    (dinit isa NoTangent || iszero(dinit)) && return nothing
+    return _throw_gpu_argument_error(
+        "Mooncake: keyword reductions over CuArray treat `init` as a constant, but it " *
+        "received a nonzero tangent. Differentiating with respect to `init` is not " *
+        "supported. " *
+        _UNIMPL_MSG,
+    )
+end
+
+for _fn in (:sum, :prod, :maximum, :minimum)
+    @eval @is_primitive(
+        MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof($_fn),CuNonDiffArray}
+    )
+    @eval function frule!!(
+        ::Dual{typeof(Core.kwcall)},
+        kw::Dual{<:NamedTuple},
+        ::Dual{typeof($_fn)},
+        x::Dual{<:CuNonDiffArray},
+    )
+        _check_reduction_init(tangent(kw))
+        y = $_fn(primal(x); primal(kw)...)
+        return Dual(y, zero_tangent(y))
+    end
+    @eval function rrule!!(
+        ::CoDual{typeof(Core.kwcall)},
+        kw::CoDual{<:NamedTuple},
+        ::CoDual{typeof($_fn)},
+        x::CoDual{<:CuNonDiffArray},
+    )
+        pkw = primal(kw)
+        kw_rdata = zero_rdata(pkw)
+        y = $_fn(primal(x); pkw...)
+        # `::Any`: the output is an Integer without `init` and a float with one, so the
+        # incoming rdata is NoRData or a number depending on the call.
+        nodiff_reduction_kw_pb!!(::Any) = (NoRData(), kw_rdata, NoRData(), NoRData())
+        return zero_fcodual(y), nodiff_reduction_kw_pb!!
+    end
+end
 
 # Rule for `unsafe_copyto!(dest, doffs, src, soffs, n)` on GPU arrays.
 # This function contains try/catch blocks (UpsilonNodes) from `context!(...)` that
@@ -1209,9 +1275,7 @@ end
 # re-running the rule would see a different array.
 #
 # CuNonDiffArray is disjoint from CuMaybeComplexArray and CuMaybeWrappedArray, so these
-# claims are unambiguous with the rules above, and it is exactly what they can serve: an
-# eltype off the whitelist has no NoTangent tangent, so claiming it would only turn a
-# trace failure into a MethodError.
+# claims are unambiguous with the rules above and cover exactly what they can serve.
 #
 # Note the asymmetry in `src`: a CPU Array{Int} has fdata Vector{NoTangent}, and only the
 # CuArray side collapses to NoTangent, so `src`'s tangent is left unconstrained.
@@ -1618,10 +1682,9 @@ end
 #
 # repeat places the copy of x[i] for inner offset k and outer offset o at
 # k + (i-1)*I + (o-1)*I*S along each dimension, which is exactly column-major
-# (inner, size, outer).  So the pullback reshapes the cotangent into those triples and
-# sums the inner and outer axes away — reshape plus a dims-reduction, with no scalar
-# indexing.  ChainRules instead loops over `pairs(IndexCartesian(), dY)` for the keyword
-# form, which cannot run on a device.
+# (inner, size, outer), so reshaping into those triples and summing the inner and outer
+# axes needs no scalar indexing.  ChainRules instead loops over
+# `pairs(IndexCartesian(), dY)` for the keyword form, which cannot run on a device.
 #
 # `counts` may be shorter than ndims(x) (padded with 1) or longer (the result gains
 # dimensions), so sizes are padded to ndims of the output and the result reshaped back.
@@ -1725,16 +1788,7 @@ function frule!!(
     x::Dual{<:CuMaybeComplexArray},
 )
     pkw = primal(kw)
-    dkw = tangent(kw)
-    dinit = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
-    if !(dinit isa NoTangent) && !iszero(dinit)
-        _throw_gpu_argument_error(
-            "Mooncake: keyword sum on CuArray treats `init` as a constant, but it " *
-            "received a nonzero tangent. Differentiating with respect to `init` is " *
-            "not supported. " *
-            _UNIMPL_MSG,
-        )
-    end
+    _check_reduction_init(tangent(kw))
     px, dx = arrayify(x)
     y = sum(px; pkw...)
     return Dual(y, sum(dx; dims=get(pkw, :dims, :), init=zero(eltype(y))))

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -861,6 +861,22 @@ _winner(i::CartesianIndex) = Ref(i)
 _winner(i::AbstractArray{<:CartesianIndex}) = i
 _winner(i::AbstractArray{<:Integer}) = CartesianIndex.(i)
 
+# `init` competes with the elements rather than seeding an accumulator, so it takes the
+# whole derivative of every reduced slice it beats.  Unlike `sum`, whose `init` derivative
+# is backend-defined because GPUArrays folds it into each partial reduction, max and min are
+# idempotent, so the folding is invisible and this derivative is exact.  A tie counts as a
+# win for the array, matching how findmax breaks ties.
+_minmax_init_tangent(dkw) = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
+_minmax_init_jvp(dy, ::NoTangent, won) = dy
+_minmax_init_jvp(dy, dinit::Number, won) = dy .+ dinit .* .!won
+# Takes dy rather than a finished cotangent so that a call with no differentiable `init`
+# never launches the reduction.  `sum` also covers the scalar branch, where dy is a number.
+_minmax_init_rdata(kw_rdata::NoRData, dy, won) = kw_rdata
+function _minmax_init_rdata(kw_rdata::NamedTuple, dy, won)
+    (haskey(kw_rdata, :init) && !(kw_rdata.init isa NoRData)) || return kw_rdata
+    return merge(kw_rdata, (; init=oftype(kw_rdata.init, sum(dy .* .!won))))
+end
+
 for (_fn, _find) in ((:maximum, :findmax), (:minimum, :findmin))
     @eval @is_primitive(MinimalCtx, Tuple{typeof($_fn),CuFloatArray})
     @eval @is_primitive(
@@ -882,6 +898,9 @@ for (_fn, _find) in ((:maximum, :findmax), (:minimum, :findmin))
         return CoDual(y, NoFData()), minmax_pb!!
     end
 
+    # The value comes from the primal call, not from findmax, which reads only `dims`: an
+    # `init` that beats every element leaves the result independent of x, and an unsupported
+    # keyword has to raise the primal's own MethodError.  findmax supplies just the argmax.
     @eval function frule!!(
         ::Dual{typeof(Core.kwcall)},
         kw::Dual{<:NamedTuple},
@@ -891,8 +910,11 @@ for (_fn, _find) in ((:maximum, :findmax), (:minimum, :findmin))
         pkw = primal(kw)
         px, dx = arrayify(x)
         dims = get(pkw, :dims, :)
-        y, ind = $_find(px; dims=dims)
-        return Dual(y, sum(dx .* (CartesianIndices(px) .== _winner(ind)); dims=dims))
+        y = $_fn(px; pkw...)
+        m, ind = $_find(px; dims=dims)
+        won = m .== y
+        dy = sum(dx .* (CartesianIndices(px) .== _winner(ind)); dims=dims) .* won
+        return Dual(y, _minmax_init_jvp(dy, _minmax_init_tangent(tangent(kw)), won))
     end
     @eval function rrule!!(
         ::CoDual{typeof(Core.kwcall)},
@@ -901,20 +923,25 @@ for (_fn, _find) in ((:maximum, :findmax), (:minimum, :findmin))
         x::CoDual{<:CuFloatArray},
     )
         pkw = primal(kw)
+        kw_rdata = zero_rdata(pkw)
         px, dx = arrayify(x)
         dims = get(pkw, :dims, :)
-        y, ind = $_find(px; dims=dims)
+        y = $_fn(px; pkw...)
+        m, ind = $_find(px; dims=dims)
+        won = m .== y
         if dims isa Colon
             function minmax_kw_scalar_pb!!(dy)
-                dx .+= dy .* (CartesianIndices(px) .== _winner(ind))
-                return NoRData(), NoRData(), NoRData(), NoRData()
+                dx .+= dy .* (CartesianIndices(px) .== _winner(ind)) .* won
+                dkw = _minmax_init_rdata(kw_rdata, dy, won)
+                return NoRData(), dkw, NoRData(), NoRData()
             end
             return CoDual(y, NoFData()), minmax_kw_scalar_pb!!
         end
         dy_out = zero(y)
         function minmax_kw_array_pb!!(::NoRData)
-            dx .+= dy_out .* (CartesianIndices(px) .== _winner(ind))
-            return NoRData(), NoRData(), NoRData(), NoRData()
+            dx .+= dy_out .* (CartesianIndices(px) .== _winner(ind)) .* won
+            dkw = _minmax_init_rdata(kw_rdata, dy_out, won)
+            return NoRData(), dkw, NoRData(), NoRData()
         end
         return CoDual(y, dy_out), minmax_kw_array_pb!!
     end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -996,6 +996,53 @@ function rrule!!(::CoDual{typeof(prod)}, x::CoDual{<:CuMaybeComplexArray})
     return zero_fcodual(y), prod_pb!!
 end
 
+# `prod(x; dims)`: the same derivative per reduced slice, y_j/x_i for x_i in slice j, which
+# broadcasts because the reduced dimensions stay singleton.  The zero-element caveat is also
+# per slice, and nan_tangent_guard applies it without the bare rule's device→host sync: a
+# slice containing a zero has y_j == 0, so every term in it drops.  `init` multiplies into a
+# backend-defined number of partial reductions, so like `sum` it stays a constant.
+@is_primitive(
+    MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(prod),CuMaybeComplexArray}
+)
+function frule!!(
+    ::Dual{typeof(Core.kwcall)},
+    kw::Dual{<:NamedTuple},
+    ::Dual{typeof(prod)},
+    x::Dual{<:CuMaybeComplexArray},
+)
+    pkw = primal(kw)
+    _check_reduction_init(tangent(kw))
+    px, dx = arrayify(x)
+    y = prod(px; pkw...)
+    inv_px = nan_tangent_guard.(px, inv.(px))
+    return Dual(y, y .* sum(dx .* inv_px; dims=get(pkw, :dims, :)))
+end
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    kw::CoDual{<:NamedTuple},
+    ::CoDual{typeof(prod)},
+    x::CoDual{<:CuMaybeComplexArray},
+)
+    pkw = primal(kw)
+    kw_rdata = zero_rdata(pkw)
+    px, dx = arrayify(x)
+    y = prod(px; pkw...)
+    inv_cx_px = nan_tangent_guard.(px, inv.(conj.(px)))
+    if get(pkw, :dims, :) isa Colon
+        function prod_kw_scalar_pb!!(dy)
+            dx .+= dy .* conj.(y) .* inv_cx_px
+            return NoRData(), kw_rdata, NoRData(), NoRData()
+        end
+        return CoDual(y, NoFData()), prod_kw_scalar_pb!!
+    end
+    dy_out = zero(y)
+    function prod_kw_array_pb!!(::NoRData)
+        dx .+= dy_out .* conj.(y) .* inv_cx_px
+        return NoRData(), kw_rdata, NoRData(), NoRData()
+    end
+    return CoDual(y, dy_out), prod_kw_array_pb!!
+end
+
 # Rules for `cumsum(x)` on GPU arrays.
 #
 # y[k] = Σᵢ₌₁ᵏ x[i],  so ∂y[k]/∂x[i] = 1 if i≤k else 0
@@ -1058,6 +1105,35 @@ function rrule!!(::CoDual{typeof(cumprod)}, x::CoDual{<:CuMaybeComplexArray}; kw
     return CoDual(y, dy_out), cumprod_pb!!
 end
 
+# Mooncake lowers every keyword call to Core.kwcall, which the positional claims above do
+# not cover, so `cumsum(x; dims=1)` decomposed onto the untraceable kernel instead.  Base
+# requires `dims` for an array of more than one dimension, so those rules reached only
+# vectors.  The keyword-free bodies already take the keywords, hence the forwarding.
+for _fn in (:cumsum, :cumprod)
+    @eval @is_primitive(
+        MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof($_fn),CuMaybeComplexArray}
+    )
+    @eval function frule!!(
+        ::Dual{typeof(Core.kwcall)},
+        kw::Dual{<:NamedTuple},
+        f::Dual{typeof($_fn)},
+        x::Dual{<:CuMaybeComplexArray},
+    )
+        return frule!!(f, x; primal(kw)...)
+    end
+    @eval function rrule!!(
+        ::CoDual{typeof(Core.kwcall)},
+        kw::CoDual{<:NamedTuple},
+        f::CoDual{typeof($_fn)},
+        x::CoDual{<:CuMaybeComplexArray},
+    )
+        kw_rdata = zero_rdata(primal(kw))
+        y, pb = rrule!!(f, x; primal(kw)...)
+        cum_kw_pb!!(dy) = (NoRData(), kw_rdata, pb(dy)...)
+        return y, cum_kw_pb!!
+    end
+end
+
 # Rules for `accumulate(+, x)` — identical to cumsum but via the accumulate interface.
 # Other operators are not supported and throw an informative error (catch-all below).
 @is_primitive(MinimalCtx, Tuple{typeof(accumulate),typeof(+),CuMaybeComplexArray})
@@ -1095,6 +1171,53 @@ function rrule!!(::CoDual{typeof(accumulate)}, op::CoDual, x::CoDual{<:CuArray};
         "Mooncake: accumulate on CuArray only supports op=+; got op=$(primal(op)). " *
         _UNIMPL_MSG,
     )
+end
+# The Core.kwcall spellings of both, `accumulate(+, x; dims=1)` and its error arm.
+@is_primitive(
+    MinimalCtx,
+    Tuple{typeof(Core.kwcall),NamedTuple,typeof(accumulate),typeof(+),CuMaybeComplexArray},
+)
+function frule!!(
+    ::Dual{typeof(Core.kwcall)},
+    kw::Dual{<:NamedTuple},
+    f::Dual{typeof(accumulate)},
+    op::Dual{typeof(+)},
+    x::Dual{<:CuMaybeComplexArray},
+)
+    return frule!!(f, op, x; primal(kw)...)
+end
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    kw::CoDual{<:NamedTuple},
+    f::CoDual{typeof(accumulate)},
+    op::CoDual{typeof(+)},
+    x::CoDual{<:CuMaybeComplexArray},
+)
+    kw_rdata = zero_rdata(primal(kw))
+    y, pb = rrule!!(f, op, x; primal(kw)...)
+    accumulate_plus_kw_pb!!(dy) = (NoRData(), kw_rdata, pb(dy)...)
+    return y, accumulate_plus_kw_pb!!
+end
+@is_primitive(
+    MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(accumulate),Any,CuArray}
+)
+function frule!!(
+    ::Dual{typeof(Core.kwcall)},
+    ::Dual{<:NamedTuple},
+    f::Dual{typeof(accumulate)},
+    op::Dual,
+    x::Dual{<:CuArray},
+)
+    return frule!!(f, op, x)
+end
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    ::CoDual{<:NamedTuple},
+    f::CoDual{typeof(accumulate)},
+    op::CoDual,
+    x::CoDual{<:CuArray},
+)
+    return rrule!!(f, op, x)
 end
 
 # Rule for `sum(x)` — widened from CuFloatArray to also cover complex CuArrays.

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -3917,7 +3917,6 @@ end
 # Only the outermost function needs this. A cast nested inside the tree is materialized by
 # `_premat_nondiff_args` before the kernel ever sees it; the one at the top is the only one
 # that survives, because nothing materializes the tree's own root.
-_desugar_casts(x) = x
 function _desugar_casts(bc::Broadcasted{S}) where {S}
     bc.f isa Type ? Broadcasted{S}(_CastTo{bc.f}(), bc.args, bc.axes) : bc
 end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -739,10 +739,54 @@ end
 # reduces with `&` and hits the mapreduce catch-all.
 #
 # frule:    dy = dx[idx]          (gather tangents)
-# pullback: dx[idx] .+= dy_out   (scatter-add cotangents)
+# pullback: scatter-add the output cotangents back to the elements they were read from
 #
-# Note: repeated indices in idx are undefined (last write wins on GPU without atomics).
-# Distinct-index usage (e.g. embedding lookup, slicing) is safe.
+# A repeated index means several outputs read one element, so that element is owed the sum of
+# their cotangents.  `dx[idx] .+= dy` is a read-modify-write per output: where an index
+# repeats the reads race and a single contribution survives, silently.  An embedding lookup is
+# exactly a repeated gather, so this is scattered atomically instead.  `@atomic` has no
+# Complex method, so a complex buffer is scattered as its interleaved real and imaginary
+# halves, which are independent sums.
+function _gpu_scatter_add_kernel!(dx, lin, dy)
+    i = (CUDACore.blockIdx().x - 1) * CUDACore.blockDim().x + CUDACore.threadIdx().x
+    @inbounds if i <= length(lin)
+        CUDACore.@atomic dx[lin[i]] += dy[i]
+    end
+    return nothing
+end
+function _gpu_scatter_add_complex_kernel!(rdx, lin, rdy)
+    i = (CUDACore.blockIdx().x - 1) * CUDACore.blockDim().x + CUDACore.threadIdx().x
+    @inbounds if i <= length(lin)
+        j = lin[i]
+        CUDACore.@atomic rdx[2j - 1] += rdy[2i - 1]
+        CUDACore.@atomic rdx[2j] += rdy[2i]
+    end
+    return nothing
+end
+function _gpu_scatter_add!(dx, pidx, dy)
+    n = length(pidx)
+    iszero(n) && return dx
+    # The complex kernel indexes the reinterpreted halves arithmetically, so both paths take
+    # linear indices; a Cartesian index vector is converted once, on the device.
+    li = LinearIndices(size(dx))
+    idx_lin = eltype(pidx) <: Integer ? pidx : map(I -> li[I], pidx)
+    # The index vector may live on the host — `x[[1, 2, 3]]` is a perfectly ordinary
+    # spelling — and a kernel argument has to be on the device.
+    lin = idx_lin isa CuArray ? idx_lin : CuArray(idx_lin)
+    threads = min(n, 256)
+    blocks = cld(n, threads)
+    if eltype(dx) <: Complex
+        R = real(eltype(dx))
+        CUDACore.@cuda threads = threads blocks = blocks _gpu_scatter_add_complex_kernel!(
+            reinterpret(R, dx), lin, reinterpret(R, dy)
+        )
+    else
+        CUDACore.@cuda threads = threads blocks = blocks _gpu_scatter_add_kernel!(
+            dx, lin, dy
+        )
+    end
+    return dx
+end
 @is_primitive(
     MinimalCtx,
     Tuple{
@@ -767,7 +811,7 @@ function rrule!!(
     y = px[pidx]
     dy_out = zero(y)
     function getindex_pb!!(::NoRData)
-        dx[pidx] .+= dy_out
+        _gpu_scatter_add!(dx, pidx, dy_out)
         return NoRData(), NoRData(), NoRData()
     end
     return CoDual(y, dy_out), getindex_pb!!

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -102,6 +102,11 @@ const CuMaybeComplexArray = Union{CuFloatArray,CuComplexArray}
 # generic struct handler, which fails building CuArray's inner DataRef; extend the union
 # if such a case turns up.
 const CuNonDiffArray = CuArray{<:Union{Integer,Bool,CartesianIndex}}
+# `x .= 0f0` reaches the two-argument `materialize!` as a zero-dimensional Broadcasted: it is
+# handed the right-hand side's style alone, and the destination is combined in only inside
+# the three-argument method, so a scalar right-hand side never carries `CuArrayStyle`. A
+# `DefaultArrayStyle{N}` for N > 0 means host arrays are involved and stays out.
+const _GpuMaterializeStyle = Union{CuArrayStyle,Base.Broadcast.DefaultArrayStyle{0}}
 
 # Without these overloads the generic struct handler would recurse into CuMaybeComplexArray's
 # Julia-visible fields — wrong for GPU arrays.
@@ -4212,16 +4217,23 @@ end
 #
 # A broadcast into a wrapped `CuArray` still forms a `Broadcasted{CuArrayStyle}`, so a bare
 # `CuArray` bound left it to the interpreter, which died tracing the kernel launch.
+#
+# `x .= 0f0` is claimed here too, through `DefaultArrayStyle{0}`: the two-argument
+# materialize! is handed the right-hand side's style alone, and the destination is combined
+# in only inside the three-argument method below this claim, so a scalar right-hand side
+# never reaches `CuArrayStyle`. Its args are all scalars, so the kernel hands back a scalar
+# NDual, which the primal write and the JVP accumulation each broadcast over `dest`. A
+# `DefaultArrayStyle{N}` for N > 0 means host arrays are involved and stays out.
 @is_primitive(
     MinimalCtx,
     Tuple{
-        typeof(Base.Broadcast.materialize!),P,<:Broadcasted{<:CuArrayStyle}
+        typeof(Base.Broadcast.materialize!),P,<:Broadcasted{<:_GpuMaterializeStyle}
     } where {P<:CuMaybeWrappedArray},
 )
 function frule!!(
     ::Dual{typeof(Base.Broadcast.materialize!)},
     dest::Dual{P},
-    bc::Dual{<:Broadcasted{<:CuArrayStyle}},
+    bc::Dual{<:Broadcasted{<:_GpuMaterializeStyle}},
 ) where {P<:CuMaybeWrappedArray}
     bc_primal = primal(bc)
     _, flat_bc, flat_pargs, flat_ts = _prepare_gpu_broadcast(bc_primal, tangent(bc))
@@ -4251,7 +4263,7 @@ end
 function rrule!!(
     ::CoDual{typeof(Base.Broadcast.materialize!),NoFData},
     dest::CoDual{P},
-    bc::CoDual{<:Broadcasted{<:CuArrayStyle}},
+    bc::CoDual{<:Broadcasted{<:_GpuMaterializeStyle}},
 ) where {P<:CuMaybeWrappedArray}
     pout, dout = arrayify(dest)
     bc_primal = primal(bc)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -861,20 +861,22 @@ _winner(i::CartesianIndex) = Ref(i)
 _winner(i::AbstractArray{<:CartesianIndex}) = i
 _winner(i::AbstractArray{<:Integer}) = CartesianIndex.(i)
 
-# `init` competes with the elements rather than seeding an accumulator, so it takes the
-# whole derivative of every reduced slice it beats.  Unlike `sum`, whose `init` derivative
-# is backend-defined because GPUArrays folds it into each partial reduction, max and min are
-# idempotent, so the folding is invisible and this derivative is exact.  A tie counts as a
-# win for the array, matching how findmax breaks ties.
-_minmax_init_tangent(dkw) = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
-_minmax_init_jvp(dy, ::NoTangent, won) = dy
-_minmax_init_jvp(dy, dinit::Number, won) = dy .+ dinit .* .!won
+# Two of these reductions have an `init` whose derivative survives the backend's folding:
+# maximum/minimum, where it competes with the elements and takes the whole derivative of each
+# reduced slice it beats, and accumulate(+, …), where it adds to every element.  Both are
+# idempotent in the folding — unlike sum and prod, whose `init` is folded into a
+# backend-defined number of partial reductions, leaving it a constant.  `from_init` says
+# where `init` decided the output: a mask for max/min, `true` throughout for accumulate.  A
+# tie counts against `init`, matching how findmax breaks ties.
+_kw_init_tangent(dkw) = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
+_kw_init_jvp(dy, ::NoTangent, from_init) = dy
+_kw_init_jvp(dy, dinit::Number, from_init) = dy .+ dinit .* from_init
 # Takes dy rather than a finished cotangent so that a call with no differentiable `init`
 # never launches the reduction.  `sum` also covers the scalar branch, where dy is a number.
-_minmax_init_rdata(kw_rdata::NoRData, dy, won) = kw_rdata
-function _minmax_init_rdata(kw_rdata::NamedTuple, dy, won)
+_kw_init_rdata(kw_rdata::NoRData, dy, from_init) = kw_rdata
+function _kw_init_rdata(kw_rdata::NamedTuple, dy, from_init)
     (haskey(kw_rdata, :init) && !(kw_rdata.init isa NoRData)) || return kw_rdata
-    return merge(kw_rdata, (; init=oftype(kw_rdata.init, sum(dy .* .!won))))
+    return merge(kw_rdata, (; init=oftype(kw_rdata.init, sum(dy .* from_init))))
 end
 # findmax answers `dims` and nothing else, so those calls keep the plain argmax path.
 _minmax_kw_is_plain(::NamedTuple{K}) where {K} = K === () || K === (:dims,)
@@ -922,8 +924,7 @@ for (_fn, _find, _beat) in ((:maximum, :findmax, :<), (:minimum, :findmin, :>))
         won = .!broadcast($_beat, m, y)
         dy = sum(dx .* (CartesianIndices(px) .== _winner(ind)); dims=dims)
         return Dual(
-            y,
-            _minmax_init_jvp(eltype(y).(dy) .* won, _minmax_init_tangent(tangent(kw)), won),
+            y, _kw_init_jvp(eltype(y).(dy) .* won, _kw_init_tangent(tangent(kw)), .!won)
         )
     end
     @eval function rrule!!(
@@ -946,7 +947,7 @@ for (_fn, _find, _beat) in ((:maximum, :findmax, :<), (:minimum, :findmin, :>))
         if dims isa Colon
             function minmax_kw_scalar_pb!!(dy)
                 dx .+= dy .* (CartesianIndices(px) .== _winner(ind)) .* won
-                dkw = _minmax_init_rdata(kw_rdata, dy, won)
+                dkw = _kw_init_rdata(kw_rdata, dy, .!won)
                 return NoRData(), dkw, NoRData(), NoRData()
             end
             return CoDual(y, NoFData()), minmax_kw_scalar_pb!!
@@ -954,7 +955,7 @@ for (_fn, _find, _beat) in ((:maximum, :findmax, :<), (:minimum, :findmin, :>))
         dy_out = zero(y)
         function minmax_kw_array_pb!!(::NoRData)
             dx .+= dy_out .* (CartesianIndices(px) .== _winner(ind)) .* won
-            dkw = _minmax_init_rdata(kw_rdata, dy_out, won)
+            dkw = _kw_init_rdata(kw_rdata, dy_out, .!won)
             return NoRData(), dkw, NoRData(), NoRData()
         end
         return CoDual(y, dy_out), minmax_kw_array_pb!!
@@ -1190,7 +1191,10 @@ function rrule!!(::CoDual{typeof(accumulate)}, op::CoDual, x::CoDual{<:CuArray};
         _UNIMPL_MSG,
     )
 end
-# The Core.kwcall spellings of both, `accumulate(+, x; dims=1)` and its error arm.
+# The Core.kwcall spellings of both, `accumulate(+, x; dims=1)` and its error arm.  These do
+# not forward to the rules above because `accumulate` takes an `init` that cumsum does not:
+# it adds to every output element, so it collects the whole cotangent, and it widens the
+# output eltype, which the tangent has to follow.
 @is_primitive(
     MinimalCtx,
     Tuple{typeof(Core.kwcall),NamedTuple,typeof(accumulate),typeof(+),CuMaybeComplexArray},
@@ -1198,23 +1202,36 @@ end
 function frule!!(
     ::Dual{typeof(Core.kwcall)},
     kw::Dual{<:NamedTuple},
-    f::Dual{typeof(accumulate)},
-    op::Dual{typeof(+)},
+    ::Dual{typeof(accumulate)},
+    ::Dual{typeof(+)},
     x::Dual{<:CuMaybeComplexArray},
 )
-    return frule!!(f, op, x; primal(kw)...)
+    pkw = primal(kw)
+    px, dx = arrayify(x)
+    y = accumulate(+, px; pkw...)
+    dy = eltype(y).(cumsum(dx; dims=get(pkw, :dims, 1)))
+    return Dual(y, _kw_init_jvp(dy, _kw_init_tangent(tangent(kw)), true))
 end
 function rrule!!(
     ::CoDual{typeof(Core.kwcall)},
     kw::CoDual{<:NamedTuple},
-    f::CoDual{typeof(accumulate)},
-    op::CoDual{typeof(+)},
+    ::CoDual{typeof(accumulate)},
+    ::CoDual{typeof(+)},
     x::CoDual{<:CuMaybeComplexArray},
 )
-    kw_rdata = zero_rdata(primal(kw))
-    y, pb = rrule!!(f, op, x; primal(kw)...)
-    accumulate_plus_kw_pb!!(dy) = (NoRData(), kw_rdata, pb(dy)...)
-    return y, accumulate_plus_kw_pb!!
+    pkw = primal(kw)
+    kw_rdata = zero_rdata(pkw)
+    px, dx = arrayify(x)
+    y = accumulate(+, px; pkw...)
+    dy_out = zero(y)
+    d = get(pkw, :dims, 1)
+    function accumulate_plus_kw_pb!!(::NoRData)
+        dx .+= reverse(cumsum(reverse(dy_out; dims=d); dims=d); dims=d)
+        return NoRData(),
+        _kw_init_rdata(kw_rdata, dy_out, true), NoRData(), NoRData(),
+        NoRData()
+    end
+    return CoDual(y, dy_out), accumulate_plus_kw_pb!!
 end
 @is_primitive(
     MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(accumulate),Any,CuArray}
@@ -1352,8 +1369,8 @@ for (_fn, _beat) in ((:maximum, :<), (:minimum, :>))
         else
             .!broadcast($_beat, $_fn(px; dims=get(pkw, :dims, :)), y)
         end
-        dinit = _minmax_init_tangent(tangent(kw))
-        return Dual(y, _minmax_init_jvp(zero_tangent(y), dinit, won))
+        dinit = _kw_init_tangent(tangent(kw))
+        return Dual(y, _kw_init_jvp(zero_tangent(y), dinit, .!won))
     end
     @eval function rrule!!(
         ::CoDual{typeof(Core.kwcall)},
@@ -1373,7 +1390,7 @@ for (_fn, _beat) in ((:maximum, :<), (:minimum, :>))
         # `::Any`: a `dims` reduction carries its cotangent in the output's fdata, a scalar
         # one in the incoming rdata.
         function nodiff_minmax_kw_pb!!(dy::Any)
-            dkw = _minmax_init_rdata(kw_rdata, dy isa NoRData ? tangent(out) : dy, won)
+            dkw = _kw_init_rdata(kw_rdata, dy isa NoRData ? tangent(out) : dy, .!won)
             return NoRData(), dkw, NoRData(), NoRData()
         end
         return out, nodiff_minmax_kw_pb!!

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -4159,9 +4159,14 @@ function frule!!(
     out = _gpu_broadcast_dual(flat_bc.f, flat_pargs...)
     decoded = _gpu_decode_ndual_output(Val(:broadcast), out, flat_pargs)
 
-    # Non-differentiable output (e.g. Bool from comparisons): zero tangent.
+    # `is_diff` says the kernel's element type carried no partials, which is not the same as
+    # the output being non-differentiable: a float array built only from index arrays, say
+    # `cnt ./ 2`, carries a tangent type even though nothing flows into it. Bool output from
+    # a comparison is the case this branch was written for, and there tangent_type really is
+    # NoTangent.
     if !decoded.is_diff
-        return Dual(out, NoTangent())
+        T = tangent_type(typeof(out))
+        return Dual(out, T === NoTangent ? NoTangent() : zero_tangent(out))
     end
 
     dy = _gpu_accumulate_jvp!(zero(decoded.primal_out), flat_pargs, flat_ts, out)
@@ -4186,9 +4191,11 @@ function rrule!!(
         Val(:broadcast), out, flat_pargs; extract_partials=true
     )
 
-    # Non-differentiable output (e.g. Bool from x .!= 0): return zero gradients.
+    # As in the frule: a float output with no differentiable leaf still needs an fdata of
+    # its declared type, or the caller is handed a NoFData where it expects a CuArray.
     if !decoded.is_diff
-        return CoDual(out, NoFData()), NoPullback(mat_fn, bc)
+        fd = tangent_type(typeof(out)) === NoTangent ? NoFData() : zero_tangent(out)
+        return CoDual(out, fd), NoPullback(mat_fn, bc)
     end
 
     dy_out = zero(decoded.primal_out)  # accumulated into by the downstream reverse pass

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -3575,6 +3575,22 @@ end
            !(first(bc.args) isa Broadcasted)
 end
 
+# `Float64.(Float32.(x))` — a cast whose argument is itself a cast. `_premat_nondiff_args`
+# materializes the inner one first, which makes the outer a simple cast and collapses the
+# whole chain to a plain leaf, so the tangent that has to be reattached belongs to the array
+# at the bottom rather than to the outer cast's immediate argument.
+@inline _gpu_is_cast_chain(::Any) = false
+@inline function _gpu_is_cast_chain(bc::Broadcasted)
+    bc.f isa Type{<:CuFloatOrComplex} || return false
+    length(bc.args) == 1 || return false
+    a = first(bc.args)
+    return !(a isa Broadcasted) || _gpu_is_cast_chain(a)
+end
+@inline _gpu_cast_chain_leaf(a, td) = (a, td)
+@inline _gpu_cast_chain_leaf(bc::Broadcasted, td) = _gpu_cast_chain_leaf(
+    first(bc.args), first(_fields(td).args)
+)
+
 @inline _gpu_bcast_arg_dof(x::IEEEFloat) = 1
 @inline _gpu_bcast_arg_dof(x::Complex{<:IEEEFloat}) = 2
 @inline _gpu_bcast_arg_dof(x::AbstractArray{<:IEEEFloat}) = 1
@@ -3766,7 +3782,11 @@ end
     args_prepared
 )
 @inline function _gpu_cast_diff_arg(bc::Broadcasted, td)
-    return _gpu_broadcast_cast_diff(bc.f, first(bc.args), first(_fields(td).args))
+    # Casting is the identity up to rounding, so the whole chain contributes the bottom
+    # leaf's tangent under the outermost cast; the value itself comes from the prepared
+    # (already fully cast) leaf.
+    p, t = _gpu_cast_chain_leaf(first(bc.args), first(_fields(td).args))
+    return _gpu_broadcast_cast_diff(bc.f, p, t)
 end
 @inline function _gpu_bcast_leaves_args(
     args_prepared::Tuple, args_primal::Tuple, tds::Tuple
@@ -3787,7 +3807,7 @@ end
         # the cast explicitly in the JVP/pullback.
         diff = if td1 isa Union{NoTangent,NoFData}
             NoTangent()
-        elseif _gpu_is_simple_cast_broadcast(a1_primal)
+        elseif _gpu_is_cast_chain(a1_primal)
             _gpu_cast_diff_arg(a1_primal, td1)
         else
             NoTangent()

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -3911,8 +3911,18 @@ struct _CastTo{T} end
 # Converting a dual has no method of its own, so a cast reaching the kernel over live
 # partials infers `Union{}` and the launch is refused. The cast is the identity up to
 # rounding, so it applies to the partials exactly as it does to the value.
-@inline function (::_CastTo{T})(x::Nfwd.NDual{V,N}) where {T,V,N}
+@inline function (::_CastTo{T})(x::Nfwd.NDual{V,N}) where {T<:Real,V,N}
     return Nfwd.NDual{T,N}(T(x.value), map(T, x.partials))
+end
+# A complex leaf reaches the kernel as `Complex{<:NDual}`, one dual per degree of freedom
+# rather than one dual holding a complex, so a complex target converts the two parts. Casting
+# a real leaf to a complex one leaves its derivative wholly in the real part.
+@inline (::_CastTo{T})(x::Complex{<:Nfwd.NDual}) where {T<:Complex} = Complex(
+    _CastTo{real(T)}()(real(x)), _CastTo{real(T)}()(imag(x))
+)
+@inline function (::_CastTo{T})(x::Nfwd.NDual) where {T<:Complex}
+    re = _CastTo{real(T)}()(x)
+    return Complex(re, zero(re))
 end
 # Only the outermost function needs this. A cast nested inside the tree is materialized by
 # `_premat_nondiff_args` before the kernel ever sees it; the one at the top is the only one

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1704,7 +1704,12 @@ end
 
 # unsafe_free! releases GPU memory early (normally handled by GC finalizer).
 # It is a pure side-effect with no mathematical output — gradient is zero.
-# Both the primal and its fdata (if any) are independent GPU allocations; free both.
+#
+# The primal and its fdata are independent allocations with different lifetimes, and only
+# forward mode may free both: there the tangent travels with the primal and dies with it.  In
+# reverse mode the fdata is the accumulator that the pullbacks of *earlier* operations write
+# into, long after the forward sweep reaches this call, so freeing it hands the reverse pass a
+# freed reference.  Reverse therefore frees the primal only, and gives up half the saving.
 @is_primitive MinimalCtx Tuple{typeof(unsafe_free!),CuArray}
 function frule!!(::Dual{typeof(unsafe_free!)}, x::Dual{<:CuArray})
     unsafe_free!(primal(x))
@@ -1714,8 +1719,6 @@ function frule!!(::Dual{typeof(unsafe_free!)}, x::Dual{<:CuArray})
 end
 function rrule!!(::CoDual{typeof(unsafe_free!)}, x::CoDual{<:CuArray})
     unsafe_free!(primal(x))
-    dx = tangent(x)
-    dx isa NoFData || unsafe_free!(dx)
     return CoDual(nothing, NoFData()), _nopb(Val(2))
 end
 

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -2294,19 +2294,20 @@ function rrule!!(
     pC_copy = copy(pC)
     cuBLAS.gemm!(tAv, tBv, _α, pA, pB, _β, pC)
     function generic_matmatmul!_7arg_pb!!(::NoRData)
-        # Adjoint of C = α*op_A(A)*op_B(B) + β*C_old requires conj(α) and conj(β).
-        # For real scalars conj is identity, so this is backward-compatible.
+        # Adjoint of C = α*op_A(A)*op_B(B) + β*C_old requires conj(α) and conj(β), except
+        # against a transposed operand: adjoint(α*adjoint(A)) folds the two conjugations
+        # together, leaving α itself.  For real scalars conj is identity either way.
         _cα = conj(_α)
         _cβ = conj(_β)
         if tAv == 'N'
             cuBLAS.gemm!('N', tBv == 'N' ? 'C' : 'N', _cα, dC, pB, _1, dA) # dA += conj(α)*dC*op_B(B)^H
         else
-            cuBLAS.gemm!(tBv, 'C', _cα, pB, dC, _1, dA)                     # dA += conj(α)*op_B(B)*dC^H
+            cuBLAS.gemm!(tBv, 'C', _α, pB, dC, _1, dA)                      # dA += α*op_B(B)*dC^H
         end
         if tBv == 'N'
             cuBLAS.gemm!(tAv == 'N' ? 'C' : 'N', 'N', _cα, pA, dC, _1, dB) # dB += conj(α)*op_A(A)^H*dC
         else
-            cuBLAS.gemm!('C', tAv, _cα, dC, pA, _1, dB)                     # dB += conj(α)*dC^H*op_A(A)
+            cuBLAS.gemm!('C', tAv, _α, dC, pA, _1, dB)                      # dB += α*dC^H*op_A(A)
         end
         copyto!(pC, pC_copy)
         dC .*= _cβ  # gradient w.r.t. C_old: ΔC_old = conj(β) * ΔC_new
@@ -2425,11 +2426,12 @@ end
 # (an outer product) reshape both vectors to (n,1) matrices and use cuBLAS.gemm!.
 #
 # Backward formulas for Y = alpha*op(A)*B + beta*Y_old (ȳ = cotangent of Y):
-#   tA='N': dA += alpha * ȳ * B^H  (outer product via gemm!('N','C'))
-#   tA≠'N': dA += alpha * B * ȳ^H  (outer product via gemm!('N','C'), roles swapped)
-#   tA='N': dB += alpha * A^H * ȳ  (gemv!('C'))
-#   tA≠'N': dB += alpha * A   * ȳ  (gemv!('N'), since op(A)^H = A)
-#   dY_old  = beta * ȳ             (pass-through scaled by beta)
+#   tA='N': dA += conj(alpha) * ȳ * B^H  (outer product via gemm!('N','C'))
+#   tA≠'N': dA += alpha * B * ȳ^H        (roles swapped; adjoint(alpha*adjoint(A)) folds
+#                                         the two conjugations together)
+#   tA='N': dB += conj(alpha) * A^H * ȳ  (gemv!('C'))
+#   tA≠'N': dB += conj(alpha) * A   * ȳ  (gemv!('N'), since op(A)^H = A)
+#   dY_old  = conj(beta) * ȳ             (pass-through scaled by beta)
 #
 # Limitation: 'T' flag for complex arrays is rejected (same as generic_matmatmul!).
 
@@ -2497,18 +2499,18 @@ function rrule!!(
         dY_mat = reshape(dY, :, 1)
         pB_mat = reshape(pB, :, 1)
         if tAv == 'N'
-            cuBLAS.gemm!('N', 'C', av, dY_mat, pB_mat, _1, dA) # dA += av * ȳ * B^H
+            cuBLAS.gemm!('N', 'C', conj(av), dY_mat, pB_mat, _1, dA) # dA += conj(av)*ȳ*B^H
         else
             cuBLAS.gemm!('N', 'C', av, pB_mat, dY_mat, _1, dA) # dA += av * B * ȳ^H
         end
         # dB update: gemv with Hermitian conjugate of op(A)
         if tAv == 'N'
-            cuBLAS.gemv!('C', av, pA, dY, _1, dB) # dB += av * A^H * ȳ
+            cuBLAS.gemv!('C', conj(av), pA, dY, _1, dB) # dB += conj(av) * A^H * ȳ
         else
-            cuBLAS.gemv!('N', av, pA, dY, _1, dB) # dB += av * A   * ȳ  (op(A)^H = A)
+            cuBLAS.gemv!('N', conj(av), pA, dY, _1, dB) # dB += conj(av)*A*ȳ (op(A)^H = A)
         end
         # Y tangent passes through scaled by beta
-        dY .*= bv
+        dY .*= conj(bv)
         copyto!(pY, pY_copy)
         return NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), NoRData()
     end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1497,6 +1497,10 @@ end
 @is_primitive(
     MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(accumulate),Any,CuNonDiffArray}
 )
+# The array carries no derivative, but a float `init` widens the output to a float array and
+# adds to every element of it, so it collects the whole cotangent — the same accounting the
+# differentiable accumulate rules do, including the identity path where the scan dimension
+# exceeds the array's and `init` never reaches the result.
 function frule!!(
     ::Dual{typeof(Core.kwcall)},
     kw::Dual{<:NamedTuple},
@@ -1504,8 +1508,11 @@ function frule!!(
     op::Dual,
     x::Dual{<:CuNonDiffArray},
 )
-    y = accumulate(primal(op), primal(x); primal(kw)...)
-    return Dual(y, zero_tangent(y))
+    pkw = primal(kw)
+    px = primal(x)
+    y = accumulate(primal(op), px; pkw...)
+    applies = _scan_applies_init(px, get(pkw, :dims, nothing))
+    return Dual(y, _kw_init_jvp(zero_tangent(y), _kw_init_tangent(tangent(kw)), applies))
 end
 function rrule!!(
     ::CoDual{typeof(Core.kwcall)},
@@ -1514,9 +1521,18 @@ function rrule!!(
     op::CoDual,
     x::CoDual{<:CuNonDiffArray},
 )
-    y = accumulate(primal(op), primal(x); primal(kw)...)
-    accumulate_nodiff_kw_pb!!(::Any) = ntuple(_ -> NoRData(), 5)
-    return zero_fcodual(y), accumulate_nodiff_kw_pb!!
+    pkw = primal(kw)
+    px = primal(x)
+    kw_rdata = zero_rdata(pkw)
+    y = accumulate(primal(op), px; pkw...)
+    applies = _scan_applies_init(px, get(pkw, :dims, nothing))
+    out = zero_fcodual(y)
+    dy_out = tangent(out)
+    function accumulate_nodiff_kw_pb!!(::Any)
+        dkw = _kw_init_rdata(kw_rdata, dy_out, applies)
+        return NoRData(), dkw, NoRData(), NoRData(), NoRData()
+    end
+    return out, accumulate_nodiff_kw_pb!!
 end
 
 # `count` returns an Integer for every array, float included, so it never has a derivative.
@@ -1594,6 +1610,22 @@ function _check_reduction_identity(f, pkw)
         "($identity). GPUArrays folds `init` into a backend-defined number of partial " *
         "reductions, so the result itself is undefined — sum(CuArray([1, 2, 3]); init=1.0) " *
         "returns 101.0, not 7.0. Pass the identity, or add `init` to the array instead. " *
+        _UNIMPL_MSG,
+    )
+end
+
+# The keyword mapreduce rules delegate to the keyword-free `sum(f, x)` rule, which seeds its
+# accumulator from the array. GPUArrays instead takes the output eltype from `init`, so an
+# `init` of any other type returns a value the delegate cannot produce — and a tangent typed
+# to match it. Compare against what the delegate actually returned rather than guessing the
+# natural output type, which the mapped function decides.
+function _check_mapreduce_init_type(pkw, y)
+    (!haskey(pkw, :init) || typeof(pkw.init) === typeof(y)) && return nothing
+    return _throw_gpu_argument_error(
+        "Mooncake: mapreduce over CuArray was given init::$(typeof(pkw.init)) where the " *
+        "reduction produces $(typeof(y)). GPUArrays takes the output eltype from `init`, " *
+        "so this changes the result type, which the rule cannot follow. Pass an init of " *
+        "type $(typeof(y)). " *
         _UNIMPL_MSG,
     )
 end
@@ -2257,8 +2289,11 @@ for _op in (:(+), :(Base.add_sum))
     )
         pkw = primal(kw)
         _check_reduction_identity(sum, pkw)
+        _check_reduction_init(tangent(kw))
         _mapreduce_kw_is_plain(pkw) || return _throw_gpu_mapreduce_dims()
-        return frule!!(Dual(sum, NoTangent()), f, x)
+        out = frule!!(Dual(sum, NoTangent()), f, x)
+        _check_mapreduce_init_type(pkw, primal(out))
+        return out
     end
     @eval function rrule!!(
         ::CoDual{typeof(Core.kwcall)},
@@ -2273,6 +2308,7 @@ for _op in (:(+), :(Base.add_sum))
         _mapreduce_kw_is_plain(pkw) || return _throw_gpu_mapreduce_dims()
         kw_rdata = zero_rdata(pkw)
         y, pb!! = rrule!!(zero_fcodual(sum), f, x)
+        _check_mapreduce_init_type(pkw, primal(y))
         function mapreduce_kw_pb!!(dy)
             _, r_f, r_x = pb!!(dy)          # delegate pullback: (sum, f, x)
             return NoRData(), kw_rdata, NoRData(), r_f, NoRData(), r_x

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -826,8 +826,16 @@ end
 function frule!!(::Dual{typeof(norm)}, x::Dual{<:CuMaybeComplexArray})
     px, dx = arrayify(x)
     y = norm(px)
-    dy = iszero(y) ? zero(real(eltype(px))) : real(dot(px, dx)) / y
-    return Dual(y, dy)
+    iszero(y) && return Dual(y, zero(real(eltype(px))))
+    s = real(dot(px, dx))
+    # dot overflows once norm(px)*norm(dx) leaves the eltype's range, while the JVP it
+    # divides down to is still representable — reachable in Float16, whose dot saturates
+    # at 65504. Rescaling costs a temporary, so only fall back to it from a non-finite
+    # dot, matching the core `BLAS.nrm2` frule.
+    if !isfinite(s) && isfinite(y)
+        return Dual(y, real(dot(px ./ y, dx)))
+    end
+    return Dual(y, s / y)
 end
 function rrule!!(::CoDual{typeof(norm)}, x::CoDual{<:CuMaybeComplexArray})
     px, dx = arrayify(x)
@@ -4323,8 +4331,10 @@ end
 # Statistics' generic `centralize_sumabs2(A, m) / (n - Int(corrected))`, which divides
 # AFTER summing in T/Int promotion arithmetic. The tangent does the same: this method
 # also runs (traced) on the CPU, and a CUDA-only rule must not give it a different
-# derivative — at Float16 n > 65504 the promoted denominator is Inf16, zeroing the
-# quotient on both backends.
+# derivative. Dividing each summand first would be better conditioned — it returns
+# 46677.3 where summing first overflows Float16 to Inf — but only here, so the two
+# backends would then disagree. At Float16 n > 65504 both orderings give NaN, since
+# the summand overflows before the Inf16-promoted denominator can zero the quotient.
 function _varm_scalar_colon_tangent(px, dx, pm, dm, corrected::Bool)
     # n == 0: the primal takes Statistics' constant-NaN branch, so the derivative is
     # the zero map (dividing the empty sum by 0 would instead manufacture a NaN).

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1959,7 +1959,7 @@ function frule!!(::Dual{typeof(unsafe_free!)}, x::Dual{<:CuArray})
     return Dual(nothing, NoTangent())
 end
 function rrule!!(::CoDual{typeof(unsafe_free!)}, ::CoDual{<:CuArray})
-    CoDual(nothing, NoFData()), _nopb(Val(2))
+    return CoDual(nothing, NoFData()), _nopb(Val(2))
 end
 
 # Core.finalizer(f, x) registers f as a GC finalizer for x. This is a pure side-effect
@@ -3673,7 +3673,6 @@ end
 # still decides the result, which is a Bool, so the capture's derivative is genuinely zero and
 # the state guard below has nothing to protect.
 @inline _gpu_bcast_has_nondiff_result(f::Base.Fix2) = _gpu_bcast_has_nondiff_result(f.f)
-@inline _gpu_bcast_has_nondiff_result(f::Base.Fix1) = _gpu_bcast_has_nondiff_result(f.f)
 @inline _gpu_bcast_has_nondiff_result(::Any) = false
 @inline _gpu_is_simple_cast_broadcast(::Any) = false
 @inline function _gpu_is_simple_cast_broadcast(bc::Broadcasted)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1341,8 +1341,46 @@ end
 # positional mapreduce catch-all does not claim, so claim `count` itself.
 @zero_derivative MinimalCtx Tuple{typeof(count),CuArray}
 @zero_derivative MinimalCtx Tuple{typeof(count),Any,CuArray}
-@zero_derivative MinimalCtx Tuple{typeof(Core.kwcall),NamedTuple,typeof(count),CuArray}
-@zero_derivative MinimalCtx Tuple{typeof(Core.kwcall),NamedTuple,typeof(count),Any,CuArray}
+
+# The positional spellings above take no `init` and are zero-derivative outright.  The keyword
+# ones accept one, and GPUArrays sums it like `sum`'s: a float `init` makes the result a float
+# that visibly depends on it, folded into a backend-defined number of partial reductions, so
+# `count(>(0.0), x; init=1.0)` returns 98.0 where the count is 3.  Same identity check as
+# `sum`, so the wrong value is refused rather than its derivative silently zeroed.
+for _n_args in (0, 1)
+    _pred_d = _n_args == 1 ? (:(pred::Dual),) : ()
+    _pred_c = _n_args == 1 ? (:(pred::CoDual),) : ()
+    _pred_v = _n_args == 1 ? (:(primal(pred)),) : ()
+    _slot = _n_args == 1 ? (:Any,) : ()
+    @eval @is_primitive(
+        MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(count),$(_slot...),CuArray}
+    )
+    @eval function frule!!(
+        ::Dual{typeof(Core.kwcall)},
+        kw::Dual{<:NamedTuple},
+        ::Dual{typeof(count)},
+        $(_pred_d...),
+        x::Dual{<:CuArray},
+    )
+        pkw = primal(kw)
+        _check_reduction_identity(count, pkw)
+        y = count($(_pred_v...), primal(x); pkw...)
+        return Dual(y, zero_tangent(y))
+    end
+    @eval function rrule!!(
+        ::CoDual{typeof(Core.kwcall)},
+        kw::CoDual{<:NamedTuple},
+        ::CoDual{typeof(count)},
+        $(_pred_c...),
+        x::CoDual{<:CuArray},
+    )
+        pkw = primal(kw)
+        _check_reduction_identity(count, pkw)
+        y = count($(_pred_v...), primal(x); pkw...)
+        count_kw_pb!!(::Any) = ntuple(_ -> NoRData(), $(_n_args + 4))
+        return zero_fcodual(y), count_kw_pb!!
+    end
+end
 
 # The keyword spellings cannot be zero-derivative outright: a float `init` makes the output
 # differentiable, so dropping its derivative would be silently wrong.  Nor is it 1 —
@@ -1362,6 +1400,7 @@ end
 # maximum/minimum need no such guard: max and min are idempotent, so their fold is exact and
 # a non-identity `init` is the point of passing one.
 _reduction_identity(::typeof(sum)) = 0
+_reduction_identity(::typeof(count)) = 0
 _reduction_identity(::typeof(prod)) = 1
 _reduction_identity(_) = nothing
 function _check_reduction_identity(f, pkw)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -939,6 +939,16 @@ end
 # findmax answers `dims` and nothing else, so those calls keep the plain argmax path.
 _minmax_kw_is_plain(::NamedTuple{K}) where {K} = K === () || K === (:dims,)
 
+# Reducing over an empty extent has a well-defined primal — GPUArrays fills each slice with
+# `init`, or with the eltype's identity when there is none — but no argmax to report, and
+# findmax/findmin read out of bounds there: a device-side BoundsError that surfaces at some
+# later synchronisation.  A Colon reduction over an empty non-vector instead hands `_winner`
+# a linear index outside CartesianIndices.  Since no element competes, x's derivative is
+# zero and `init` takes all of it.
+_empty_minmax_slice(px, ::Colon) = isempty(px)
+_empty_minmax_slice(px, dims::Integer) = size(px, dims) == 0
+_empty_minmax_slice(px, dims) = any(d -> size(px, d) == 0, dims)
+
 for (_fn, _find, _beat) in ((:maximum, :findmax, :<), (:minimum, :findmin, :>))
     @eval @is_primitive(MinimalCtx, Tuple{typeof($_fn),CuFloatArray})
     @eval @is_primitive(
@@ -947,11 +957,13 @@ for (_fn, _find, _beat) in ((:maximum, :findmax, :<), (:minimum, :findmin, :>))
 
     @eval function frule!!(::Dual{typeof($_fn)}, x::Dual{<:CuFloatArray})
         px, dx = arrayify(x)
+        isempty(px) && return Dual($_fn(px), zero(eltype(px)))
         y, ind = $_find(px)
         return Dual(y, sum(dx .* (CartesianIndices(px) .== _winner(ind))))
     end
     @eval function rrule!!(::CoDual{typeof($_fn)}, x::CoDual{<:CuFloatArray})
         px, dx = arrayify(x)
+        isempty(px) && return CoDual($_fn(px), NoFData()), _nopb(Val(2))
         y, ind = $_find(px)
         function minmax_pb!!(dy)
             dx .+= dy .* (CartesianIndices(px) .== _winner(ind))
@@ -974,6 +986,10 @@ for (_fn, _find, _beat) in ((:maximum, :findmax, :<), (:minimum, :findmin, :>))
         pkw = primal(kw)
         px, dx = arrayify(x)
         dims = get(pkw, :dims, :)
+        if _empty_minmax_slice(px, dims)
+            y_e = $_fn(px; pkw...)
+            return Dual(y_e, _kw_init_jvp(zero(y_e), _kw_init_tangent(tangent(kw)), true))
+        end
         m, ind = $_find(px; dims=dims)
         if _minmax_kw_is_plain(pkw)
             return Dual(m, sum(dx .* (CartesianIndices(px) .== _winner(ind)); dims=dims))
@@ -995,6 +1011,22 @@ for (_fn, _find, _beat) in ((:maximum, :findmax, :<), (:minimum, :findmin, :>))
         kw_rdata = zero_rdata(pkw)
         px, dx = arrayify(x)
         dims = get(pkw, :dims, :)
+        if _empty_minmax_slice(px, dims)
+            y_e = $_fn(px; pkw...)
+            if dims isa Colon
+                function minmax_empty_scalar_pb!!(dy)
+                    dkw = _kw_init_rdata(kw_rdata, dy, true)
+                    return NoRData(), dkw, NoRData(), NoRData()
+                end
+                return CoDual(y_e, NoFData()), minmax_empty_scalar_pb!!
+            end
+            dy_e = zero(y_e)
+            function minmax_empty_array_pb!!(::NoRData)
+                dkw = _kw_init_rdata(kw_rdata, dy_e, true)
+                return NoRData(), dkw, NoRData(), NoRData()
+            end
+            return CoDual(y_e, dy_e), minmax_empty_array_pb!!
+        end
         m, ind = $_find(px; dims=dims)
         y, won = if _minmax_kw_is_plain(pkw)
             m, true

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1086,17 +1086,18 @@ function rrule!!(::CoDual{typeof(sum)}, x::CoDual{<:CuMaybeComplexArray})
     return zero_fcodual(sum(primal(x))), sum_pb!!
 end
 
-# Reductions over an index or mask array have no derivative: the array has no tangent and
-# the result is an Integer.  Without a rule they decompose onto one of GPUArrays'
-# untraceable reduction paths, which one depending on spelling and eltype.
+# Reductions and orderings over an index or mask array have no derivative: the array has no
+# tangent, and the result is an Integer or another such array.  Without a rule they
+# decompose onto one of GPUArrays' untraceable paths, which one depending on spelling and
+# eltype.
 #
-# `maximum`/`minimum` cannot use @zero_derivative: it generates `CoDual{<:typeof(f)}`,
-# which is equal in extent to their catch-all error rules' `CoDual{typeof(f)}` but not
-# comparable with it, so the two would be ambiguous.  Spelling the signature the same way
-# lets the narrower array type decide, leaving those rules to report float arrays.
+# sum and prod can use @zero_derivative; for the other five it generates
+# `CoDual{<:typeof(f)}`, equal in extent to their catch-all error rules' `CoDual{typeof(f)}`
+# but not comparable with it, so the two would be ambiguous.  Spelling the signature the
+# same way lets the narrower array type decide, leaving those rules to report float arrays.
 @zero_derivative MinimalCtx Tuple{typeof(sum),CuNonDiffArray}
 @zero_derivative MinimalCtx Tuple{typeof(prod),CuNonDiffArray}
-for _fn in (:maximum, :minimum)
+for _fn in (:maximum, :minimum, :diff, :sort, :sortperm)
     @eval @is_primitive(MinimalCtx, Tuple{typeof($_fn),CuNonDiffArray})
     @eval frule!!(f::Dual{typeof($_fn)}, x::Dual{<:CuNonDiffArray}) = zero_derivative(f, x)
     @eval rrule!!(f::CoDual{typeof($_fn)}, x::CoDual{<:CuNonDiffArray}) = zero_adjoint(f, x)
@@ -1112,9 +1113,12 @@ end
 
 # The keyword spellings cannot be zero-derivative outright: a float `init` makes the output
 # differentiable, so dropping its derivative would be silently wrong.  Nor is it 1 —
-# GPUArrays folds `init` into a backend-defined number of partial reductions, so
-# `init=1.0` over `[1,2,3]` gives 101.0 — so a nonzero `init` tangent is rejected.  Only
-# the frules can check it; reverse mode has no incoming `init` tangent.
+# GPUArrays folds `init` into a backend-defined number of partial reductions, so `init=1.0`
+# over `[1,2,3]` gives 101.0 — so a nonzero `init` tangent is rejected instead.  Only the
+# frules can check it; reverse mode has no incoming `init` tangent.
+#
+# sum, prod, maximum and minimum all accept `init`; diff/sort/sortperm do not, so the guard
+# is a no-op for those three and one path covers all seven.
 function _check_reduction_init(dkw)
     dinit = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
     (dinit isa NoTangent || iszero(dinit)) && return nothing
@@ -1126,7 +1130,7 @@ function _check_reduction_init(dkw)
     )
 end
 
-for _fn in (:sum, :prod, :maximum, :minimum)
+for _fn in (:sum, :prod, :maximum, :minimum, :diff, :sort, :sortperm)
     @eval @is_primitive(
         MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof($_fn),CuNonDiffArray}
     )

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1795,34 +1795,50 @@ end
 # CuComplexArray overload below.  This correctly handles non-holomorphic f (e.g. abs2)
 # via Wirtinger calculus.
 #
-# Limitation: the NDual pass threads duals only through the CuArray *elements*.
-# Scalars or other state captured inside f's closure are invisible to the kernel
-# and receive no gradient.  If f has differentiable captured variables
-# (rdata_type(f) ≠ NoRData), the pullback would silently return zero for them,
-# producing wrong gradients and a type mismatch in increment!!.
-# _check_gpu_sum_f detects this case early and raises an informative error.
-function _check_gpu_sum_f(f)
-    F = typeof(f)
-    # Zero-field types (singletons such as typeof(abs2), typeof(sin)) have no captured
-    # state and are always safe. Calling rdata_type on them can hit an internal
-    # fields_type MethodError for plain function types, so we short-circuit here.
-    fieldcount(F) == 0 && return nothing
-    RT = rdata_type(F)
-    if RT !== NoRData
-        throw(
-            ArgumentError(
-                "Mooncake GPU sum/mapreduce rule does not support $F as the mapping " *
-                "function because it has rdata type $RT, meaning it captures " *
-                "differentiable state (e.g. a closed-over Float32 scalar). The GPU rule " *
-                "threads NDuals only through the CuArray elements and cannot propagate " *
-                "gradients back through captured variables. To fix this, implement a " *
-                "custom rrule!! for the enclosing function (e.g. Statistics.varm) or " *
-                "restructure the computation to avoid differentiable closures.",
-            ),
-        )
-    end
-    return nothing
+# Limitation: the NDual pass threads partials through the CuArray *elements* and the scalar
+# arguments only.  Anything a function carries itself — a closed-over scalar or array, a
+# callable struct's field — is invisible to the kernel, so its gradient would come back an
+# exact zero.  Both the mapped reductions and the broadcast rules refuse that instead.
+#
+# Keyed on `tangent_type`, not `rdata_type`: a captured CuArray has no rdata at all yet is
+# every bit as differentiable, and `rdata_type` applied to a primal type throws inside
+# `fields_type` — which is what used to reach the user in place of this message.
+function _throw_gpu_unthreaded(T, spelling, noun)
+    return _throw_gpu_argument_error(
+        "Mooncake: $spelling over CuArray does not support $noun of type $T. Partials are " *
+        "threaded through GPU array elements and real or complex float scalars only, so " *
+        "this one's gradient would silently be zero. Pass captured state as an argument " *
+        "instead — `((t, c) -> c * t).(x, a)` differentiates correctly — or write a rule " *
+        "for the enclosing operation. " *
+        _UNIMPL_MSG,
+    )
 end
+# Does a tangent type bottom out in anything a kernel would have to thread?  NoTangent does
+# not, and a struct or Ref tangent does only if one of its fields does — `x .^ 7` lowers to
+# `literal_pow.(Ref(^), x, Ref(Val(7)))`, whose Ref tangents are MutableTangents over
+# NoTangent and must pass.  Unrecognised tangent types count as carrying data: refusing a
+# case that turns out to be inert is a visible error, while passing one that is not is a
+# silent zero.
+_carries_tangent(::Type{NoTangent}) = false
+_carries_tangent(::Type{Mooncake.PossiblyUninitTangent{T}}) where {T} = _carries_tangent(T)
+function _carries_tangent(::Type{T}) where {T}
+    T <: Union{Tangent,Mooncake.MutableTangent} || return true
+    return any(_carries_tangent, fieldtypes(Mooncake.fields_type(T)))
+end
+_carries_differentiable_state(x) = _carries_tangent(tangent_type(typeof(x)))
+
+function _check_gpu_captured_state(f, spelling)
+    _carries_differentiable_state(f) || return nothing
+    return _throw_gpu_unthreaded(typeof(f), spelling, "a function carrying its own state")
+end
+_check_gpu_sum_f(f) = _check_gpu_captured_state(f, "sum(f, x) / mapreduce")
+
+# A leaf the kernel can thread: a GPU array (wrappers included) or a float/complex scalar.
+# Anything else that carries a tangent — a Ref over a float, a struct, a host array — would be
+# dropped in silence by _leaf_effective_tangent's catch-all.
+_gpu_threads_leaf(::CuMaybeWrappedArray) = true
+_gpu_threads_leaf(::CuFloatOrComplex) = true
+_gpu_threads_leaf(x) = !_carries_differentiable_state(x)
 
 function _gpu_sum_f_frule(f, x)
     _check_gpu_sum_f(f)
@@ -3364,7 +3380,25 @@ end
     end
 end
 
+# The functions are checked before flattening, so the type named in the error is the one the
+# caller wrote rather than a Broadcast-internal composition wrapper.
+_check_gpu_bcast_captures(::Tuple{}) = nothing
+function _check_gpu_bcast_captures(args::Tuple)
+    a = first(args)
+    if a isa Broadcasted
+        _check_gpu_bcast_captures(a)
+    elseif !_gpu_threads_leaf(a)
+        _throw_gpu_unthreaded(typeof(a), "broadcasting", "a differentiable argument")
+    end
+    return _check_gpu_bcast_captures(Base.tail(args))
+end
+function _check_gpu_bcast_captures(bc::Broadcasted)
+    _check_gpu_captured_state(bc.f, "broadcasting")
+    return _check_gpu_bcast_captures(bc.args)
+end
+
 function _prepare_gpu_broadcast(bc_primal, tangent_or_fdata)
+    _check_gpu_bcast_captures(bc_primal)
     bc_prepared = _premat_nondiff_args(bc_primal, tangent_or_fdata)
     flat_bc = Base.Broadcast.flatten(bc_prepared)
     flat_pargs, flat_tangent_or_fdata = _gpu_bcast_leaves(

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -965,13 +965,12 @@ _winner(i::CartesianIndex) = Ref(i)
 _winner(i::AbstractArray{<:CartesianIndex}) = i
 _winner(i::AbstractArray{<:Integer}) = CartesianIndex.(i)
 
-# Two of these reductions have an `init` whose derivative survives the backend's folding:
-# maximum/minimum, where it competes with the elements and takes the whole derivative of each
-# reduced slice it beats, and accumulate(+, …), where it adds to every element.  Both are
-# idempotent in the folding — unlike sum and prod, whose `init` is folded into a
-# backend-defined number of partial reductions, leaving it a constant.  `from_init` says
-# where `init` decided the output: a mask for max/min, `true` throughout for accumulate.  A
-# tie counts against `init`, matching how findmax breaks ties.
+# Two reductions have an `init` whose derivative survives the folding, because theirs is
+# idempotent where sum's and prod's is not: maximum/minimum, where it competes with the
+# elements and takes the whole derivative of every slice it beats, and accumulate(+, …),
+# where it adds to each element.  `from_init` says where `init` decided the output: a mask
+# for max/min, `true` throughout for accumulate.  A tie counts against `init`, as findmax
+# breaks them.
 _kw_init_tangent(dkw) = dkw isa NamedTuple ? get(dkw, :init, NoTangent()) : NoTangent()
 _kw_init_jvp(dy, ::NoTangent, from_init) = dy
 _kw_init_jvp(dy, dinit::Number, from_init) = dy .+ dinit .* from_init
@@ -1130,8 +1129,7 @@ end
 # point — the exclusion is what the division could not express.
 #
 # Both quantities come from the same reduction the primal ran, over `px` with its zeros
-# replaced by ones, so an `init` folded into a backend-defined number of partial reductions
-# scales the derivative exactly as it scaled the value.
+# replaced by ones, so a folded `init` scales the derivative exactly as it scaled the value.
 function _prod_exclusive(px, dims, kw)
     T = eltype(px)
     nonzero = ifelse.(iszero.(px), one(T), px)
@@ -1559,10 +1557,9 @@ end
 @zero_derivative MinimalCtx Tuple{typeof(count),Any,CuArray}
 
 # The positional spellings above take no `init` and are zero-derivative outright.  The keyword
-# ones accept one, and GPUArrays sums it like `sum`'s: a float `init` makes the result a float
-# that visibly depends on it, folded into a backend-defined number of partial reductions, so
-# `count(>(0.0), x; init=1.0)` returns 98.0 where the count is 3.  Same identity check as
-# `sum`, so the wrong value is refused rather than its derivative silently zeroed.
+# ones accept one, and GPUArrays folds it as it does `sum`'s: `count(>(0.0), x; init=1.0)`
+# returns 98.0 where the count is 3.  Same identity check, so the wrong value is refused
+# rather than its derivative silently zeroed.
 for _n_args in (0, 1)
     _pred_d = _n_args == 1 ? (:(pred::Dual),) : ()
     _pred_c = _n_args == 1 ? (:(pred::CoDual),) : ()
@@ -1598,23 +1595,12 @@ for _n_args in (0, 1)
     end
 end
 
-# The keyword spellings cannot be zero-derivative outright: a float `init` makes the output
-# differentiable, so dropping its derivative would be silently wrong.  Nor is it 1 —
-# GPUArrays folds `init` into a backend-defined number of partial reductions, so `init=1.0`
-# over `[1,2,3]` gives 101.0 — so a nonzero `init` tangent is rejected instead.  Only the
-# frules can check it: reverse mode sees no tangent, and cannot tell a constant `init` from
-# one the caller wants a gradient for, so a guard there rejects correct programs.
-#
-# This covers sum and prod, whose `init` folding is what makes the derivative undefined, and
-# diff/sort/sortperm, which take no `init` at all.  maximum and minimum are idempotent, so
-# their `init` derivative survives the folding exactly; they get it below.
-# `sum` and `prod` fold `init` into a backend-defined number of partial reductions, and + and
-# * are not idempotent, so anything but the identity changes the result itself:
-# sum(CuArray([1, 2, 3]); init=1.0) is 101.0, not 7.0, and prod(…; init=2.0) is 2.4e29, not
-# 12.  Neither that value nor a derivative through it is defined, so both modes refuse it.
-# Unlike the tangent check below, this reads the value, which reverse mode can also see.
-# maximum/minimum need no such guard: max and min are idempotent, so their fold is exact and
-# a non-identity `init` is the point of passing one.
+# GPUArrays folds `init` into a backend-defined number of partial reductions, so for the
+# non-idempotent ops it changes the value itself: sum(CuArray([1, 2, 3]); init=1.0) is 101.0,
+# not 7.0. Neither that value nor a derivative through it is defined, so both modes refuse a
+# non-identity `init` — a check on the value, which reverse mode can see too, unlike the
+# tangent check below. max and min fold exactly, so a non-identity `init` is the point of
+# passing one to them and they need no guard; diff/sort/sortperm take no `init` at all.
 _reduction_identity(::typeof(sum)) = 0
 _reduction_identity(::typeof(count)) = 0
 _reduction_identity(::typeof(prod)) = 1

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -3899,10 +3899,32 @@ function _check_gpu_bcast_captures(bc::Broadcasted)
     return _check_gpu_bcast_captures(bc.args)
 end
 
+# A `Type` used as a broadcast function is a `DataType`, which is not a bitstype and so
+# cannot be captured by a GPU kernel. `flatten` either hands it over raw, which fails to
+# compile, or folds it into a closure whose element type inference is version-dependent —
+# Julia 1.10 gives up and infers `Any` where 1.12 does not. Swapping in a singleton that
+# carries the target type as a parameter removes the question: it is a bitstype either way,
+# and it composes into whatever `flatten` builds. The tree is rebuilt before flattening and
+# only the functions change, so the leaves walk still pairs it with the original arg by arg.
+struct _CastTo{T} end
+@inline (::_CastTo{T})(x) where {T} = T(x)
+# Converting a dual has no method of its own, so a cast reaching the kernel over live
+# partials infers `Union{}` and the launch is refused. The cast is the identity up to
+# rounding, so it applies to the partials exactly as it does to the value.
+@inline function (::_CastTo{T})(x::Nfwd.NDual{V,N}) where {T,V,N}
+    return Nfwd.NDual{T,N}(T(x.value), map(T, x.partials))
+end
+# Only the outermost function needs this. A cast nested inside the tree is materialized by
+# `_premat_nondiff_args` before the kernel ever sees it; the one at the top is the only one
+# that survives, because nothing materializes the tree's own root.
+_desugar_casts(x) = x
+_desugar_casts(bc::Broadcasted{S}) where {S} =
+    bc.f isa Type ? Broadcasted{S}(_CastTo{bc.f}(), bc.args, bc.axes) : bc
+
 function _prepare_gpu_broadcast(bc_primal, tangent_or_fdata)
     _check_gpu_bcast_captures(bc_primal)
     bc_prepared = _premat_nondiff_args(bc_primal, tangent_or_fdata)
-    flat_bc = Base.Broadcast.flatten(bc_prepared)
+    flat_bc = Base.Broadcast.flatten(_desugar_casts(bc_prepared))
     flat_pargs, flat_tangent_or_fdata = _gpu_bcast_leaves(
         bc_prepared, bc_primal, tangent_or_fdata
     )

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -2324,23 +2324,26 @@ end
 # ccall, whose scalars are passed as CuRef{T} — a primitive type with no tangent_type,
 # which is the error users actually see; defining that tangent_type would only move the
 # failure to the ccall itself.
-#
-# alpha and beta are treated as constants.  Unlike the gemm! rules, they cannot be typed
-# as NoTangent: the generated `+`/`-` pass `one(T)`, a float literal, so they arrive with
-# a real (zero) tangent.  A nonzero tangent would be silently dropped, so reject it.
-@inline function _check_geam_scalar(t, name)
-    (t isa NoTangent || iszero(t)) && return nothing
-    return _throw_gpu_argument_error(
-        "Mooncake: geam! treats `$name` as a constant, but it received a nonzero " *
-        "tangent. Differentiating with respect to it is not supported. " *
-        _UNIMPL_MSG,
-    )
-end
-
 function _geam_op(t::Char, M)
     t == 'N' && return M
     return t == 'T' ? transpose(M) : adjoint(M)
 end
+
+# alpha and beta are differentiated: the generated `+`/`-` pass `one(T)`, a float literal,
+# so they cannot be typed as NoTangent the way the gemm! rules type theirs, and reverse
+# mode has no way to tell that literal from a scalar the caller wants a gradient for.
+_geam_scalar_jvp!(dC, ::NoTangent, ::Char, X) = dC
+function _geam_scalar_jvp!(dC, ds::Number, t::Char, X)
+    iszero(ds) && return dC
+    return dC .+= convert(eltype(dC), ds) .* _geam_op(t, X)
+end
+
+# C = s*op(X) + …, so s's cotangent is sum(conj(op(X)) .* dC), projected onto s's own type:
+# a real s over a complex array keeps the real part.  A Bool or Integer s has no derivative;
+# the assertion makes a scalar type that does carry one an error, not a silent zero.
+_geam_scalar_rdata(s::IEEEFloat, X, dC) = oftype(s, real(sum(conj.(X) .* dC)))
+_geam_scalar_rdata(s::Complex{<:IEEEFloat}, X, dC) = oftype(s, sum(conj.(X) .* dC))
+_geam_scalar_rdata(s::Number, X, dC) = zero_rdata(s)::NoRData
 
 @is_primitive(
     MinimalCtx,
@@ -2365,16 +2368,18 @@ function frule!!(
     B::Dual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
     C::Dual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
 )
-    _check_geam_scalar(tangent(alpha), "alpha")
-    _check_geam_scalar(tangent(beta), "beta")
     pA, dA = matrixify(A)
     pB, dB = matrixify(B)
     pC, dC = matrixify(C)
     T = eltype(pA)
     tav, tbv = primal(ta), primal(tb)
     _a, _b = T(primal(alpha)), T(primal(beta))
-    cuBLAS.geam!(tav, tbv, _a, pA, _b, pB, pC)
+    # The tangent runs first: cuBLAS geam runs in place for C === A or C === B, so the
+    # primal call would otherwise overwrite the pA/pB that the scalar terms read.
     cuBLAS.geam!(tav, tbv, _a, dA, _b, dB, dC)
+    _geam_scalar_jvp!(dC, tangent(alpha), tav, pA)
+    _geam_scalar_jvp!(dC, tangent(beta), tbv, pB)
+    cuBLAS.geam!(tav, tbv, _a, pA, _b, pB, pC)
     return C
 end
 function rrule!!(
@@ -2396,17 +2401,22 @@ function rrule!!(
     pC_copy = copy(pC)
     cuBLAS.geam!(tav, tbv, _a, pA, _b, pB, pC)
     function geam!_pb!!(::NoRData)
-        dA .+= conj(_a) .* _geam_op(tav, dC)
-        dB .+= conj(_b) .* _geam_op(tbv, dC)
+        # C may be A or B (cuBLAS geam runs in place for C === A or C === B), so restore the
+        # primal and read dC out before touching pA/pB or dA/dB, which alias them.
         copyto!(pC, pC_copy)
+        dC_copy = copy(dC)
         # geam has no C_old term, so C's cotangent is consumed rather than scaled.
         fill!(dC, zero(T))
+        # 'C' takes alpha unconjugated: adjoint(alpha * adjoint(A)) folds the two
+        # conjugations together.  Real scalars are unaffected either way.
+        dA .+= (tav == 'C' ? _a : conj(_a)) .* _geam_op(tav, dC_copy)
+        dB .+= (tbv == 'C' ? _b : conj(_b)) .* _geam_op(tbv, dC_copy)
         return NoRData(),
         NoRData(),
         NoRData(),
-        zero_rdata(primal(alpha)),
+        _geam_scalar_rdata(primal(alpha), _geam_op(tav, pA), dC_copy),
         NoRData(),
-        zero_rdata(primal(beta)),
+        _geam_scalar_rdata(primal(beta), _geam_op(tbv, pB), dC_copy),
         NoRData(),
         NoRData()
     end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -3060,6 +3060,14 @@ function rrule!!(
 end
 # The tangent of Array{T} is Array{T} (fdata, accumulated in-place).
 # The tangent of CuArray{T} is CuArray{T} (fdata, accumulated in-place).
+#
+# `cu` is a host-to-device transfer for a host argument and a copy for a device one, and the
+# claim admits both, so the cotangent has to travel back to whichever side the argument's
+# fdata lives on.  Pulling it to the host unconditionally asked a device buffer to accumulate
+# a host array, which is a kernel-compilation failure rather than a scalar-indexing error.
+_cu_pullback_like(::AbstractArray, dy) = Array(dy)
+_cu_pullback_like(::CuArray, dy) = dy
+
 @is_primitive(MinimalCtx, Tuple{typeof(cu),AbstractArray{<:CuFloatOrComplex}})
 function frule!!(::Dual{typeof(cu)}, x::Dual{<:AbstractArray{<:CuFloatOrComplex}})
     return Dual(cu(primal(x)), cu(tangent(x)))
@@ -3068,7 +3076,7 @@ function rrule!!(::CoDual{typeof(cu)}, x::CoDual{<:AbstractArray{<:CuFloatOrComp
     dx = tangent(x)
     dy_gpu = cu(zero(primal(x)))  # output fdata, accumulated into by downstream
     function cu_pb!!(::NoRData)
-        dx .+= Array(dy_gpu)      # transfer gradient back to CPU in-place
+        dx .+= _cu_pullback_like(dx, dy_gpu)
         return NoRData(), NoRData()
     end
     return CoDual(cu(primal(x)), dy_gpu), cu_pb!!

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1096,7 +1096,7 @@ function rrule!!(::CoDual{typeof(cumsum)}, x::CoDual{<:CuMaybeComplexArray}; kw.
     dy_out = zero(y)
     d = get(kw, :dims, 1)
     function cumsum_pb!!(::NoRData)
-        dx .+= reverse(cumsum(reverse(dy_out; dims=d); dims=d); dims=d)
+        dx .+= _scan_pullback(dy_out, d)
         return NoRData(), NoRData()
     end
     return CoDual(y, dy_out), cumsum_pb!!
@@ -1197,7 +1197,13 @@ end
 _scan_jvp(dx, ::Nothing) = reshape(cumsum(vec(dx)), size(dx))
 _scan_jvp(dx, d) = cumsum(dx; dims=d)
 _scan_pullback(dy, ::Nothing) = reshape(reverse(cumsum(reverse(vec(dy)))), size(dy))
-_scan_pullback(dy, d) = reverse(cumsum(reverse(dy; dims=d); dims=d); dims=d)
+function _scan_pullback(dy, d)
+    # Scanning along a dimension the array does not have is the identity — the primal and the
+    # JVP both accept it — so the adjoint is the identity too.  `reverse` would refuse that
+    # dimension, which is what used to make the pullback the only mode to reject it.
+    d > ndims(dy) && return dy
+    return reverse(cumsum(reverse(dy; dims=d); dims=d); dims=d)
+end
 
 # Rules for `accumulate(+, x)` — identical to cumsum but via the accumulate interface.
 # Other operators are not supported and throw an informative error (catch-all below).

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -92,6 +92,9 @@ import Mooncake.TestUtils:
 const CuFloatArray = CuArray{<:IEEEFloat}
 const CuComplexArray = CuArray{<:Complex{<:IEEEFloat}}
 const CuMaybeComplexArray = Union{CuFloatArray,CuComplexArray}
+# Index and mask arrays. A whitelist: an eltype outside it whose tangent_type is
+# NoTangent (Char, Symbol, Enum) still falls through to the struct handler.
+const CuNonDiffArray = CuArray{<:Union{Integer,Bool,CartesianIndex}}
 
 # Without these overloads the generic struct handler would recurse into CuMaybeComplexArray's
 # Julia-visible fields — wrong for GPU arrays.
@@ -453,18 +456,11 @@ _register_cudataref_internal_types!()
 # for those, but Mooncake may infer MutableTangent for the inner RefCounted struct,
 # causing a tangent type mismatch.
 @zero_derivative MinimalCtx Tuple{typeof(Base.mightalias),T,S} where {T<:CuArray,S<:CuArray}
-# CuArray{<:Integer}, {<:Bool} and {<:CartesianIndex} are index/mask arrays — not
-# differentiable. Assigning NoTangent stops Mooncake from building a struct tangent from
-# CuArray's internal fields (data::CuDataRef, maxsize::Int, offset::Int, dims::NTuple).
+# Assigning NoTangent stops Mooncake from building a struct tangent from CuArray's
+# internal fields (data::CuDataRef, maxsize::Int, offset::Int, dims::NTuple).
 # The CuMaybeComplexArray rule above takes priority for float and complex arrays.
-# This is a whitelist: an eltype outside it whose tangent_type is NoTangent (Char, Symbol,
-# Enum) still falls through to the struct handler and builds an unconstructible tangent.
-tangent_type(::Type{<:CuArray{<:Union{Integer,Bool,CartesianIndex}}}) = NoTangent
-function tangent_type(
-    ::Type{<:CuArray{<:Union{Integer,Bool,CartesianIndex}}}, ::Type{NoRData}
-)
-    NoTangent
-end
+tangent_type(::Type{<:CuNonDiffArray}) = NoTangent
+tangent_type(::Type{<:CuNonDiffArray}, ::Type{NoRData}) = NoTangent
 
 tangent(p::CuMaybeComplexArray, ::NoRData) = p
 
@@ -494,7 +490,7 @@ function TestUtils.has_equal_data_internal(
 end
 function TestUtils.has_equal_data_internal(
     x::P, y::P, equal_undefs::Bool, d::IdDict{Any,Bool}
-) where {P<:CuArray{<:Union{Integer,Bool,CartesianIndex}}}
+) where {P<:CuNonDiffArray}
     # For non-differentiable CuArrays, compare by content by downloading to CPU.
     size(x) != size(y) && return false
     return Array(x) == Array(y)
@@ -1198,19 +1194,30 @@ end
 # `unsafe_copyto!` and `fill!` into a device array whose elements carry no derivative
 # information (index arrays, masks).  The rules above all require a tangent array, so
 # these spellings had no rule at all and died in the same try/catch and fill kernel.
-# Keying the methods on the tangent being NoTangent keeps them disjoint from those rules
-# without enumerating element types.  There is no gradient to propagate, but the pullback
-# must still undo the mutation, or re-running the rule would see a different array.
+# There is no gradient to propagate, but the pullback must still undo the mutation, or
+# re-running the rule would see a different array.
+#
+# CuNonDiffArray is disjoint from CuMaybeComplexArray and CuMaybeWrappedArray, so these
+# claims are unambiguous with the rules above, and it is exactly what they can serve: an
+# eltype off the whitelist has no NoTangent tangent, so claiming it would only turn a
+# trace failure into a MethodError.
 #
 # Note the asymmetry in `src`: a CPU Array{Int} has fdata Vector{NoTangent}, and only the
 # CuArray side collapses to NoTangent, so `src`'s tangent is left unconstrained.
 @is_primitive(
     MinimalCtx,
-    Tuple{typeof(unsafe_copyto!),CuArray,Integer,Union{Array,CuArray},Integer,Integer},
+    Tuple{
+        typeof(unsafe_copyto!),
+        <:CuNonDiffArray,
+        Integer,
+        <:Union{Array,CuArray},
+        Integer,
+        Integer,
+    },
 )
 function frule!!(
     ::Dual{typeof(unsafe_copyto!)},
-    dest::Dual{<:CuArray,NoTangent},
+    dest::Dual{<:CuNonDiffArray},
     doffs::Dual{<:Integer,NoTangent},
     src::Dual{<:Union{Array,CuArray}},
     soffs::Dual{<:Integer,NoTangent},
@@ -1221,7 +1228,7 @@ function frule!!(
 end
 function rrule!!(
     ::CoDual{typeof(unsafe_copyto!)},
-    dest::CoDual{<:CuArray,NoFData},
+    dest::CoDual{<:CuNonDiffArray},
     doffs::CoDual{<:Integer,NoFData},
     src::CoDual{<:Union{Array,CuArray}},
     soffs::CoDual{<:Integer,NoFData},
@@ -1239,12 +1246,12 @@ function rrule!!(
     return dest, unsafe_copyto!_nodiff_pb!!
 end
 
-@is_primitive(MinimalCtx, Tuple{typeof(fill!),CuArray,Any})
-function frule!!(::Dual{typeof(fill!)}, a::Dual{<:CuArray,NoTangent}, x::Dual)
+@is_primitive(MinimalCtx, Tuple{typeof(fill!),<:CuNonDiffArray,Any})
+function frule!!(::Dual{typeof(fill!)}, a::Dual{<:CuNonDiffArray}, x::Dual)
     fill!(primal(a), primal(x))
     return a
 end
-function rrule!!(::CoDual{typeof(fill!)}, a::CoDual{<:CuArray,NoFData}, x::CoDual)
+function rrule!!(::CoDual{typeof(fill!)}, a::CoDual{<:CuNonDiffArray}, x::CoDual)
     pa = primal(a)
     old = copy(pa)
     fill!(pa, primal(x))
@@ -1610,13 +1617,8 @@ function _repeat_reduce(
 ) where {N}
     triples = ntuple(3N) do d
         dim, which = fldmod1(d, 3)
-        if which == 1
-            inner[dim]
-        elseif which == 2
-            S[dim]
-        else
-            outer[dim]
-        end
+        which == 1 && return inner[dim]
+        return which == 2 ? S[dim] : outer[dim]
     end
     reduced_axes = ntuple(2N) do d
         dim, which = fldmod1(d, 2)
@@ -1646,10 +1648,10 @@ function rrule!!(
     N = ndims(y)
     S = _repeat_pad(size(px), Val(N))
     outer = _repeat_pad(c, Val(N))
-    ones_ = ntuple(_ -> 1, Val(N))
+    inner = ntuple(_ -> 1, Val(N))
     dy = zero(y)
     function repeat_pb!!(::NoRData)
-        dx .+= reshape(_repeat_reduce(dy, S, ones_, outer), size(dx))
+        dx .+= reshape(_repeat_reduce(dy, S, inner, outer), size(dx))
         return ntuple(_ -> NoRData(), length(counts) + 2)
     end
     return CoDual(y, dy), repeat_pb!!
@@ -2242,14 +2244,10 @@ end
     )
 end
 
-_geam_op(t::Char, M) =
-    if t == 'N'
-        M
-    elseif t == 'T'
-        transpose(M)
-    else
-        adjoint(M)
-    end
+function _geam_op(t::Char, M)
+    t == 'N' && return M
+    return t == 'T' ? transpose(M) : adjoint(M)
+end
 
 @is_primitive(
     MinimalCtx,

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -2532,8 +2532,9 @@ end
 # covers the pure LinearAlgebra fallback path; this rule covers the CUDA.jl path
 # (cublas/linalg.jl line 349) that is reached from `A * B` → `mul!` → matmul dispatch.
 #
-# alpha / beta are treated as non-differentiable (NoTangent / NoFData): they are
-# typically `true`/`false` (from `MulAddMul`) and we never differentiate w.r.t. them.
+# alpha / beta are differentiated.  They are usually `true`/`false` (from `MulAddMul`), which
+# carry no derivative and cost nothing here, but a caller may pass floats — `mul!(C, A, B, α,
+# β)` — and their derivatives are simple: ⟨op_A(A)·op_B(B), dC⟩ and ⟨C_old, dC⟩.
 
 @is_primitive(
     MinimalCtx,
@@ -2555,8 +2556,8 @@ function frule!!(
     tB::Dual{Char,NoTangent},
     A::Dual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
     B::Dual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
-    alpha::Dual{<:Number,NoTangent},
-    beta::Dual{<:Number,NoTangent},
+    alpha::Dual{<:Number},
+    beta::Dual{<:Number},
 )
     pC, dC = matrixify(C)
     pA, dA = matrixify(A)
@@ -2568,11 +2569,15 @@ function frule!!(
     _α = T(primal(alpha))
     _β = T(primal(beta))
     _1 = one(T)
-    # primal: C := α*op_A(A)*op_B(B) + β*C
-    cuBLAS.gemm!(tAv, tBv, _α, pA, pB, _β, pC)
-    # tangent: dC := α*(op_A(dA)*op_B(pB) + op_A(pA)*op_B(dB)) + β*dC
+    # tangent: dC := α*(op_A(dA)*op_B(pB) + op_A(pA)*op_B(dB)) + β*dC + dα*op_A(A)*op_B(B)
+    #               + dβ*C_old.  It runs before the primal so that the dβ term still sees the
+    # old C, which the primal overwrites.
     cuBLAS.gemm!(tAv, tBv, _α, dA, pB, _β, dC)
     cuBLAS.gemm!(tAv, tBv, _α, pA, dB, _1, dC)
+    _geam_scalar_jvp!(dC, tangent(beta), 'N', pC)
+    _blas_product_jvp!(dC, tangent(alpha), _geam_op(tAv, pA), _geam_op(tBv, pB))
+    # primal: C := α*op_A(A)*op_B(B) + β*C
+    cuBLAS.gemm!(tAv, tBv, _α, pA, pB, _β, pC)
     return C
 end
 function rrule!!(
@@ -2582,8 +2587,8 @@ function rrule!!(
     tB::CoDual{Char,NoFData},
     A::CoDual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
     B::CoDual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
-    alpha::CoDual{<:Number,NoFData},
-    beta::CoDual{<:Number,NoFData},
+    alpha::CoDual{<:Number},
+    beta::CoDual{<:Number},
 )
     pC, dC = matrixify(C)
     pA, dA = matrixify(A)
@@ -2613,11 +2618,12 @@ function rrule!!(
         else
             cuBLAS.gemm!('C', tAv, _α, dC, pA, _1, dB)                      # dB += α*dC^H*op_A(A)
         end
+        # Both scalar cotangents read the incoming dC, before β rescales it below.
+        dα = _blas_product_rdata(primal(alpha), _geam_op(tAv, pA), _geam_op(tBv, pB), dC)
+        dβ = _blas_scalar_rdata(primal(beta), pC_copy, dC)
         copyto!(pC, pC_copy)
         dC .*= _cβ  # gradient w.r.t. C_old: ΔC_old = conj(β) * ΔC_new
-        return NoRData(),
-        NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), NoRData(),
-        NoRData()
+        return NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), dα, dβ
     end
     return C, generic_matmatmul!_7arg_pb!!
 end
@@ -2642,12 +2648,27 @@ function _geam_scalar_jvp!(dC, ds::Number, t::Char, X)
     return dC .+= convert(eltype(dC), ds) .* _geam_op(t, X)
 end
 
-# C = s*op(X) + …, so s's cotangent is sum(conj(op(X)) .* dC), projected onto s's own type:
-# a real s over a complex array keeps the real part.  A Bool or Integer s has no derivative;
-# the assertion makes a scalar type that does carry one an error, not a silent zero.
-_geam_scalar_rdata(s::IEEEFloat, X, dC) = oftype(s, real(sum(conj.(X) .* dC)))
-_geam_scalar_rdata(s::Complex{<:IEEEFloat}, X, dC) = oftype(s, sum(conj.(X) .* dC))
-_geam_scalar_rdata(s::Number, X, dC) = zero_rdata(s)::NoRData
+# A scalar factor s multiplying a matrix X into the output takes the real inner product
+# ⟨X, dC⟩ = sum(conj(X) .* dC), projected onto s's own type: a real s over a complex array
+# keeps the real part.  A Bool or Integer s has no derivative; the assertion makes a scalar
+# type that does carry one an error, not a silent zero.
+_blas_scalar_rdata(s::IEEEFloat, X, dC) = oftype(s, real(sum(conj.(X) .* dC)))
+_blas_scalar_rdata(s::Complex{<:IEEEFloat}, X, dC) = oftype(s, sum(conj.(X) .* dC))
+_blas_scalar_rdata(s::Number, X, dC) = zero_rdata(s)::NoRData
+
+# The same, where X is a product the rule never formed: `mul!(C, A, B)` passes Bool scalars,
+# whose rdata is NoRData, and dispatch then skips the matmul rather than computing it to
+# throw it away.  The JVP counterpart skips it for a zero tangent, which is what the float
+# literal in a keyword-free `mul!` carries.
+_blas_product_rdata(s::Number, X1, X2, dC) = zero_rdata(s)::NoRData
+function _blas_product_rdata(s::CuFloatOrComplex, X1, X2, dC)
+    return _blas_scalar_rdata(s, X1 * X2, dC)
+end
+_blas_product_jvp!(dC, ::NoTangent, X1, X2) = dC
+function _blas_product_jvp!(dC, ds::Number, X1, X2)
+    iszero(ds) && return dC
+    return dC .+= convert(eltype(dC), ds) .* (X1 * X2)
+end
 
 @is_primitive(
     MinimalCtx,
@@ -2718,9 +2739,9 @@ function rrule!!(
         return NoRData(),
         NoRData(),
         NoRData(),
-        _geam_scalar_rdata(primal(alpha), _geam_op(tav, pA), dC_copy),
+        _blas_scalar_rdata(primal(alpha), _geam_op(tav, pA), dC_copy),
         NoRData(),
-        _geam_scalar_rdata(primal(beta), _geam_op(tbv, pB), dC_copy),
+        _blas_scalar_rdata(primal(beta), _geam_op(tbv, pB), dC_copy),
         NoRData(),
         NoRData()
     end
@@ -2767,8 +2788,8 @@ function frule!!(
     tA::Dual{<:AbstractChar,NoTangent},
     A::Dual{<:CuMaybeComplexMat,<:CuMaybeComplexMat},
     B::Dual{<:CuMaybeComplexVec,<:CuMaybeComplexVec},
-    alpha::Dual{<:Number,NoTangent},
-    beta::Dual{<:Number,NoTangent},
+    alpha::Dual{<:Number},
+    beta::Dual{<:Number},
 )
     pY, dY = primal(Y), tangent(Y)
     pA, dA = primal(A), tangent(A)
@@ -2780,9 +2801,13 @@ function frule!!(
     _check_gemv_eltypes(T, eltype(pB))
     _check_complex_matvecmul_transpose(T, tAv)
     _1 = one(T)
-    # tangent (product rule): dY = av*op(dA)*pB + av*op(pA)*dB + bv*dY
+    # tangent (product rule): dY = av*op(dA)*pB + av*op(pA)*dB + bv*dY + dav*op(pA)*pB
+    #                              + dbv*Y_old.  The dbv term needs the old Y, so the primal
+    # runs last.
     cuBLAS.gemv!(tAv, av, dA, pB, bv, dY) # dY  = av*op(dA)*pB + bv*dY
     cuBLAS.gemv!(tAv, av, pA, dB, _1, dY) # dY += av*op(pA)*dB
+    _geam_scalar_jvp!(dY, tangent(beta), 'N', pY)
+    _blas_product_jvp!(dY, tangent(alpha), _geam_op(tAv, pA), pB)
     # primal: pY = av*op(pA)*pB + bv*pY
     cuBLAS.gemv!(tAv, av, pA, pB, bv, pY)
     return Y
@@ -2793,8 +2818,8 @@ function rrule!!(
     tA::CoDual{<:AbstractChar,NoFData},
     A::CoDual{<:CuMaybeComplexMat,<:CuMaybeComplexMat},
     B::CoDual{<:CuMaybeComplexVec,<:CuMaybeComplexVec},
-    alpha::CoDual{<:Number,NoFData},
-    beta::CoDual{<:Number,NoFData},
+    alpha::CoDual{<:Number},
+    beta::CoDual{<:Number},
 )
     pY, dY = primal(Y), tangent(Y)
     pA, dA = primal(A), tangent(A)
@@ -2823,10 +2848,13 @@ function rrule!!(
         else
             cuBLAS.gemv!('N', conj(av), pA, dY, _1, dB) # dB += conj(av)*A*ȳ (op(A)^H = A)
         end
+        # Both scalar cotangents read the incoming dY, before beta rescales it below.
+        dav = _blas_product_rdata(av, _geam_op(tAv, pA), pB, dY)
+        dbv = _blas_scalar_rdata(bv, pY_copy, dY)
         # Y tangent passes through scaled by beta
         dY .*= conj(bv)
         copyto!(pY, pY_copy)
-        return NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), NoRData()
+        return NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), dav, dbv
     end
     return Y, generic_matvecmul!_pb!!
 end

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1153,6 +1153,14 @@ for _fn in (:cumsum, :cumprod)
     end
 end
 
+# CUDA scans a `dims`-less `accumulate` in linear order — `reshape(accumulate(op, A[:]),
+# size(A))` — rather than column by column, so an N-d array's adjoint is the vectorised one.
+# cumsum needs no such split: Base rejects it without `dims` past one dimension.
+_scan_jvp(dx, ::Nothing) = reshape(cumsum(vec(dx)), size(dx))
+_scan_jvp(dx, d) = cumsum(dx; dims=d)
+_scan_pullback(dy, ::Nothing) = reshape(reverse(cumsum(reverse(vec(dy)))), size(dy))
+_scan_pullback(dy, d) = reverse(cumsum(reverse(dy; dims=d); dims=d); dims=d)
+
 # Rules for `accumulate(+, x)` — identical to cumsum but via the accumulate interface.
 # Other operators are not supported and throw an informative error (catch-all below).
 @is_primitive(MinimalCtx, Tuple{typeof(accumulate),typeof(+),CuMaybeComplexArray})
@@ -1160,7 +1168,7 @@ function frule!!(
     ::Dual{typeof(accumulate)}, ::Dual{typeof(+)}, x::Dual{<:CuMaybeComplexArray}; kw...
 )
     px, dx = arrayify(x)
-    return Dual(accumulate(+, px; kw...), cumsum(dx; kw...))
+    return Dual(accumulate(+, px; kw...), _scan_jvp(dx, get(kw, :dims, nothing)))
 end
 function rrule!!(
     ::CoDual{typeof(accumulate)},
@@ -1171,9 +1179,9 @@ function rrule!!(
     px, dx = arrayify(x)
     y = accumulate(+, px; kw...)
     dy_out = zero(y)
-    d = get(kw, :dims, 1)
+    d = get(kw, :dims, nothing)
     function accumulate_plus_pb!!(::NoRData)
-        dx .+= reverse(cumsum(reverse(dy_out; dims=d); dims=d); dims=d)
+        dx .+= _scan_pullback(dy_out, d)
         return NoRData(), NoRData(), NoRData()
     end
     return CoDual(y, dy_out), accumulate_plus_pb!!
@@ -1181,13 +1189,15 @@ end
 @is_primitive(MinimalCtx, Tuple{typeof(accumulate),Any,CuArray})
 function frule!!(::Dual{typeof(accumulate)}, op::Dual, x::Dual{<:CuArray}; kwargs...)
     return _throw_gpu_argument_error(
-        "Mooncake: accumulate on CuArray only supports op=+; got op=$(primal(op)). " *
+        "Mooncake: accumulate on CuArray supports only op=+ over a float or complex " *
+        "array; got op=$(primal(op)) over $(typeof(primal(x))). " *
         _UNIMPL_MSG,
     )
 end
 function rrule!!(::CoDual{typeof(accumulate)}, op::CoDual, x::CoDual{<:CuArray}; kwargs...)
     return _throw_gpu_argument_error(
-        "Mooncake: accumulate on CuArray only supports op=+; got op=$(primal(op)). " *
+        "Mooncake: accumulate on CuArray supports only op=+ over a float or complex " *
+        "array; got op=$(primal(op)) over $(typeof(primal(x))). " *
         _UNIMPL_MSG,
     )
 end
@@ -1209,7 +1219,7 @@ function frule!!(
     pkw = primal(kw)
     px, dx = arrayify(x)
     y = accumulate(+, px; pkw...)
-    dy = eltype(y).(cumsum(dx; dims=get(pkw, :dims, 1)))
+    dy = eltype(y).(_scan_jvp(dx, get(pkw, :dims, nothing)))
     return Dual(y, _kw_init_jvp(dy, _kw_init_tangent(tangent(kw)), true))
 end
 function rrule!!(
@@ -1224,9 +1234,9 @@ function rrule!!(
     px, dx = arrayify(x)
     y = accumulate(+, px; pkw...)
     dy_out = zero(y)
-    d = get(pkw, :dims, 1)
+    d = get(pkw, :dims, nothing)
     function accumulate_plus_kw_pb!!(::NoRData)
-        dx .+= reverse(cumsum(reverse(dy_out; dims=d); dims=d); dims=d)
+        dx .+= _scan_pullback(dy_out, d)
         return NoRData(),
         _kw_init_rdata(kw_rdata, dy_out, true), NoRData(), NoRData(),
         NoRData()

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1326,12 +1326,18 @@ end
 # cumsum needs no such split: Base rejects it without `dims` past one dimension.
 _scan_jvp(dx, ::Nothing) = reshape(cumsum(vec(dx)), size(dx))
 _scan_jvp(dx, d) = cumsum(dx; dims=d)
-_scan_pullback(dy, ::Nothing) = reshape(reverse(cumsum(reverse(vec(dy)))), size(dy))
+# `reverse` sizes its grid from the element count and refuses an empty one, while `cumsum`
+# over an empty array is fine — so an empty input reached the pullback and only the pullback.
+# Its adjoint is empty whatever the scan was, including a 0x3 reduced along its non-empty
+# dimension.
+function _scan_pullback(dy, ::Nothing)
+    isempty(dy) ? dy : reshape(reverse(cumsum(reverse(vec(dy)))), size(dy))
+end
 function _scan_pullback(dy, d)
     # Scanning along a dimension the array does not have is the identity — the primal and the
     # JVP both accept it — so the adjoint is the identity too.  `reverse` would refuse that
     # dimension, which is what used to make the pullback the only mode to reject it.
-    d > ndims(dy) && return dy
+    (isempty(dy) || d > ndims(dy)) && return dy
     return reverse(cumsum(reverse(dy; dims=d); dims=d); dims=d)
 end
 # Same boundary seen from `init`: on that identity path CUDA's scan copies the input and

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -4064,7 +4064,10 @@ function _gpu_accum_pullback!(
                 (p, d) -> real(conj(d) * p), partial_slots[meta.slot1], dy_out
             )
             if meta.is_scalar
-                (scalar_grads::Vector{Any})[scalar_index] = sum(contrib)
+                # The partials carry whatever type the broadcast promoted to, which is the
+                # array's eltype whenever it is the wider one, but a leaf's rdata follows
+                # the leaf — the same `oftype` the BLAS scalars take.
+                (scalar_grads::Vector{Any})[scalar_index] = oftype(pa, sum(contrib))
                 scalar_index += 1
             else
                 _leaf_accum_fdata!(pa, fd, contrib)
@@ -4077,7 +4080,10 @@ function _gpu_accum_pullback!(
                 dy_out,
             )
             if meta.is_scalar
-                (scalar_grads::Vector{Any})[scalar_index] = sum(contrib)
+                # The partials carry whatever type the broadcast promoted to, which is the
+                # array's eltype whenever it is the wider one, but a leaf's rdata follows
+                # the leaf — the same `oftype` the BLAS scalars take.
+                (scalar_grads::Vector{Any})[scalar_index] = oftype(pa, sum(contrib))
                 scalar_index += 1
             else
                 _leaf_accum_fdata!(pa, fd, contrib)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1114,10 +1114,9 @@ end
 # The keyword spellings cannot be zero-derivative outright: a float `init` makes the output
 # differentiable, so dropping its derivative would be silently wrong.  Nor is it 1 —
 # GPUArrays folds `init` into a backend-defined number of partial reductions, so `init=1.0`
-# over `[1,2,3]` gives 101.0 — so a nonzero `init` tangent is rejected instead.  Reverse
-# mode has no incoming `init` tangent, and detects the same case from the far side: over a
-# non-differentiable array `init` is the only path a gradient can take, so a nonzero
-# cotangent on the output means the zero rdata would be wrong, not merely conservative.
+# over `[1,2,3]` gives 101.0 — so a nonzero `init` tangent is rejected instead.  Only the
+# frules can check it: reverse mode sees no tangent, and cannot tell a constant `init` from
+# one the caller wants a gradient for, so a guard there rejects correct programs.
 #
 # sum, prod, maximum and minimum all accept `init`; diff/sort/sortperm do not, so the guard
 # is a no-op for those three and one path covers all seven.
@@ -1127,17 +1126,6 @@ function _check_reduction_init(dkw)
     return _throw_gpu_argument_error(
         "Mooncake: keyword reductions over CuArray treat `init` as a constant, but it " *
         "received a nonzero tangent. Differentiating with respect to `init` is not " *
-        "supported. " *
-        _UNIMPL_MSG,
-    )
-end
-
-function _check_reduction_init_cotangent(kw_rdata, dy)
-    (kw_rdata isa NoRData || dy isa NoFData || iszero(dy)) && return nothing
-    return _throw_gpu_argument_error(
-        "Mooncake: keyword reductions over CuArray treat `init` as a constant, but this " *
-        "reduction over a non-differentiable array has a nonzero output cotangent, which " *
-        "only `init` could carry. Differentiating with respect to `init` is not " *
         "supported. " *
         _UNIMPL_MSG,
     )
@@ -1165,15 +1153,11 @@ for _fn in (:sum, :prod, :maximum, :minimum, :diff, :sort, :sortperm)
     )
         pkw = primal(kw)
         kw_rdata = zero_rdata(pkw)
-        out = zero_fcodual($_fn(primal(x); pkw...))
+        y = $_fn(primal(x); pkw...)
         # `::Any`: the output is an Integer without `init` and a float with one, so the
-        # incoming rdata is NoRData or a number depending on the call; a `dims` reduction
-        # carries its cotangent in the output's fdata instead.
-        function nodiff_reduction_kw_pb!!(dy::Any)
-            _check_reduction_init_cotangent(kw_rdata, dy isa NoRData ? tangent(out) : dy)
-            return (NoRData(), kw_rdata, NoRData(), NoRData())
-        end
-        return out, nodiff_reduction_kw_pb!!
+        # incoming rdata is NoRData or a number depending on the call.
+        nodiff_reduction_kw_pb!!(::Any) = (NoRData(), kw_rdata, NoRData(), NoRData())
+        return zero_fcodual(y), nodiff_reduction_kw_pb!!
     end
 end
 

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -2180,11 +2180,22 @@ end
 # frule:    tangent of concatenation = concatenation of tangents (concat is linear).
 # pullback: selectdim returns a view (no allocation per slice); running-offset loop
 #           avoids pre-allocating an offsets array.
+# A real variable's cotangent is real even where the operation that consumed it produced a
+# complex output: Mooncake's convention carries dL/dRe in the real field, and the imaginary
+# part of a real leaf's contribution belongs to no variable.  Concatenating or casting a real
+# array alongside a complex one is where that shows up, and accumulating unprojected would ask
+# the device to convert a Complex to a Float — a kernel-side exception, not a clean error.
+@inline _project_cotangent(dst, contrib) = contrib
+@inline _project_cotangent(dst::AbstractArray{<:Real}, contrib) = real.(contrib)
+@inline _project_cotangent(::Real, contrib) = real(contrib)
+
 @inline function _cu_concat_pb!(fdatas, dy_out, dim::Integer)
     offset = 0
     for i in eachindex(fdatas)
         n = size(fdatas[i], dim)
-        fdatas[i] .+= selectdim(dy_out, dim, (offset + 1):(offset + n))
+        fdatas[i] .+= _project_cotangent(
+            fdatas[i], selectdim(dy_out, dim, (offset + 1):(offset + n))
+        )
         offset += n
     end
     return nothing
@@ -2206,7 +2217,7 @@ end
                 k = findfirst(==(d), dims)
                 k === nothing ? Colon() : (offs[k] + 1):(offs[k] + size(fi, d))
             end
-            fi .+= view(dy_out, ranges...)
+            fi .+= _project_cotangent(fi, view(dy_out, ranges...))
             ntuple(k -> offs[k] + size(fi, dims[k]), Val(K))
         end
     end
@@ -3292,8 +3303,15 @@ end
 
 @inline _gpu_cast_like(::Type{T}, x::AbstractArray) where {T} = T.(x)
 @inline _gpu_cast_like(::Type{T}, x::CuFloatOrComplex) where {T} = convert(T, x)
-@inline _gpu_cast_back_like(pa::AbstractArray, contrib) = eltype(pa).(contrib)
-@inline _gpu_cast_back_like(pa::CuFloatOrComplex, contrib) = convert(typeof(pa), contrib)
+# A real->complex cast leaf gets a complex contribution back; project before narrowing, or
+# the eltype conversion is Float32(::ComplexF32).  Widening casts (Float64.(x32)) are real
+# throughout and unaffected.
+@inline _gpu_cast_back_like(pa::AbstractArray, contrib) = eltype(pa).(
+    _project_cotangent(pa, contrib)
+)
+@inline _gpu_cast_back_like(pa::CuFloatOrComplex, contrib) = convert(
+    typeof(pa), _project_cotangent(pa, contrib)
+)
 
 @inline function _leaf_effective_tangent(_, diff::_GpuBroadcastCastDiff{T}) where {T}
     t_eff = _leaf_effective_tangent(diff.primal_arg, diff.diff_arg)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1963,6 +1963,101 @@ for (_op, _fn) in ((:(+), :sum), (:(Base.:*), :prod))
     end
 end
 
+# The Core.kwcall spellings.  Mooncake lowers every keyword call to Core.kwcall, which the
+# positional claims above do not cover, so `reduce(+, x; dims=1)` and friends escaped to
+# GPUArrays' untraceable reduction kernel.  `reduce` forwards to the sum/prod *keyword* rules,
+# picking up `dims`, `init` and the identity check with them.
+for (_op, _fn) in ((:(+), :sum), (:(Base.:*), :prod))
+    @eval @is_primitive(
+        MinimalCtx,
+        Tuple{
+            typeof(Core.kwcall),NamedTuple,typeof(reduce),typeof($_op),CuMaybeComplexArray
+        },
+    )
+    @eval function frule!!(
+        kc::Dual{typeof(Core.kwcall)},
+        kw::Dual{<:NamedTuple},
+        ::Dual{typeof(reduce)},
+        ::Dual{typeof($_op)},
+        x::Dual{<:CuMaybeComplexArray},
+    )
+        return frule!!(kc, kw, Dual($_fn, NoTangent()), x)
+    end
+    @eval function rrule!!(
+        kc::CoDual{typeof(Core.kwcall)},
+        kw::CoDual{<:NamedTuple},
+        ::CoDual{typeof(reduce)},
+        ::CoDual{typeof($_op)},
+        x::CoDual{<:CuMaybeComplexArray},
+    )
+        y, pb!! = rrule!!(kc, kw, zero_fcodual($_fn), x)
+        function reduce_kw_pb!!(dy)
+            _, r_kw, _, r_x = pb!!(dy)     # delegate pullback: (kwcall, kw, fn, x)
+            return NoRData(), r_kw, NoRData(), NoRData(), r_x
+        end
+        return y, reduce_kw_pb!!
+    end
+end
+
+# mapreduce's keyword spelling equals its positional one exactly when the keywords do not
+# change the reduction: no `dims` (or `dims=:`) and an `init` at the operator's identity.  A
+# real `dims` would need the `sum(f, x; dims)` rule that is not written yet, and a
+# non-identity `init` is refused for the folding reason `sum` refuses it.
+_mapreduce_kw_is_plain(pkw) = get(pkw, :dims, :) isa Colon
+for _op in (:(+), :(Base.add_sum))
+    @eval @is_primitive(
+        MinimalCtx,
+        Tuple{
+            typeof(Core.kwcall),
+            NamedTuple,
+            typeof(mapreduce),
+            Any,
+            typeof($_op),
+            CuMaybeComplexArray,
+        },
+    )
+    @eval function frule!!(
+        ::Dual{typeof(Core.kwcall)},
+        kw::Dual{<:NamedTuple},
+        ::Dual{typeof(mapreduce)},
+        f::Dual,
+        ::Dual{typeof($_op)},
+        x::Dual{<:CuMaybeComplexArray},
+    )
+        pkw = primal(kw)
+        _check_reduction_identity(sum, pkw)
+        _mapreduce_kw_is_plain(pkw) || return _throw_gpu_mapreduce_dims()
+        return frule!!(Dual(sum, NoTangent()), f, x)
+    end
+    @eval function rrule!!(
+        ::CoDual{typeof(Core.kwcall)},
+        kw::CoDual{<:NamedTuple},
+        ::CoDual{typeof(mapreduce)},
+        f::CoDual,
+        ::CoDual{typeof($_op)},
+        x::CoDual{<:CuMaybeComplexArray},
+    )
+        pkw = primal(kw)
+        _check_reduction_identity(sum, pkw)
+        _mapreduce_kw_is_plain(pkw) || return _throw_gpu_mapreduce_dims()
+        kw_rdata = zero_rdata(pkw)
+        y, pb!! = rrule!!(zero_fcodual(sum), f, x)
+        function mapreduce_kw_pb!!(dy)
+            _, r_f, r_x = pb!!(dy)          # delegate pullback: (sum, f, x)
+            return NoRData(), kw_rdata, NoRData(), r_f, NoRData(), r_x
+        end
+        return y, mapreduce_kw_pb!!
+    end
+end
+function _throw_gpu_mapreduce_dims()
+    return _throw_gpu_argument_error(
+        "Mooncake: keyword mapreduce(f, op, x; dims) on CuArray is not yet differentiable, " *
+        "for the same reason keyword sum(f, x; dims) is not: it needs the mapped rule's " *
+        "NDual machinery combined with per-slice geometry. " *
+        _UNIMPL_MSG,
+    )
+end
+
 # Catch-all rules for unsupported operators — give a clear error rather than letting
 # Mooncake attempt to trace into an opaque CUDA reduction kernel.
 @is_primitive(MinimalCtx, Tuple{typeof(mapreduce),Any,Any,CuArray})
@@ -1997,6 +2092,49 @@ function rrule!!(::CoDual{typeof(reduce)}, op::CoDual, x::CoDual{<:CuArray})
         "got op=$(primal(op)). " *
         _UNIMPL_MSG,
     )
+end
+
+@is_primitive(
+    MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(mapreduce),Any,Any,CuArray}
+)
+function frule!!(
+    ::Dual{typeof(Core.kwcall)},
+    ::Dual{<:NamedTuple},
+    f::Dual{typeof(mapreduce)},
+    mf::Dual,
+    op::Dual,
+    x::Dual{<:CuArray},
+)
+    return frule!!(f, mf, op, x)
+end
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    ::CoDual{<:NamedTuple},
+    f::CoDual{typeof(mapreduce)},
+    mf::CoDual,
+    op::CoDual,
+    x::CoDual{<:CuArray},
+)
+    return rrule!!(f, mf, op, x)
+end
+@is_primitive(MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(reduce),Any,CuArray})
+function frule!!(
+    ::Dual{typeof(Core.kwcall)},
+    ::Dual{<:NamedTuple},
+    f::Dual{typeof(reduce)},
+    op::Dual,
+    x::Dual{<:CuArray},
+)
+    return frule!!(f, op, x)
+end
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    ::CoDual{<:NamedTuple},
+    f::CoDual{typeof(reduce)},
+    op::CoDual,
+    x::CoDual{<:CuArray},
+)
+    return rrule!!(f, op, x)
 end
 
 # repeat on GPU arrays, both the `counts...` and the `inner=`/`outer=` spellings.

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1098,37 +1098,59 @@ end
 
 # Rules for `cumprod(x)` on GPU arrays.
 #
-# y[k] = Πᵢ₌₁ᵏ x[i],  ∂y[k]/∂x[i] = y[k]/x[i] if i≤k else 0
-# frule:    dy[k] = y[k] · cumsum(dx ./ x)[k]
-# pullback: dx[i] += (1/x[i]) · Σₖ≥ᵢ dy[k]·y[k]
-#           i.e.  dx .+= reverse(cumsum(reverse(dy .* y))) ./ x
+# y[k] = Πᵢ₌₁ᵏ x[i], so ∂y[k]/∂x[i] for i ≤ k is that prefix product with x[i] excluded.
+# Excluding it by dividing y[k] by x[i] fails at a zero, exactly as it did for `prod`, and the
+# same accounting fixes it — per prefix rather than per slice: a nonzero x[i] contributes only
+# to prefixes that hold no zero at all, a zero x[i] only to prefixes where it is the only
+# zero, and a prefix holding two zeros has no derivative anywhere. `nzeros` and `pnz` are the
+# cumulative forms of the two reductions `_prod_exclusive` uses; `denom` is x with its zeros
+# replaced by ones, so nothing ever divides by zero.
 #
-# Zero elements: when x[i] == 0 the cumulative product y[k] == 0 for all k ≥ i,
-# so the Jacobian at that position is zero (the zero annihilates the product).
-# nan_tangent_guard is used to return zero instead of NaN/Inf from 0/0 or x/0.
+#   dy[k] = pnz[k] · (nzeros[k] == 0 ? cumsum(dx ./ denom)[k] :
+#                     nzeros[k] == 1 ? cumsum(dx at the zeros)[k] : 0)
+#   dx[i] += (Σ over k ≥ i of dy[k]·pnz[k], masked to the prefixes i contributes to) / denom[i]
+function _cumprod_pieces(px, d)
+    T = eltype(px)
+    zero_at = iszero.(px)
+    denom = ifelse.(zero_at, one(T), px)
+    return zero_at, cumsum(zero_at; dims=d), cumprod(denom; dims=d), denom
+end
+
 @is_primitive(MinimalCtx, Tuple{typeof(cumprod),CuMaybeComplexArray})
 function frule!!(::Dual{typeof(cumprod)}, x::Dual{<:CuMaybeComplexArray}; kw...)
     px, dx = arrayify(x)
+    d = get(kw, :dims, 1)
     y = cumprod(px; kw...)
-    inv_px = nan_tangent_guard.(px, inv.(px))
-    dy = y .* cumsum(dx .* inv_px; kw...)
-    return Dual(y, dy)
+    zero_at, nzeros, pnz, denom = _cumprod_pieces(px, d)
+    from_nonzeros = cumsum(dx ./ denom; dims=d)
+    from_the_zero = cumsum(ifelse.(zero_at, dx, zero(eltype(dx))); dims=d)
+    contribution = ifelse.(
+        iszero.(nzeros),
+        from_nonzeros,
+        ifelse.(nzeros .== 1, from_the_zero, zero(eltype(dx))),
+    )
+    return Dual(y, pnz .* contribution)
 end
 function rrule!!(::CoDual{typeof(cumprod)}, x::CoDual{<:CuMaybeComplexArray}; kw...)
     px, dx = arrayify(x)
     y = cumprod(px; kw...)
     dy_out = zero(y)
     d = get(kw, :dims, 1)
-    # Pre-compute once at rule construction time: reused on every pullback call.
-    # nan_tangent_guard: where px == 0 the product is annihilated (zero gradient).
-    inv_cx_px = nan_tangent_guard.(px, inv.(conj.(px)))
+    # Pre-computed once at rule construction time: reused on every pullback call.
+    zero_at, nzeros, pnz, denom = _cumprod_pieces(px, d)
+    clean, only_zero = iszero.(nzeros), nzeros .== 1
+    cpnz, cdenom = conj.(pnz), conj.(denom)
     function cumprod_pb!!(::NoRData)
-        # Wirtinger chain rule: Δxᵢ = (1/conj(xᵢ)) · Σₖ≥ᵢ Δyₖ · conj(yₖ)
-        # i.e. dx .+= reverse(cumsum(reverse(dy .* conj.(y)))) ./ conj.(px)
-        # For real inputs conj is a no-op, so this is backward compatible.
+        # Wirtinger chain rule: Δxᵢ = Σₖ≥ᵢ Δyₖ · conj(∂yₖ/∂xᵢ).  For real inputs conj is a
+        # no-op.  A nonzero xᵢ reads the prefixes with no zero, a zero xᵢ those where it is
+        # the only one, so the two masked reverse scans cover every case.
+        weighted = dy_out .* cpnz
         dx .+=
-            reverse(cumsum(reverse(dy_out .* conj.(y); dims=d); dims=d); dims=d) .*
-            inv_cx_px
+            ifelse.(
+                zero_at,
+                _scan_pullback(weighted .* only_zero, d),
+                _scan_pullback(weighted .* clean, d),
+            ) ./ cdenom
         return NoRData(), NoRData()
     end
     return CoDual(y, dy_out), cumprod_pb!!

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -984,38 +984,46 @@ for _fn in (:maximum, :minimum)
     )
 end
 
-# Rules for `prod(x)` on GPU arrays.
+# Rules for `prod(x)` on GPU arrays, bare and `dims`.
 #
-# prod(x) = x₁·x₂·…·xₙ,  ∂prod/∂xᵢ = prod(x)/xᵢ
-# frule:    dy = prod(x) · sum(dx ./ x)
-# pullback: dx[i] += dy · prod(x) / x[i]
+# ∂prod/∂xᵢ is the product of xᵢ's slice excluding xᵢ.  Reading that off as y/xᵢ divides by
+# zero precisely where the answer is not zero, so it is built from two reductions instead: a
+# nonzero xᵢ contributes only when its slice holds no zero at all, and a zero xᵢ contributes
+# the product of the rest when it is its slice's only zero.  Two zeros in a slice leave every
+# derivative in it zero.  `prod` is a polynomial, so none of this is a non-differentiable
+# point — the exclusion is what the division could not express.
 #
-# Note: undefined when any element of x is zero (gradient is skipped in that case).
+# Both quantities come from the same reduction the primal ran, over `px` with its zeros
+# replaced by ones, so an `init` folded into a backend-defined number of partial reductions
+# scales the derivative exactly as it scaled the value.
+function _prod_exclusive(px, dims, kw)
+    T = eltype(px)
+    nonzero = ifelse.(iszero.(px), one(T), px)
+    pnz = prod(nonzero; kw...)
+    nzeros = sum(iszero.(px); dims=dims)
+    contributes = ifelse.(iszero.(px), nzeros .== 1, iszero.(nzeros))
+    return ifelse.(contributes, pnz ./ nonzero, zero(T))
+end
+
 @is_primitive(MinimalCtx, Tuple{typeof(prod),CuMaybeComplexArray})
 function frule!!(::Dual{typeof(prod)}, x::Dual{<:CuMaybeComplexArray})
     px, dx = arrayify(x)
-    y = prod(px)
-    dy = iszero(y) ? zero(y) : y * sum(dx ./ px)
-    return Dual(y, dy)
+    return Dual(prod(px), sum(dx .* _prod_exclusive(px, :, (;))))
 end
 function rrule!!(::CoDual{typeof(prod)}, x::CoDual{<:CuMaybeComplexArray})
     px, dx = arrayify(x)
-    y = prod(px)
+    excl = _prod_exclusive(px, :, (;))
     function prod_pb!!(dy)
-        # Wirtinger chain rule for holomorphic prod: Δxᵢ = Δy · conj(y/xᵢ)
-        # For real inputs conj is a no-op, so this is backward compatible.
-        # iszero triggers a device→host sync — inherent since we branch on the scalar result.
-        iszero(y) || (dx .+= dy .* conj.(y ./ px))
+        # Wirtinger chain rule for holomorphic prod: Δxᵢ = Δy · conj(∂prod/∂xᵢ).
+        # For real inputs conj is a no-op.
+        dx .+= dy .* conj.(excl)
         return NoRData(), NoRData()
     end
-    return zero_fcodual(y), prod_pb!!
+    return zero_fcodual(prod(px)), prod_pb!!
 end
 
-# `prod(x; dims)`: the same derivative per reduced slice, y_j/x_i for x_i in slice j, which
-# broadcasts because the reduced dimensions stay singleton.  The zero-element caveat is also
-# per slice, and nan_tangent_guard applies it without the bare rule's device→host sync: a
-# slice containing a zero has y_j == 0, so every term in it drops.  `init` multiplies into a
-# backend-defined number of partial reductions, so like `sum` it stays a constant.
+# The `dims` spelling: the same exclusive product per reduced slice, which broadcasts because
+# the reduced dimensions stay singleton.
 @is_primitive(
     MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(prod),CuMaybeComplexArray}
 )
@@ -1028,13 +1036,12 @@ function frule!!(
     pkw = primal(kw)
     _check_reduction_init(tangent(kw))
     px, dx = arrayify(x)
+    dims = get(pkw, :dims, :)
     y = prod(px; pkw...)
-    inv_px = nan_tangent_guard.(px, inv.(px))
     # `init` fixes the output eltype, and the tangent has to follow it.  Converting after
     # the reduction rather than seeding it: a widening seed over a broadcast fails to
     # compile a kernel.
-    dy = eltype(y).(sum(dx .* inv_px; dims=get(pkw, :dims, :)))
-    return Dual(y, y .* dy)
+    return Dual(y, eltype(y).(sum(dx .* _prod_exclusive(px, dims, pkw); dims=dims)))
 end
 function rrule!!(
     ::CoDual{typeof(Core.kwcall)},
@@ -1045,18 +1052,19 @@ function rrule!!(
     pkw = primal(kw)
     kw_rdata = zero_rdata(pkw)
     px, dx = arrayify(x)
+    dims = get(pkw, :dims, :)
     y = prod(px; pkw...)
-    inv_cx_px = nan_tangent_guard.(px, inv.(conj.(px)))
-    if get(pkw, :dims, :) isa Colon
+    excl = conj.(_prod_exclusive(px, dims, pkw))
+    if dims isa Colon
         function prod_kw_scalar_pb!!(dy)
-            dx .+= dy .* conj.(y) .* inv_cx_px
+            dx .+= dy .* excl
             return NoRData(), kw_rdata, NoRData(), NoRData()
         end
         return CoDual(y, NoFData()), prod_kw_scalar_pb!!
     end
     dy_out = zero(y)
     function prod_kw_array_pb!!(::NoRData)
-        dx .+= dy_out .* conj.(y) .* inv_cx_px
+        dx .+= dy_out .* excl
         return NoRData(), kw_rdata, NoRData(), NoRData()
     end
     return CoDual(y, dy_out), prod_kw_array_pb!!

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -1928,8 +1928,11 @@ end
 @is_primitive MinimalCtx Tuple{typeof(unsafe_free!),CuArray}
 function frule!!(::Dual{typeof(unsafe_free!)}, x::Dual{<:CuArray})
     unsafe_free!(primal(x))
+    # The claim covers index and mask arrays too, whose forward tangent is `NoTangent`, so
+    # test for the thing to be freed rather than against the reverse mode's empty type: a
+    # float array's forward tangent is a CuArray and never `NoFData` anyway.
     dx = tangent(x)
-    dx isa NoFData || unsafe_free!(dx)
+    dx isa CuArray && unsafe_free!(dx)
     return Dual(nothing, NoTangent())
 end
 function rrule!!(::CoDual{typeof(unsafe_free!)}, x::CoDual{<:CuArray})
@@ -3918,8 +3921,9 @@ end
 # `_premat_nondiff_args` before the kernel ever sees it; the one at the top is the only one
 # that survives, because nothing materializes the tree's own root.
 _desugar_casts(x) = x
-_desugar_casts(bc::Broadcasted{S}) where {S} =
+function _desugar_casts(bc::Broadcasted{S}) where {S}
     bc.f isa Type ? Broadcasted{S}(_CastTo{bc.f}(), bc.args, bc.axes) : bc
+end
 
 function _prepare_gpu_broadcast(bc_primal, tangent_or_fdata)
     _check_gpu_bcast_captures(bc_primal)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -453,12 +453,18 @@ _register_cudataref_internal_types!()
 # for those, but Mooncake may infer MutableTangent for the inner RefCounted struct,
 # causing a tangent type mismatch.
 @zero_derivative MinimalCtx Tuple{typeof(Base.mightalias),T,S} where {T<:CuArray,S<:CuArray}
-# CuArray{<:Integer} and CuArray{<:Bool} are index/mask arrays — not differentiable.
-# Assigning NoTangent stops Mooncake from building a struct tangent from CuArray's
-# internal fields (data::CuDataRef, maxsize::Int, offset::Int, dims::NTuple).
+# CuArray{<:Integer}, {<:Bool} and {<:CartesianIndex} are index/mask arrays — not
+# differentiable. Assigning NoTangent stops Mooncake from building a struct tangent from
+# CuArray's internal fields (data::CuDataRef, maxsize::Int, offset::Int, dims::NTuple).
 # The CuMaybeComplexArray rule above takes priority for float and complex arrays.
-tangent_type(::Type{<:CuArray{<:Union{Integer,Bool}}}) = NoTangent
-tangent_type(::Type{<:CuArray{<:Union{Integer,Bool}}}, ::Type{NoRData}) = NoTangent
+# This is a whitelist: an eltype outside it whose tangent_type is NoTangent (Char, Symbol,
+# Enum) still falls through to the struct handler and builds an unconstructible tangent.
+tangent_type(::Type{<:CuArray{<:Union{Integer,Bool,CartesianIndex}}}) = NoTangent
+function tangent_type(
+    ::Type{<:CuArray{<:Union{Integer,Bool,CartesianIndex}}}, ::Type{NoRData}
+)
+    NoTangent
+end
 
 tangent(p::CuMaybeComplexArray, ::NoRData) = p
 
@@ -488,8 +494,8 @@ function TestUtils.has_equal_data_internal(
 end
 function TestUtils.has_equal_data_internal(
     x::P, y::P, equal_undefs::Bool, d::IdDict{Any,Bool}
-) where {P<:CuArray{<:Union{Integer,Bool}}}
-    # For integer/bool CuArrays, compare by content by downloading to CPU.
+) where {P<:CuArray{<:Union{Integer,Bool,CartesianIndex}}}
+    # For non-differentiable CuArrays, compare by content by downloading to CPU.
     size(x) != size(y) && return false
     return Array(x) == Array(y)
 end
@@ -725,7 +731,9 @@ function rrule!!(
     return _throw_gpu_argument_error(_SCALAR_IDX_MSG)
 end
 
-# Vector indexing: y = x[idx] where idx is a vector of integers (gather).
+# Vector indexing: y = x[idx] where idx is a vector of linear or Cartesian indices
+# (gather).  Without the CartesianIndex arm the trace falls into `checkbounds`, which
+# reduces with `&` and hits the mapreduce catch-all.
 #
 # frule:    dy = dx[idx]          (gather tangents)
 # pullback: dx[idx] .+= dy_out   (scatter-add cotangents)
@@ -733,12 +741,15 @@ end
 # Note: repeated indices in idx are undefined (last write wins on GPU without atomics).
 # Distinct-index usage (e.g. embedding lookup, slicing) is safe.
 @is_primitive(
-    MinimalCtx, Tuple{typeof(getindex),CuMaybeComplexArray,AbstractVector{<:Integer}}
+    MinimalCtx,
+    Tuple{
+        typeof(getindex),CuMaybeComplexArray,AbstractVector{<:Union{Integer,CartesianIndex}}
+    },
 )
 function frule!!(
     ::Dual{typeof(getindex)},
     x::Dual{<:CuMaybeComplexArray},
-    idx::Dual{<:AbstractVector{<:Integer}},
+    idx::Dual{<:AbstractVector{<:Union{Integer,CartesianIndex}}},
 )
     px, dx = arrayify(x)
     return Dual(px[primal(idx)], dx[primal(idx)])
@@ -746,7 +757,7 @@ end
 function rrule!!(
     ::CoDual{typeof(getindex)},
     x::CoDual{<:CuMaybeComplexArray},
-    idx::CoDual{<:AbstractVector{<:Integer}},
+    idx::CoDual{<:AbstractVector{<:Union{Integer,CartesianIndex}}},
 )
     px, dx = arrayify(x)
     pidx = primal(idx)
@@ -1068,6 +1079,73 @@ function rrule!!(
         return NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), NoRData()
     end
     return dest, mixed_copyto!_pb!!
+end
+
+# `unsafe_copyto!` and `fill!` into a device array whose elements carry no derivative
+# information (index arrays, masks).  The rules above all require a tangent array, so
+# these spellings had no rule at all and died in the same try/catch and fill kernel.
+# Keying the methods on the tangent being NoTangent keeps them disjoint from those rules
+# without enumerating element types.  There is no gradient to propagate, but the pullback
+# must still undo the mutation, or re-running the rule would see a different array.
+#
+# Note the asymmetry in `src`: a CPU Array{Int} has fdata Vector{NoTangent}, and only the
+# CuArray side collapses to NoTangent, so `src`'s tangent is left unconstrained.
+@is_primitive(
+    MinimalCtx,
+    Tuple{typeof(unsafe_copyto!),CuArray,Integer,Union{Array,CuArray},Integer,Integer},
+)
+function frule!!(
+    ::Dual{typeof(unsafe_copyto!)},
+    dest::Dual{<:CuArray,NoTangent},
+    doffs::Dual{<:Integer,NoTangent},
+    src::Dual{<:Union{Array,CuArray}},
+    soffs::Dual{<:Integer,NoTangent},
+    n::Dual{<:Integer,NoTangent},
+)
+    unsafe_copyto!(primal(dest), primal(doffs), primal(src), primal(soffs), primal(n))
+    return dest
+end
+function rrule!!(
+    ::CoDual{typeof(unsafe_copyto!)},
+    dest::CoDual{<:CuArray,NoFData},
+    doffs::CoDual{<:Integer,NoFData},
+    src::CoDual{<:Union{Array,CuArray}},
+    soffs::CoDual{<:Integer,NoFData},
+    n::CoDual{<:Integer,NoFData},
+)
+    pdest = primal(dest)
+    doffs_v, n_v = primal(doffs), primal(n)
+    dest_range = doffs_v:(doffs_v + n_v - 1)
+    saved = copy(view(pdest, dest_range))
+    unsafe_copyto!(pdest, doffs_v, primal(src), primal(soffs), n_v)
+    function unsafe_copyto!_nodiff_pb!!(::NoRData)
+        copyto!(view(pdest, dest_range), saved)
+        return NoRData(), NoRData(), NoRData(), NoRData(), NoRData(), NoRData()
+    end
+    return dest, unsafe_copyto!_nodiff_pb!!
+end
+
+@is_primitive(MinimalCtx, Tuple{typeof(fill!),CuArray,Any})
+function frule!!(::Dual{typeof(fill!)}, a::Dual{<:CuArray,NoTangent}, x::Dual)
+    fill!(primal(a), primal(x))
+    return a
+end
+function rrule!!(::CoDual{typeof(fill!)}, a::CoDual{<:CuArray,NoFData}, x::CoDual)
+    pa = primal(a)
+    old = copy(pa)
+    fill!(pa, primal(x))
+    function fill!_nodiff_pb!!(::NoRData)
+        copyto!(pa, old)
+        # `a` has no tangent, so nothing reaches `x`: a typed zero, not NoRData, unless
+        # `x` is itself non-differentiable.
+        dx = if tangent_type(typeof(primal(x))) == NoTangent
+            NoRData()
+        else
+            zero_rdata(primal(x))
+        end
+        return NoRData(), NoRData(), dx
+    end
+    return a, fill!_nodiff_pb!!
 end
 
 # unsafe_free! releases GPU memory early (normally handled by GC finalizer).
@@ -1398,6 +1476,103 @@ function rrule!!(::CoDual{typeof(reduce)}, op::CoDual, x::CoDual{<:CuArray})
         "got op=$(primal(op)). " *
         _UNIMPL_MSG,
     )
+end
+
+# repeat on GPU arrays, both the `counts...` and the `inner=`/`outer=` spellings.
+# Both launch a kernel Mooncake cannot trace, and the keyword form needs its own claim
+# because the positional one does not cover Core.kwcall.
+#
+# repeat places the copy of x[i] for inner offset k and outer offset o at
+# k + (i-1)*I + (o-1)*I*S along each dimension, which is exactly column-major
+# (inner, size, outer).  So the pullback reshapes the cotangent into those triples and
+# sums the inner and outer axes away — reshape plus a dims-reduction, with no scalar
+# indexing.  ChainRules instead loops over `pairs(IndexCartesian(), dY)` for the keyword
+# form, which cannot run on a device.
+#
+# `counts` may be shorter than ndims(x) (padded with 1) or longer (the result gains
+# dimensions), so sizes are padded to ndims of the output and the result reshaped back.
+function _repeat_reduce(
+    dY, S::NTuple{N,Int}, inner::NTuple{N,Int}, outer::NTuple{N,Int}
+) where {N}
+    triples = ntuple(3N) do d
+        dim, which = fldmod1(d, 3)
+        if which == 1
+            inner[dim]
+        elseif which == 2
+            S[dim]
+        else
+            outer[dim]
+        end
+    end
+    reduced_axes = ntuple(2N) do d
+        dim, which = fldmod1(d, 2)
+        which == 1 ? 3dim - 2 : 3dim
+    end
+    return reshape(sum(reshape(dY, triples); dims=reduced_axes), S)
+end
+
+_repeat_pad(t, ::Val{N}) where {N} = ntuple(d -> d <= length(t) ? Int(t[d]) : 1, N)
+
+@is_primitive(MinimalCtx, Tuple{typeof(repeat),CuMaybeComplexArray,Vararg{Integer}})
+function frule!!(
+    ::Dual{typeof(repeat)}, x::Dual{<:CuMaybeComplexArray}, counts::Vararg{Dual{<:Integer}}
+)
+    px, dx = arrayify(x)
+    c = map(primal, counts)
+    return Dual(repeat(px, c...), repeat(dx, c...))
+end
+function rrule!!(
+    ::CoDual{typeof(repeat)},
+    x::CoDual{<:CuMaybeComplexArray},
+    counts::Vararg{CoDual{<:Integer}},
+)
+    px, dx = arrayify(x)
+    c = map(primal, counts)
+    y = repeat(px, c...)
+    N = ndims(y)
+    S = _repeat_pad(size(px), Val(N))
+    outer = _repeat_pad(c, Val(N))
+    ones_ = ntuple(_ -> 1, Val(N))
+    dy = zero(y)
+    function repeat_pb!!(::NoRData)
+        dx .+= reshape(_repeat_reduce(dy, S, ones_, outer), size(dx))
+        return ntuple(_ -> NoRData(), length(counts) + 2)
+    end
+    return CoDual(y, dy), repeat_pb!!
+end
+
+@is_primitive(
+    MinimalCtx, Tuple{typeof(Core.kwcall),NamedTuple,typeof(repeat),CuMaybeComplexArray}
+)
+function frule!!(
+    ::Dual{typeof(Core.kwcall)},
+    kw::Dual{<:NamedTuple},
+    ::Dual{typeof(repeat)},
+    x::Dual{<:CuMaybeComplexArray},
+)
+    pkw = primal(kw)
+    px, dx = arrayify(x)
+    return Dual(repeat(px; pkw...), repeat(dx; pkw...))
+end
+function rrule!!(
+    ::CoDual{typeof(Core.kwcall)},
+    kw::CoDual{<:NamedTuple},
+    ::CoDual{typeof(repeat)},
+    x::CoDual{<:CuMaybeComplexArray},
+)
+    pkw = primal(kw)
+    px, dx = arrayify(x)
+    y = repeat(px; pkw...)
+    N = ndims(y)
+    S = _repeat_pad(size(px), Val(N))
+    inner = _repeat_pad(get(pkw, :inner, ()), Val(N))
+    outer = _repeat_pad(get(pkw, :outer, ()), Val(N))
+    dy = zero(y)
+    function repeat_kw_pb!!(::NoRData)
+        dx .+= reshape(_repeat_reduce(dy, S, inner, outer), size(dx))
+        return NoRData(), NoRData(), NoRData(), NoRData()
+    end
+    return CoDual(y, dy), repeat_kw_pb!!
 end
 
 # vcat / hcat / cat on CuMaybeWrappedArray (see its definition above for what that
@@ -1844,6 +2019,104 @@ function rrule!!(
         NoRData()
     end
     return C, generic_matmatmul!_7arg_pb!!
+end
+
+# cuBLAS.geam!: C := alpha*op_a(A) + beta*op_b(B).  This is the foreign-call boundary
+# reached by `A + B` and `A - B` on CuMatrix, which cuBLAS generates for all nine
+# Transpose/Adjoint combinations (cuBLAS/src/linalg.jl).  Tracing further reaches the
+# ccall, whose scalars are passed as CuRef{T} — a primitive type with no tangent_type,
+# which is the error users actually see; defining that tangent_type would only move the
+# failure to the ccall itself.
+#
+# alpha and beta are treated as constants.  Unlike the gemm! rules, they cannot be typed
+# as NoTangent: the generated `+`/`-` pass `one(T)`, a float literal, so they arrive with
+# a real (zero) tangent.  A nonzero tangent would be silently dropped, so reject it.
+@inline function _check_geam_scalar(t, name)
+    (t isa NoTangent || iszero(t)) && return nothing
+    return _throw_gpu_argument_error(
+        "Mooncake: geam! treats `$name` as a constant, but it received a nonzero " *
+        "tangent. Differentiating with respect to it is not supported. " *
+        _UNIMPL_MSG,
+    )
+end
+
+_geam_op(t::Char, M) = if t == 'N'
+    M
+elseif t == 'T'
+    transpose(M)
+else
+    adjoint(M)
+end
+
+@is_primitive(
+    MinimalCtx,
+    Tuple{
+        typeof(cuBLAS.geam!),
+        Char,
+        Char,
+        Number,
+        CuMaybeComplexArray,
+        Number,
+        CuMaybeComplexArray,
+        CuMaybeComplexArray,
+    },
+)
+function frule!!(
+    ::Dual{typeof(cuBLAS.geam!)},
+    ta::Dual{Char,NoTangent},
+    tb::Dual{Char,NoTangent},
+    alpha::Dual{<:Number},
+    A::Dual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
+    beta::Dual{<:Number},
+    B::Dual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
+    C::Dual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
+)
+    _check_geam_scalar(tangent(alpha), "alpha")
+    _check_geam_scalar(tangent(beta), "beta")
+    pA, dA = matrixify(A)
+    pB, dB = matrixify(B)
+    pC, dC = matrixify(C)
+    T = eltype(pA)
+    tav, tbv = primal(ta), primal(tb)
+    _a, _b = T(primal(alpha)), T(primal(beta))
+    cuBLAS.geam!(tav, tbv, _a, pA, _b, pB, pC)
+    cuBLAS.geam!(tav, tbv, _a, dA, _b, dB, dC)
+    return C
+end
+function rrule!!(
+    ::CoDual{typeof(cuBLAS.geam!)},
+    ta::CoDual{Char,NoFData},
+    tb::CoDual{Char,NoFData},
+    alpha::CoDual{<:Number},
+    A::CoDual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
+    beta::CoDual{<:Number},
+    B::CoDual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
+    C::CoDual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
+)
+    pA, dA = matrixify(A)
+    pB, dB = matrixify(B)
+    pC, dC = matrixify(C)
+    T = eltype(pA)
+    tav, tbv = primal(ta), primal(tb)
+    _a, _b = T(primal(alpha)), T(primal(beta))
+    pC_copy = copy(pC)
+    cuBLAS.geam!(tav, tbv, _a, pA, _b, pB, pC)
+    function geam!_pb!!(::NoRData)
+        dA .+= conj(_a) .* _geam_op(tav, dC)
+        dB .+= conj(_b) .* _geam_op(tbv, dC)
+        copyto!(pC, pC_copy)
+        # geam has no C_old term, so C's cotangent is consumed rather than scaled.
+        fill!(dC, zero(T))
+        return NoRData(),
+        NoRData(),
+        NoRData(),
+        zero_rdata(primal(alpha)),
+        NoRData(),
+        zero_rdata(primal(beta)),
+        NoRData(),
+        NoRData()
+    end
+    return C, geam!_pb!!
 end
 
 # Rule for `LinearAlgebra.generic_matvecmul!` on real and complex GPU arrays.

--- a/src/rules/blas.jl
+++ b/src/rules/blas.jl
@@ -304,22 +304,18 @@ function frule!!(
 ) where {T<:BlasFloat}
     y = BLAS.nrm2(primal(n), primal(X_dX), primal(incx))
     X, dX = viewify(primal(n), X_dX, primal(incx))
+    # X[i]*dX[i] overflows once norm(X)*norm(dX) leaves T's range, though the JVP it
+    # divides down to is representable. Scaling X by the power of two nearest y is exact,
+    # so in-range results are unchanged; a subnormal y has no representable reciprocal,
+    # and with every X[i] subnormal too it needs none.
+    r = isfinite(y) && !iszero(y) ? ldexp(one(y), -exponent(y)) : one(y)
+    isfinite(r) || (r = one(y))
     dy = zero(y)
     @inbounds for i in eachindex(X)
-        dy = dy + real(X[i] * dX[i]') + real(X[i]' * dX[i])
+        xi = X[i] * r
+        dy = dy + real(xi * dX[i]') + real(xi' * dX[i])
     end
-    # X[i]*dX[i] overflows once norm(X)*norm(dX) leaves T's range, while the JVP it
-    # divides down to is still representable. Retry scaled, but only from a non-finite
-    # accumulator, so a correct result never pays for the second pass.
-    if !isfinite(dy) && isfinite(y) && !iszero(y)
-        dy = zero(y)
-        @inbounds for i in eachindex(X)
-            xi = X[i] / y
-            dy = dy + real(xi * dX[i]') + real(xi' * dX[i])
-        end
-        return Dual(y, dy / 2)
-    end
-    return Dual(y, dy / 2y)
+    return Dual(y, dy / 2(y * r))
 end
 function rrule!!(
     ::CoDual{typeof(BLAS.nrm2)},

--- a/src/rules/blas.jl
+++ b/src/rules/blas.jl
@@ -308,6 +308,17 @@ function frule!!(
     @inbounds for i in eachindex(X)
         dy = dy + real(X[i] * dX[i]') + real(X[i]' * dX[i])
     end
+    # X[i]*dX[i] overflows once norm(X)*norm(dX) leaves T's range, while the JVP it
+    # divides down to is still representable. Retry scaled, but only from a non-finite
+    # accumulator, so a correct result never pays for the second pass.
+    if !isfinite(dy) && isfinite(y) && !iszero(y)
+        dy = zero(y)
+        @inbounds for i in eachindex(X)
+            xi = X[i] / y
+            dy = dy + real(xi * dX[i]') + real(xi' * dX[i])
+        end
+        return Dual(y, dy / 2)
+    end
     return Dual(y, dy / 2y)
 end
 function rrule!!(

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1283,9 +1283,11 @@ while failing `err`, so pin the type only where the rule throws it directly.
 `primal=true` also requires `f(x...)` itself to throw, separating a call that is already
 invalid before AD sees it from one whose primal is fine and which only AD refuses.
 
-Tangents come from `rng`, not from `zero_tangent`: a guard that fires only when an argument
-carries a derivative -- a keyword the rule treats as constant, say -- sees nothing to refuse
-in a zero seed and would let the case pass while asserting nothing.
+Forward-mode tangents come from `rng`, not from `zero_tangent`: a guard that fires only when
+an argument carries a derivative -- a keyword the rule treats as constant, say -- sees
+nothing to refuse in a zero seed and would let the case pass while asserting nothing.
+Reverse mode seeds its inputs itself and has no such tangent to offer, so name
+`mode=ForwardMode` for a guard only a nonzero tangent reaches.
 """
 function test_rule_throws(
     rng::AbstractRNG,

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1263,6 +1263,76 @@ function test_rule(
     return ts
 end
 
+"""
+    test_rule_throws(
+        rng::AbstractRNG, f, x...;
+        err::Union{Nothing,Type}=nothing,
+        msg::Union{Nothing,AbstractString,Regex}=nothing,
+        mode::Union{Nothing,Type{ForwardMode},Type{ReverseMode}}=nothing,
+        primal::Bool=false,
+    )
+
+Assert that differentiating `f(x...)` throws, in both modes unless `mode` names one. Use it
+for calls a rule deliberately refuses, in place of a `@test_throws` written out per mode.
+
+Give `err`, an exception type the thrown error must be an instance of, or `msg`, a string or
+regex that `showerror` output must contain, or both -- `@test_throws` accepts only one of the
+two, which is the gap this fills. A rule that re-raises inside a wrapper error matches `msg`
+while failing `err`, so pin the type only where the rule throws it directly.
+
+`primal=true` also requires `f(x...)` itself to throw, separating a call that is already
+invalid before AD sees it from one whose primal is fine and which only AD refuses.
+
+Tangents come from `rng`, not from `zero_tangent`: a guard that fires only when an argument
+carries a derivative -- a keyword the rule treats as constant, say -- sees nothing to refuse
+in a zero seed and would let the case pass while asserting nothing.
+"""
+function test_rule_throws(
+    rng::AbstractRNG,
+    f,
+    x...;
+    err::Union{Nothing,Type}=nothing,
+    msg::Union{Nothing,AbstractString,Regex}=nothing,
+    mode::Union{Nothing,Type{ForwardMode},Type{ReverseMode}}=nothing,
+    primal::Bool=false,
+)
+    if isnothing(err) && isnothing(msg)
+        throw(
+            ArgumentError(
+                "test_rule_throws needs `err`, `msg`, or both: with neither it would only " *
+                "assert that something was thrown.",
+            ),
+        )
+    end
+    primal && _test_throws(() -> f(x...), err, msg)
+    if mode in [nothing, ReverseMode]
+        _test_throws(err, msg) do
+            Mooncake.value_and_gradient!!(build_rrule(f, x...), f, x...)
+        end
+    end
+    if mode in [nothing, ForwardMode]
+        duals = map(v -> randn_dual(rng, v), (f, x...))
+        _test_throws(err, msg) do
+            Mooncake.value_and_derivative!!(build_frule(f, x...), duals...)
+        end
+    end
+    return nothing
+end
+
+function _test_throws(thunk, err, msg)
+    caught = try
+        thunk()
+        nothing
+    catch e
+        e
+    end
+    @test caught !== nothing
+    isnothing(caught) && return nothing
+    isnothing(err) || @test caught isa err
+    isnothing(msg) || @test occursin(msg, sprint(showerror, caught))
+    return nothing
+end
+
 function run_hand_written_rule_test_cases(rng_ctor, v::Val, mode::Type{<:Mode})
     test_cases, memory = test_hook(Mooncake.hand_written_rule_test_cases, rng_ctor, v) do
         Mooncake.hand_written_rule_test_cases(rng_ctor, v)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1304,7 +1304,9 @@ function test_rule_throws(
             ),
         )
     end
-    primal && _test_throws(() -> f(x...), err, msg)
+    primal && _test_throws(err, msg) do
+        f(x...)
+    end
     if mode in [nothing, ReverseMode]
         _test_throws(err, msg) do
             Mooncake.value_and_gradient!!(build_rrule(f, x...), f, x...)

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -190,6 +190,10 @@ end
         # vector indexing — gather/scatter-add
         _gather_sum(x, idx) = sum(x[idx])
         _gather_sum_cx(x, idx) = real(sum(x[idx]))
+        # unsafe_free! releases the primal early; in reverse mode the fdata is still the
+        # accumulator earlier pullbacks write into, so it has to outlive the call.
+        _free_intermediate(x) = (y=x .* 2; s=sum(y); CUDA.unsafe_free!(y); s)
+        _free_input(x) = (s=sum(x .* 2); CUDA.unsafe_free!(x); s)
         _cu_sum(x) = sum(cu(x))
         _array_sum(x) = sum(Array(x))     # GPU→CPU transfer
         _diagonal_sum(x) = sum(Diagonal(x)) # GPU Diagonal construction
@@ -515,6 +519,7 @@ end
                 _rand(rng, Float32, 8),
             ),
             # CPU→GPU transfer (cu)
+            (false, :none, false, _free_intermediate, _rand(rng, 4)),
             (false, :none, false, _cu_sum, _host_rand(rng, 16)),
             # `cu` of an argument that is already on the device: the cotangent must come back
             # to the device buffer rather than being pulled to the host.
@@ -1604,6 +1609,19 @@ end
             end
 
             # accumulate with unsupported op — catch-all rule throws ArgumentError.
+            @testset "freeing the input itself still differentiates" begin
+                # Not a test_rule case: the function frees its own argument, so it cannot be
+                # called twice.  The fdata must outlive the free — reverse mode accumulates
+                # into it after the forward sweep has released the primal.
+                v, (_, dx) = Mooncake.value_and_gradient!!(
+                    Mooncake.build_rrule(_free_input, CuArray([1.0, 2.0, 3.0, 4.0])),
+                    _free_input,
+                    CuArray([1.0, 2.0, 3.0, 4.0]),
+                )
+                @test v == 20.0
+                @test Array(dx) == [2.0, 2.0, 2.0, 2.0]
+            end
+
             @testset "count refuses a non-identity init" begin
                 # The count is summed with `init` folded into a backend-defined number of
                 # partial reductions, so a nonzero one changes the value, not just its

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -223,6 +223,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _geam_add(a, b) = sum(a + b)
         _geam_sub_adj(a, b) = sum(a' - b)
         _geam_add_cx(a, b) = real(sum(a + b'))
+        # C === A is cuBLAS's in-place geam: dC is then the buffer dA accumulates into.
+        _geam_alias(x, y) = sum(CUDA.cuBLAS.geam!('N', 'N', 1.0f0, x, 1.0f0, y, x))
         # A complex alpha against a transposed operand: the pullback folds the two
         # conjugations together instead of conjugating alpha.
         _mul_adj_alpha(c, a, b) = real(sum(mul!(c, a', b', 2.0 + 3.0im, -1.0 + 0.5im)))
@@ -553,9 +555,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _nodiff_sort_rev, _rand(rng, 8)),
             # geam! called directly (is_primitive=true): the only case that reaches the
             # restore of C and the consumption of its cotangent, since `+`/`-` always
-            # allocate a fresh C.  alpha/beta are passed as Bool, which has no tangent, so
-            # test_rule cannot hand them the nonzero tangent the rule rejects — the same
-            # way MulAddMul supplies them to the gemm! rules.
+            # allocate a fresh C.  Bool alpha/beta, as MulAddMul supplies them to the gemm!
+            # rules, have no tangent and so take the no-derivative arm of the scalars.
             (
                 false,
                 :none,
@@ -569,6 +570,34 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _rand(rng, Float32, 3, 3),
                 _rand(rng, Float32, 3, 3),
             ),
+            # Differentiable alpha/beta, real and complex.  The complex case is also the
+            # only one where the 'C' flag's unconjugated alpha differs from conj(alpha).
+            (
+                false,
+                :none,
+                true,
+                CUDA.cuBLAS.geam!,
+                'T',
+                'N',
+                2.0f0,
+                _rand(rng, Float32, 3, 3),
+                -1.5f0,
+                _rand(rng, Float32, 3, 3),
+                _rand(rng, Float32, 3, 3),
+            ),
+            (
+                false,
+                :none,
+                true,
+                CUDA.cuBLAS.geam!,
+                'C',
+                'T',
+                2.0 + 3.0im,
+                _rand(rng, ComplexF64, 3, 3),
+                -1.0 + 0.5im,
+                _rand(rng, ComplexF64, 3, 3),
+                _rand(rng, ComplexF64, 3, 3),
+            ),
             # cuBLAS.geam! via CuMatrix +/-, including a wrapper arm and complex.
             (false, :none, false, _geam_add, _rand(rng, 3, 3), _rand(rng, 3, 3)),
             (false, :none, false, _geam_sub_adj, _rand(rng, 3, 3), _rand(rng, 3, 3)),
@@ -579,6 +608,14 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _geam_add_cx,
                 _rand(rng, ComplexF64, 3, 3),
                 _rand(rng, ComplexF64, 3, 3),
+            ),
+            (
+                false,
+                :none,
+                false,
+                _geam_alias,
+                _rand(rng, Float32, 3, 3),
+                _rand(rng, Float32, 3, 3),
             ),
             # repeat: counts, counts that add a dimension, and the keyword spelling.
             (false, :none, false, _repeat_counts, _rand(rng, 2, 3)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -132,6 +132,12 @@ end
         _reduce_plus_cx(x) = reduce(+, x)
         _reduce_mul(x) = reduce(*, x)
         _reduce_mul_cx(x) = reduce(*, x)
+        # The Core.kwcall spellings: `reduce` forwards to the sum/prod keyword rules, and
+        # `mapreduce` to the positional sum(f, x) when the keywords leave the reduction alone.
+        _reduce_plus_d1(x) = sum(reduce(+, x; dims=1))
+        _reduce_plus_init(x) = reduce(+, x; init=0.0f0)
+        _reduce_mul_init(x) = reduce(*, x; init=1.0f0)
+        _mapreduce_abs2_init(x) = mapreduce(abs2, +, x; init=0.0f0)
         # norm / dot — cuBLAS routines with explicit rules.
         # norm() always returns a real scalar regardless of element type, so _norm_cx has
         # the same body as _norm; the alias exists solely to label the complex-input testset.
@@ -568,6 +574,10 @@ end
             (false, :none, false, _sum_f_abs2, _rand(rng, 16)),
             (false, :none, false, _sum_f_abs2, _rand(rng, ComplexF64, 16)),
             # mapreduce(f, +, x) — explicit rule, redirects to ForwardDiff.Dual machinery
+            (false, :none, false, _reduce_plus_d1, _rand(rng, Float32, 4, 3)),
+            (false, :none, false, _reduce_plus_init, _rand(rng, Float32, 6)),
+            (false, :none, false, _reduce_mul_init, _rand_pos(rng, 6)),
+            (false, :none, false, _mapreduce_abs2_init, _rand(rng, Float32, 6)),
             (false, :none, false, _mapreduce_sin, _rand(rng, 16)),
             (false, :none, false, _mapreduce_exp, _rand(rng, 16)),
             (false, :none, false, _mapreduce_cx_abs2, _rand(rng, ComplexF64, 16)),
@@ -1562,6 +1572,26 @@ end
             end
 
             # accumulate with unsupported op — catch-all rule throws ArgumentError.
+            @testset "keyword reduce/mapreduce spellings report their own limits" begin
+                # Before these claims the keyword forms escaped to GPUArrays' reduction
+                # kernel and failed there; an unsupported op or a `dims` the mapped rule
+                # cannot do yet must say so itself.
+                x = _rand(rng, Float32, 4)
+                M = _rand(rng, Float32, 4, 3)
+                fmax = z -> reduce(max, z; init=0.0f0)
+                @test_throws r"only supports op" Mooncake.value_and_gradient!!(
+                    Mooncake.build_rrule(fmax, x), fmax, x
+                )
+                fdims = z -> sum(mapreduce(abs2, +, z; dims=1))
+                @test_throws r"not yet differentiable" Mooncake.value_and_gradient!!(
+                    Mooncake.build_rrule(fdims, M), fdims, M
+                )
+                finit = z -> reduce(+, z; init=1.0f0)
+                @test_throws r"not its identity" Mooncake.value_and_gradient!!(
+                    Mooncake.build_rrule(finit, x), finit, x
+                )
+            end
+
             @testset "accumulate non-+ CuArray not differentiable" begin
                 x = _rand(rng, Float32, 4)
                 for f in (x -> sum(accumulate(*, x)), x -> sum(accumulate(*, x; dims=1)))

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -155,6 +155,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _accumulate_init(a, x) = sum(accumulate(+, x; init=a))
         _accumulate_init_d1(a, x) = sum(accumulate(+, x; dims=1, init=a))
         _accumulate_init_widens(x) = sum(accumulate(+, x; init=1.0f0))
+        # Without `dims` CUDA scans an N-d array in linear order, not column by column.
+        _accumulate_flat(x) = sum(accumulate(+, x))
+        _accumulate_flat_init(a, x) = sum(accumulate(+, x; init=a))
         # vector indexing — gather/scatter-add
         _gather_sum(x, idx) = sum(x[idx])
         _gather_sum_cx(x, idx) = real(sum(x[idx]))
@@ -332,6 +335,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _max_init_d1(a, x) = sum(maximum(x; dims=1, init=a))
         _min_init(a, x) = minimum(x; init=a)
         _max_badkw(x) = maximum(x; bad=1.0)
+        _max_nan_init(x) = maximum(x; init=-1.0f0)
         # GPUArrays takes the output eltype from typeof(init), so a Float32 init over a
         # Float64 array narrows the result and its tangent has to follow.
         _max_init_widens(x) = maximum(x; init=0.0f0)
@@ -550,6 +554,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _accumulate_init, 1.0f0, _rand(rng, Float32, 6)),
             (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),
             (false, :none, false, _accumulate_init_widens, _rand(rng, Float64, 6)),
+            (false, :none, false, _accumulate_flat, _rand(rng, 4, 3)),
+            (false, :none, false, _accumulate_flat_init, 1.0f0, _rand(rng, Float32, 4, 3)),
             # vector indexing — gather forward, scatter-add pullback
             (
                 false,
@@ -1424,7 +1430,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             @testset "accumulate non-+ CuArray not differentiable" begin
                 x = _rand(rng, Float32, 4)
                 for f in (x -> sum(accumulate(*, x)), x -> sum(accumulate(*, x; dims=1)))
-                    @test_throws r"accumulate on CuArray only supports op=\+" value_and_gradient!!(
+                    @test_throws r"supports only op=\+ over a float or complex array" value_and_gradient!!(
                         Mooncake.build_rrule(f, x), f, x
                     )
                 end
@@ -2270,9 +2276,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             end
             @testset "a NaN slice keeps the keyword-free gradient" begin
                 # `won` is a negated comparison because NaN == NaN is false, which would
-                # zero the whole slice and disagree with the positional rule.
+                # zero the whole slice and disagree with the positional rule.  The `init`
+                # case is the one that computes `won` at all; the bare rule is the baseline.
                 x = CuArray(Float32[1, NaN, 3])
-                grads = map((_max_bare, _max_nodims)) do f
+                grads = map((_max_bare, _max_nan_init)) do f
                     Array(value_and_gradient!!(Mooncake.build_rrule(f, x), f, x)[2][2])
                 end
                 @test grads[1] == grads[2] == Float32[0, 1, 0]

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -122,7 +122,7 @@ end
         # intercept op=+ / op=Base.add_sum and redirect to the ForwardDiff.Dual machinery.
         # Note: in Julia 1.11, sum(f, x) dispatches through Base._sum → mapreduce(f, add_sum, x)
         # rather than being intercepted by our sum(f, x) primitive; both code paths are tested.
-        # Note: _sum_f_sin is defined above (line 79); _sum_f_abs2 is defined below (line 135).
+        # Note: _sum_f_sin is defined above; _sum_f_abs2 below.
         _mapreduce_sin(x) = mapreduce(sin, +, x)
         _mapreduce_exp(x) = mapreduce(exp, +, x)
         _mapreduce_cx_abs2(x) = mapreduce(abs2, +, x)

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -283,6 +283,14 @@ end
         _bcast_cast_chain_sq(x) = sum(Float64.(Float32.(x)) .^ 2)
         _bcast_cast_chain_same(x) = sum(Float32.(Float32.(x)) .^ 2)
         _bcast_cast_chain_cx(z) = sum(abs2.(ComplexF64.(ComplexF32.(z))))
+        # A cast at the top of the tree is never materialized away, so it is the one place
+        # the kernel sees the cast itself: as a bare `DataType`, which cannot be captured,
+        # and applied to duals, which have no conversion of their own.
+        _bcast_cast_top(x) = sum(Float64.(x))
+        _bcast_cast_top_narrow(x) = sum(Float32.(x))
+        _bcast_cast_top_chain(x) = sum(Float64.(Float32.(x)))
+        _bcast_cast_top_nodiff(x) =
+            (i=CuArray(Int32[1, 2, 3, 4]); sum(Float64.(i)) * sum(x))
         # `x .= scalar` reaches materialize! as a zero-dimensional Broadcasted, whose style
         # is DefaultArrayStyle rather than CuArrayStyle; before the claim covered it the
         # call decomposed and tracing died inside cufunction.
@@ -815,6 +823,10 @@ end
             (false, :none, false, _view_of_view, view(_rand(rng, Float32, 8), 3:8)),
             (false, :none, false, _view_cols, view(_rand(rng, Float32, 3, 4), :, 2:3)),
             (false, :none, false, _view_weighted_cx, view(_rand(rng, ComplexF32, 8), 3:8)),
+            (false, :none, false, _bcast_cast_top, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_cast_top_narrow, _rand(rng, Float64, 4)),
+            (false, :none, false, _bcast_cast_top_chain, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_cast_top_nodiff, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_cast_chain_exp, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_cast_chain_sq, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_cast_chain_same, _rand(rng, Float64, 4)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -198,6 +198,18 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _nodiff_sum(x) = (i=CuArray([1, 2, 3]); sum(x) * Float32(sum(i)))
         _nodiff_sum_dims(x) = (i=CuArray([1 2; 3 4]); sum(x) * Float32(sum(sum(i; dims=1))))
         _nodiff_sum_mask(x) = (m=CuArray([true, false, true]); sum(x) * Float32(sum(m)))
+        # A float `init` makes the output differentiable, and GPUArrays folds init into a
+        # backend-defined number of partial reductions, so its derivative is rejected
+        # rather than silently zeroed.
+        _nodiff_sum_init(a, x) = sum(x) * Float32(sum(CuArray([1, 2, 3]); init=a))
+        # The other reductions over an index or mask array. `count` returns an Integer for
+        # any array, so the float case has no derivative either.
+        _nodiff_prod(x) = (i=CuArray([1, 2, 3]); sum(x) * Float32(prod(i)))
+        _nodiff_max(x) = (i=CuArray([1, 2, 3]); sum(x) * Float32(maximum(i)))
+        _nodiff_min_dims(x) =
+            (i=CuArray([1 2; 3 4]); sum(x) * Float32(sum(minimum(i; dims=1))))
+        _nodiff_count(x) = (i=CuArray([1, 2, 3]); sum(x) * Float32(count(>(1), i)))
+        _nodiff_count_float(x) = sum(x) * Float32(count(>(0.0f0), x))
         # CuMatrix +/- lowers to cuBLAS.geam!; the wrapper arms pick the 'T'/'C' flags.
         _geam_add(a, b) = sum(a + b)
         _geam_sub_adj(a, b) = sum(a' - b)
@@ -515,6 +527,11 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _nodiff_sum, _rand(rng, 8)),
             (false, :none, false, _nodiff_sum_dims, _rand(rng, 8)),
             (false, :none, false, _nodiff_sum_mask, _rand(rng, 8)),
+            (false, :none, false, _nodiff_prod, _rand(rng, 8)),
+            (false, :none, false, _nodiff_max, _rand(rng, 8)),
+            (false, :none, false, _nodiff_min_dims, _rand(rng, 8)),
+            (false, :none, false, _nodiff_count, _rand(rng, 8)),
+            (false, :none, false, _nodiff_count_float, _rand(rng, 8)),
             # cuBLAS.geam! via CuMatrix +/-, including a wrapper arm and complex.
             (false, :none, false, _geam_add, _rand(rng, 3, 3), _rand(rng, 3, 3)),
             (false, :none, false, _geam_sub_adj, _rand(rng, 3, 3), _rand(rng, 3, 3)),
@@ -2006,6 +2023,17 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                     frule,
                     Mooncake.Dual(_sum_kw_init_active, Mooncake.NoTangent()),
                     Mooncake.Dual(a, 1.0f0),
+                    Mooncake.Dual(x, Mooncake.zero_tangent(x)),
+                )
+            end
+            @testset "init over a non-differentiable array is rejected" begin
+                # The output is a Float64 here, so a zero derivative w.r.t. init would be
+                # silently wrong rather than merely conservative.
+                a, x = 0.0, _rand(rng, Float32, 4)
+                @test_throws r"init.*constant" Mooncake.value_and_derivative!!(
+                    Mooncake.build_frule(_nodiff_sum_init, a, x),
+                    Mooncake.Dual(_nodiff_sum_init, Mooncake.NoTangent()),
+                    Mooncake.Dual(a, 1.0),
                     Mooncake.Dual(x, Mooncake.zero_tangent(x)),
                 )
             end

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -516,6 +516,10 @@ end
             ),
             # CPU→GPU transfer (cu)
             (false, :none, false, _cu_sum, _host_rand(rng, 16)),
+            # `cu` of an argument that is already on the device: the cotangent must come back
+            # to the device buffer rather than being pulled to the host.
+            (false, :none, false, _cu_sum, _rand(rng, Float32, 4)),
+            (false, :none, false, _cu_sum, _rand(rng, Float64, 4)),
             # GPU→CPU transfer (Array)
             (false, :none, false, _array_sum, _rand(rng, 16)),
             # GPU Diagonal construction

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -308,6 +308,14 @@ end
         _vcat_cu_sum(xs...) = sum(vcat(xs...))  # vararg: reused for 2-arg and N-arg tests
         _hcat_cu_sum(xs...) = sum(hcat(xs...))  # vararg: reused for 2-arg and N-arg tests
         _cat_cu_sum(d) = (xs...) -> sum(cat(xs...; dims=d))  # vararg: reused for 2-arg and N-arg tests
+        # Concatenating a real array with a complex one promotes the output, so the real
+        # argument's slice of the output cotangent arrives complex and has to be projected
+        # onto its own field before accumulating; `imag` keeps the projected part nonzero.
+        _vcat_mixed(a, b) = imag(sum(vcat(a, b)))
+        _hcat_mixed(a, b) = imag(sum(hcat(a, b)))
+        _cat_mixed(a, b) = imag(sum(cat(a, b; dims=1)))
+        # Same projection, reached through a real->complex cast leaf inside a broadcast.
+        _cast_to_complex(a) = real(sum(ComplexF32.(a) .* (2.0f0 + 3.0f0im)))
         _permutedims_sum(perm) = x -> sum(permutedims(x, perm))
         # Wrappers for Statistics.varm GPU rule tests.
         _varm_sum_d1(x, m) = sum(varm(x, m; dims=1, corrected=false))
@@ -743,6 +751,33 @@ end
             (false, :none, false, _repeat_extends, _rand(rng, 2, 3)),
             (false, :none, false, _repeat_inner_outer, _rand(rng, 2, 3)),
             (false, :none, false, _repeat_nothing, _rand(rng, 2, 3)),
+            # A real argument concatenated with a complex one, and a real->complex cast leaf:
+            # both hand a real fdata buffer a complex cotangent.
+            (
+                false,
+                :none,
+                false,
+                _vcat_mixed,
+                _rand(rng, Float32, 3),
+                _rand(rng, ComplexF32, 3),
+            ),
+            (
+                false,
+                :none,
+                false,
+                _cat_mixed,
+                _rand(rng, Float32, 3),
+                _rand(rng, ComplexF32, 3),
+            ),
+            (
+                false,
+                :none,
+                false,
+                _hcat_mixed,
+                _rand(rng, Float32, 3, 2),
+                _rand(rng, ComplexF32, 3, 2),
+            ),
+            (false, :none, false, _cast_to_complex, _rand(rng, Float32, 3)),
             # Diagonal + lgetfield(:diag) + broadcast — exercises the full pipeline
             (false, :none, false, _diagonal_field_bcast, _rand_pos(rng, 16)),
             (false, :none, false, _diagonal_mutate, CuArray([1.0, 2.0, 3.0])),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -1637,6 +1637,17 @@ end
             @test Mooncake.primal(result) === nothing
             @test Mooncake.tangent(result) isa Mooncake.NoTangent
 
+            # The claim covers index and mask arrays as well, whose forward tangent is
+            # `NoTangent`; guarding against the reverse mode's `NoFData` let that through
+            # and tried to free it.
+            idx = CuArray([1, 2, 3])
+            idx_result = _MooncakeCUDAExt.frule!!(
+                Mooncake.Dual(unsafe_free!, Mooncake.NoTangent()),
+                Mooncake.Dual(idx, Mooncake.NoTangent()),
+            )
+            @test Mooncake.primal(idx_result) === nothing
+            @test Mooncake.tangent(idx_result) isa Mooncake.NoTangent
+
             arr2 = _rand(rng, Float32, 4)
             tarr2 = Mooncake.zero_tangent(arr2)
             out, pb = _MooncakeCUDAExt.rrule!!(

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -513,6 +513,16 @@ end
         _max_dtuple(x) = sum(maximum(x; dims=(1, 2)))
         _min_dtuple(x) = sum(minimum(x; dims=(1, 2)))
         _max_dtuple_init(a, x) = sum(maximum(x; dims=(1, 2), init=a))
+        # `count`'s keyword slot owes a NamedTuple rdata once a float `init` makes the count a
+        # float, so reverse mode has to fill it rather than return NoRData.
+        _count_init(a, x) = count(>(0.0f0), x; init=a) * sum(x)
+        _count_init_mask(a, x) = count(x .> 0.0f0; init=a) * sum(x)
+        # A reinterpret between a complex eltype and its own real part interleaves the parts,
+        # and the tangent interleaves identically, so it stays differentiable.
+        _reinterpret_cx_to_real(z) = sum(reinterpret(Float64, z))
+        _reinterpret_real_to_cx(x) = real(sum(reinterpret(ComplexF64, x)))
+        # A predicate carrying its threshold has a Bool result, so nothing of it is zeroed.
+        _map_predicate(x) = sum(map(>(0.5f0), x)) * sum(x)
         _max_badkw(x) = maximum(x; bad=1.0)
         _max_nan_init(x) = maximum(x; init=-1.0f0)
         # GPUArrays takes the output eltype from typeof(init), so a Float32 init over a
@@ -806,6 +816,9 @@ end
             (false, :none, false, _cumsum_empty_d2, CuArray{Float32}(undef, 0, 3)),
             (false, :none, false, _cumprod_empty, CuArray{Float32}(undef, 0, 3)),
             (false, :none, false, _accumulate_empty, CuArray{Float32}(undef, 0)),
+            (false, :none, false, _reinterpret_cx_to_real, _rand(rng, ComplexF64, 3)),
+            (false, :none, false, _reinterpret_real_to_cx, _rand(rng, Float64, 4)),
+            (false, :none, false, _map_predicate, _rand(rng, Float32, 4)),
             (false, :none, false, _max_dtuple, _rand(rng, Float32, 2, 3)),
             (false, :none, false, _min_dtuple, _rand(rng, Float32, 2, 3)),
             # init above every element, then below: it takes the whole derivative or none.
@@ -1646,6 +1659,30 @@ end
             @test Array(cgrads[2]) ≈ 2 .* conj.(Array(z)) rtol = 1e-14
         end
 
+        @testset "count's keyword rdata slot, reverse only" begin
+            # Reverse mode cannot tell a constant `init` from one the caller wants a gradient
+            # for, so it fills the slot with a zero rather than refusing as forward does --
+            # which means the slot has to be filled at all: a float `init` makes the count a
+            # float, and the keyword rdata is then a NamedTuple, not NoRData.  Interfaces
+            # only, because that zero is what finite differences disagree with: GPUArrays
+            # folds `init` into a backend-defined number of partial reductions, so FD reads
+            # the fold count, around 49 here, off a value that is itself meaningless.
+            @testset "$name" for (seed, name, f) in [
+                (270, "predicate", _count_init), (271, "mask", _count_init_mask)
+            ]
+                test_rule(
+                    StableRNG(seed),
+                    f,
+                    0.0,
+                    _rand(rng, Float32, 4);
+                    is_primitive=false,
+                    perf_flag=:none,
+                    mode=Mooncake.ReverseMode,
+                    interface_only=true,
+                )
+            end
+        end
+
         @testset "norm frule!! rescales an overflowing dot" begin
             # dot(px, dx) overflows once norm(px)*norm(dx) leaves the eltype's range,
             # while the JVP it divides down to is still representable. Float16 saturates
@@ -2132,6 +2169,30 @@ end
                     _max_badkw,
                     (M32,),
                     (; err=MethodError, primal=true),
+                ),
+                # A reinterpret that changes the underlying real field would hand back a
+                # tangent whose elements are bit-halves of the primal's.
+                (
+                    260,
+                    "reinterpret narrows the eltype",
+                    z -> sum(reinterpret(Float32, z)),
+                    (_rand(rng, Float64, 4),),
+                    (; msg=r"reinterpreting a CuArray of Float64 as Float32"),
+                ),
+                (
+                    261,
+                    "reinterpret to a non-float eltype",
+                    z -> Float32(sum(reinterpret(Int32, z))),
+                    (_rand(rng, Float32, 4),),
+                    (; msg=r"is not differentiable"),
+                ),
+                # `count` matches `sum`: a differentiated `init` is refused, not zeroed.
+                (
+                    262,
+                    "count, differentiated init",
+                    (c, z) -> count(>(0.0f0), z; init=c),
+                    (0.0, _rand(rng, Float32, 4)),
+                    (; msg=r"init.*constant", mode=Mooncake.ForwardMode),
                 ),
                 # mapreduce delegates to the keyword-free rule, so a differentiated `init`
                 # would be dropped instead of folded, and an `init` of another type would

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -247,6 +247,15 @@ end
         _bcast_cx_cx_scalar_mul(x, c) = real(sum(c .* x))  # complex scalar, complex array
         _bcast_nested_sin_add(x, y) = sum(sin.(x .+ y))
         _bcast_nested_float_cast_sin(x) = sum(sin.(Float64.(x)))
+        # A cast whose argument is itself a cast.  The inner one is materialized first,
+        # which collapses the whole chain to a plain leaf, so the tangent that has to be
+        # reattached belongs to the array at the bottom rather than to the outer cast's
+        # immediate argument.  Both modes agreed on an exact zero before, so nothing but a
+        # value comparison catches it.
+        _bcast_cast_chain_exp(x) = sum(exp.(Float64.(Float32.(x))))
+        _bcast_cast_chain_sq(x) = sum(Float64.(Float32.(x)) .^ 2)
+        _bcast_cast_chain_same(x) = sum(Float32.(Float32.(x)) .^ 2)
+        _bcast_cast_chain_cx(z) = sum(abs2.(ComplexF64.(ComplexF32.(z))))
         _bcast_zero_dof_nested(x, c, b) = sum(x .+ c .* Float64.(b .> 0))
         _bcast_all_scalar_leaf(x, s) = sum(x .* (s .+ 1.0))
         _inplace_zero_dof_nested!(dest, x, c, b) =
@@ -742,6 +751,10 @@ end
             (false, :none, false, _view_of_view, view(_rand(rng, Float32, 8), 3:8)),
             (false, :none, false, _view_cols, view(_rand(rng, Float32, 3, 4), :, 2:3)),
             (false, :none, false, _view_weighted_cx, view(_rand(rng, ComplexF32, 8), 3:8)),
+            (false, :none, false, _bcast_cast_chain_exp, _rand(rng, Float64, 4)),
+            (false, :none, false, _bcast_cast_chain_sq, _rand(rng, Float64, 4)),
+            (false, :none, false, _bcast_cast_chain_same, _rand(rng, Float64, 4)),
+            (false, :none, false, _bcast_cast_chain_cx, _rand(rng, ComplexF64, 4)),
             (
                 false,
                 :none,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -2210,6 +2210,27 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                     Mooncake.Dual(x, Mooncake.zero_tangent(x)),
                 )
             end
+            @testset "a non-identity init is refused in both modes" begin
+                # + and * are not idempotent, so the backend's folding changes the value
+                # itself: sum(CuArray([1, 2, 3]); init=1.0) is 101.0, not 7.0.  Reading the
+                # value rather than a tangent is what lets reverse mode refuse it too.
+                x = _rand(rng, Float32, 4)
+                for f in (
+                    z -> sum(z; init=1.0f0),
+                    z -> sum(sum(z; dims=1, init=5.0)),
+                    z -> sum(prod(z; dims=1, init=2.0)),
+                    z -> Float32(sum(CuArray([1, 2, 3]); init=1.0)) * sum(z),
+                )
+                    @test_throws r"not its identity" Mooncake.value_and_gradient!!(
+                        Mooncake.build_rrule(f, x), f, x
+                    )
+                    @test_throws r"not its identity" Mooncake.value_and_derivative!!(
+                        Mooncake.build_frule(f, x),
+                        Mooncake.Dual(f, Mooncake.zero_tangent(f)),
+                        Mooncake.Dual(x, Mooncake.zero_tangent(x)),
+                    )
+                end
+            end
             @testset "a constant init still differentiates in reverse" begin
                 # Reverse mode cannot tell this literal from an init the caller wants a
                 # gradient for, so it must not reject either: ∂/∂x is well defined here.

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -189,6 +189,15 @@ end
         _accumulate_flat_init(a, x) = sum(accumulate(+, x; init=a))
         # vector indexing — gather/scatter-add
         _gather_sum(x, idx) = sum(x[idx])
+        # A repeated index is read more than once, so its element is owed the sum of those
+        # reads.  The weighted case distinguishes a correct sum from a single surviving write.
+        _gather_dup(x) = sum(x[CuArray([1, 1, 2])])
+        _gather_dup_weighted(x) = sum(x[CuArray([1, 1, 2])] .* CuArray(Float32[1, 2, 3]))
+        _gather_dup_host(x) = sum(x[[1, 1, 2]])
+        _gather_dup_cx(x) = real(sum(x[CuArray([1, 1, 2])]))
+        _gather_dup_cartesian(m) = sum(
+            m[CuArray([CartesianIndex(1, 1), CartesianIndex(1, 1), CartesianIndex(2, 2)])]
+        )
         _gather_sum_cx(x, idx) = real(sum(x[idx]))
         # unsafe_free! releases the primal early; in reverse mode the fdata is still the
         # accumulator earlier pullbacks write into, so it has to outlive the call.
@@ -693,6 +702,11 @@ end
                 _rand(rng, 16),
                 CuArray(Int32[2, 5, 7, 3, 1, 8]),
             ),
+            (false, :none, false, _gather_dup, _rand(rng, Float32, 4)),
+            (false, :none, false, _gather_dup_weighted, _rand(rng, Float32, 4)),
+            (false, :none, false, _gather_dup_host, _rand(rng, Float32, 4)),
+            (false, :none, false, _gather_dup_cx, _rand(rng, ComplexF32, 4)),
+            (false, :none, false, _gather_dup_cartesian, _rand(rng, Float32, 2, 2)),
             (
                 false,
                 :none,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -180,6 +180,11 @@ end
         _bcast_kill_cast(x) = (y=x .* 2; y.=Float64.(y .> 0); sum(y))
         _hoisted_capture(a, x) = sum(((t, c) -> c * t).(x, a))
         _int_capture(x) = (n=3; sum((t -> n * t).(x)))
+        # A `dims` past ndims is a no-op scan the primal and the JVP both accept, so the
+        # pullback has to treat it as the identity rather than hand it to `reverse`.
+        _cumsum_trailing(x) = sum(cumsum(x; dims=2) .^ 2)
+        _cumprod_trailing(x) = sum(cumprod(x; dims=2) .^ 2)
+        _accumulate_trailing(x) = sum(accumulate(+, x; dims=3) .^ 2)
         _accumulate_flat(x) = sum(accumulate(+, x))
         _accumulate_flat_init(a, x) = sum(accumulate(+, x; init=a))
         # vector indexing — gather/scatter-add
@@ -658,6 +663,9 @@ end
             (false, :none, false, _bcast_kill_cast, CuArray([0.3, -0.7, 1.2, 2.5])),
             (false, :none, false, _hoisted_capture, 3.0, _rand(rng, 4)),
             (false, :none, false, _int_capture, _rand(rng, 4)),
+            (false, :none, false, _cumsum_trailing, _rand(rng, 4)),
+            (false, :none, false, _cumprod_trailing, _rand_pos(rng, 4)),
+            (false, :none, false, _accumulate_trailing, _rand(rng, 2, 3)),
             (false, :none, false, _accumulate_flat, _rand(rng, 4, 3)),
             (false, :none, false, _accumulate_flat_init, 1.0f0, _rand(rng, Float32, 4, 3)),
             # vector indexing — gather forward, scatter-add pullback

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -262,6 +262,12 @@ end
         # reporting float arrays.
         _nodiff_diff(x) = (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(diff(i))))
         _nodiff_sortperm(x) = (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(sortperm(i))))
+        # sortperm returns Int indices, so it is zero-derivative for a float array too, and
+        # the gather that uses them carries the gradient.  The weighted case is asymmetric,
+        # so a permutation applied the wrong way round would not pass.
+        _sortperm_gather(x) = sum(x[sortperm(x)] .^ 2)
+        _sortperm_weighted(x, w) = sum(x[sortperm(x)] .* w)
+        _sortperm_rev(x) = sum(x[sortperm(x; rev=true)] .^ 2)
         _nodiff_sort_rev(x) =
             (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(sort(i; rev=true))))
         # CuMatrix +/- lowers to cuBLAS.geam!; the wrapper arms pick the 'T'/'C' flags.
@@ -691,6 +697,16 @@ end
             (false, :none, false, _nodiff_count_float, _rand(rng, 8)),
             (false, :none, false, _nodiff_diff, _rand(rng, 8)),
             (false, :none, false, _nodiff_sortperm, _rand(rng, 8)),
+            (false, :none, false, _sortperm_gather, CuArray(Float32[0.3, 0.7, 0.2, 0.9])),
+            (false, :none, false, _sortperm_rev, CuArray(Float32[0.3, 0.7, 0.2, 0.9])),
+            (
+                false,
+                :none,
+                false,
+                _sortperm_weighted,
+                CuArray(Float32[0.3, 0.7, 0.2, 0.9]),
+                CuArray(Float32[1, 2, 3, 4]),
+            ),
             (false, :none, false, _nodiff_sort_rev, _rand(rng, 8)),
             # geam! called directly (is_primitive=true): the only case that reaches the
             # restore of C and the consumption of its cotangent, since `+`/`-` always

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -275,6 +275,7 @@ end
         _inplace_cx_abs2!(x, y) = (x.=abs2.(y); real(sum(x)))
         # GPU→CPU transfer inside the function: Array(x::CuArray) path.
         _gpu_to_cpu(x) = sum(Array(x) .^ 2)
+        _gpu_to_cpu_cx(z) = real(sum(Array(z) .^ 2))
         # CPU→GPU transfer: copies a host Array into a GPU dest via unsafe_copyto!(GPU←CPU).
         # Exercises the mixed-device rrule (dest::CuArray, src::Array).
         # The gradient flows back from the GPU cotangent to the CPU src tangent.
@@ -1460,6 +1461,24 @@ end
             @test Mooncake.tangent(out) isa typeof(tref)
             @test Mooncake.tangent(out) !== tref
             @test all(x -> x isa Mooncake.NoRData, pb(Mooncake.NoRData()))
+        end
+
+        @testset "Array(x) pullback keeps the eltype it was given" begin
+            # `cu` is an adaptor, not a transfer — it narrows Float64 to Float32 — so
+            # routing the cotangent home through it cost about seven digits while leaving
+            # the gradient's eltype Float64, so nothing errored.  test_rule cannot see this:
+            # its finite differences are themselves only good to about 1e-6, which is why
+            # `_gpu_to_cpu` passes either way.  Compare against the exact derivative.
+            x = CuArray([1.234567890123, 2.345678901234])
+            _, grads = value_and_gradient!!(
+                Mooncake.build_rrule(_gpu_to_cpu, x), _gpu_to_cpu, x
+            )
+            @test Array(grads[2]) ≈ 2 .* Array(x) rtol = 1e-14
+            z = CuArray(ComplexF64[1.234567890123 - 0.7im, 2.345678901234 + 0.3im])
+            _, cgrads = value_and_gradient!!(
+                Mooncake.build_rrule(_gpu_to_cpu_cx, z), _gpu_to_cpu_cx, z
+            )
+            @test Array(cgrads[2]) ≈ 2 .* conj.(Array(z)) rtol = 1e-14
         end
 
         @testset "norm frule!! rescales an overflowing dot" begin

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -193,6 +193,11 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         # unsafe_copyto!(CuArray{Int}, Array{Int}), the zeros through the fill kernel.
         _nodiff_index_copy(x) = (i=CuArray([1, 2]); sum(x[i]))
         _nodiff_fill(x) = (i=CUDA.zeros(Int64, 2); fill!(i, 3); sum(x))
+        # Reducing an index or mask array: no derivative, but it still needs a rule.
+        # The Bool case reaches GPUArrays._mapreduce by a different internal route.
+        _nodiff_sum(x) = (i=CuArray([1, 2, 3]); sum(x) * Float32(sum(i)))
+        _nodiff_sum_dims(x) = (i=CuArray([1 2; 3 4]); sum(x) * Float32(sum(sum(i; dims=1))))
+        _nodiff_sum_mask(x) = (m=CuArray([true, false, true]); sum(x) * Float32(sum(m)))
         # CuMatrix +/- lowers to cuBLAS.geam!; the wrapper arms pick the 'T'/'C' flags.
         _geam_add(a, b) = sum(a + b)
         _geam_sub_adj(a, b) = sum(a' - b)
@@ -504,9 +509,12 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _rand(rng, 4, 4),
                 CuArray([CartesianIndex(1, 1), CartesianIndex(2, 3)]),
             ),
-            # Non-differentiable device arrays: copy and fill had no rule at all.
+            # Non-differentiable device arrays: copy, fill and reductions had no rule.
             (false, :none, false, _nodiff_index_copy, _rand(rng, 8)),
             (false, :none, false, _nodiff_fill, _rand(rng, 8)),
+            (false, :none, false, _nodiff_sum, _rand(rng, 8)),
+            (false, :none, false, _nodiff_sum_dims, _rand(rng, 8)),
+            (false, :none, false, _nodiff_sum_mask, _rand(rng, 8)),
             # cuBLAS.geam! via CuMatrix +/-, including a wrapper arm and complex.
             (false, :none, false, _geam_add, _rand(rng, 3, 3), _rand(rng, 3, 3)),
             (false, :none, false, _geam_sub_adj, _rand(rng, 3, 3), _rand(rng, 3, 3)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -508,6 +508,11 @@ end
         _max_init_d1(a, x) = sum(maximum(x; dims=1, init=a))
         _min_init(a, x) = minimum(x; init=a)
         _min_init_d1(a, x) = sum(minimum(x; dims=1, init=a))
+        # A tuple `dims` reduces over several axes at once, which is its own branch in the
+        # empty-extent test and was the one dispatch of that helper no case reached.
+        _max_dtuple(x) = sum(maximum(x; dims=(1, 2)))
+        _min_dtuple(x) = sum(minimum(x; dims=(1, 2)))
+        _max_dtuple_init(a, x) = sum(maximum(x; dims=(1, 2), init=a))
         _max_badkw(x) = maximum(x; bad=1.0)
         _max_nan_init(x) = maximum(x; init=-1.0f0)
         # GPUArrays takes the output eltype from typeof(init), so a Float32 init over a
@@ -801,6 +806,13 @@ end
             (false, :none, false, _cumsum_empty_d2, CuArray{Float32}(undef, 0, 3)),
             (false, :none, false, _cumprod_empty, CuArray{Float32}(undef, 0, 3)),
             (false, :none, false, _accumulate_empty, CuArray{Float32}(undef, 0)),
+            (false, :none, false, _max_dtuple, _rand(rng, Float32, 2, 3)),
+            (false, :none, false, _min_dtuple, _rand(rng, Float32, 2, 3)),
+            # init above every element, then below: it takes the whole derivative or none.
+            (false, :none, false, _max_dtuple_init, 9.0f0, CuArray(Float32[1 5 2; 3 2 4])),
+            (false, :none, false, _max_dtuple_init, 0.0f0, CuArray(Float32[1 5 2; 3 2 4])),
+            # every reduced slice empty, so `init` decides the output alone.
+            (false, :none, false, _max_dtuple_init, -9.0f0, CuArray{Float32}(undef, 0, 3)),
             (false, :none, false, _accumulate_nodiff_init, 1.0, CuArray(Int32[1, 2, 3])),
             (false, :none, false, _accumulate_nodiff_init_d1, 1.0, CuArray(Int32[1, 2, 3])),
             (

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -242,6 +242,12 @@ end
         # accumulator earlier pullbacks write into, so it has to outlive the call.
         _free_intermediate(x) = (y=x .* 2; s=sum(y); CUDA.unsafe_free!(y); s)
         _free_input(x) = (s=sum(x .* 2); CUDA.unsafe_free!(x); s)
+        # Freeing an array a pullback still needs.  The gather keeps its index array to
+        # scatter with, and constructing one is itself an `unsafe_copyto!` whose rule keeps
+        # the destination to restore, so both reach the reverse sweep after the free.
+        _free_nodiff(x) = (i=CuArray([1, 2, 3]); CUDA.unsafe_free!(i); sum(x))
+        _free_gathered_idx(x) = (i=CuArray([1, 2, 3]); s=sum(x[i]); CUDA.unsafe_free!(i); s)
+        _free_mask(x) = (m=CuArray([true, false, true]); CUDA.unsafe_free!(m); sum(x))
         _cu_sum(x) = sum(cu(x))
         _array_sum(x) = sum(Array(x))     # GPU→CPU transfer
         _diagonal_sum(x) = sum(Diagonal(x)) # GPU Diagonal construction
@@ -635,6 +641,9 @@ end
             ),
             # CPU→GPU transfer (cu)
             (false, :none, false, _free_intermediate, _rand(rng, 4)),
+            (false, :none, false, _free_nodiff, _rand(rng, Float32, 3)),
+            (false, :none, false, _free_gathered_idx, _rand(rng, Float32, 3)),
+            (false, :none, false, _free_mask, _rand(rng, Float32, 3)),
             (false, :none, false, _cu_sum, _host_rand(rng, 16)),
             # `cu` of an argument that is already on the device: the cotangent must come back
             # to the device buffer rather than being pulled to the host.

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -189,6 +189,18 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             copyto!(dest, Array(x))
             return sum(dest)
         end
+        # Device arrays with no derivative information: the index upload goes through
+        # unsafe_copyto!(CuArray{Int}, Array{Int}), the zeros through the fill kernel.
+        _nodiff_index_copy(x) = (i=CuArray([1, 2]); sum(x) * Float32(length(i)))
+        _nodiff_fill(x) = (i=CUDA.zeros(Int64, 2); fill!(i, 3); sum(x))
+        # CuMatrix +/- lowers to cuBLAS.geam!; the wrapper arms pick the 'T'/'C' flags.
+        _geam_add(a, b) = sum(a + b)
+        _geam_sub_adj(a, b) = sum(a' - b)
+        _geam_add_cx(a, b) = real(sum(a + b'))
+        # repeat: positional counts and the keyword spelling (separate rules).
+        _repeat_counts(x) = sum(repeat(x, 2, 3))
+        _repeat_extends(x) = sum(repeat(x, 2, 3, 2))
+        _repeat_inner_outer(x) = sum(repeat(x; inner=(2, 1), outer=(1, 2)))
         # CuPtr arithmetic — exercises the CuPtr{T} + Integer primitives.
         # _view_sum: view(x, range) triggers SubArray → unsafe_convert(CuPtr{T}, parent) +
         # offset, which is CuPtr{Float32} + Integer (differentiable T).
@@ -470,6 +482,34 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 _rand(rng, ComplexF64, 16),
                 CuArray(Int32[2, 5, 7, 3, 1, 8]),
             ),
+            # Gather with Cartesian indices: without the CartesianIndex arm of the claim
+            # the trace falls into checkbounds, which reduces with `&`.
+            (
+                false,
+                :none,
+                false,
+                _gather_sum,
+                _rand(rng, 4, 4),
+                CuArray([CartesianIndex(1, 1), CartesianIndex(2, 3)]),
+            ),
+            # Non-differentiable device arrays: copy and fill had no rule at all.
+            (false, :none, false, _nodiff_index_copy, _rand(rng, 8)),
+            (false, :none, false, _nodiff_fill, _rand(rng, 8)),
+            # cuBLAS.geam! via CuMatrix +/-, including a wrapper arm and complex.
+            (false, :none, false, _geam_add, _rand(rng, 3, 3), _rand(rng, 3, 3)),
+            (false, :none, false, _geam_sub_adj, _rand(rng, 3, 3), _rand(rng, 3, 3)),
+            (
+                false,
+                :none,
+                false,
+                _geam_add_cx,
+                _rand(rng, ComplexF64, 3, 3),
+                _rand(rng, ComplexF64, 3, 3),
+            ),
+            # repeat: counts, counts that add a dimension, and the keyword spelling.
+            (false, :none, false, _repeat_counts, _rand(rng, 2, 3)),
+            (false, :none, false, _repeat_extends, _rand(rng, 2, 3)),
+            (false, :none, false, _repeat_inner_outer, _rand(rng, 2, 3)),
             # Diagonal + lgetfield(:diag) + broadcast — exercises the full pipeline
             (false, :none, false, _diagonal_field_bcast, _rand_pos(rng, 16)),
             # sum(f, x) with non-smooth f (abs)

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -227,6 +227,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _repeat_counts(x) = sum(repeat(x, 2, 3))
         _repeat_extends(x) = sum(repeat(x, 2, 3, 2))
         _repeat_inner_outer(x) = sum(repeat(x; inner=(2, 1), outer=(1, 2)))
+        # `nothing` is Base.repeat's own default for inner/outer, so it can arrive here.
+        _repeat_nothing(x) = sum(repeat(x; inner=nothing, outer=(2, 2)))
         # CuPtr arithmetic — exercises the CuPtr{T} + Integer primitives.
         # _view_sum: view(x, range) triggers SubArray → unsafe_convert(CuPtr{T}, parent) +
         # offset, which is CuPtr{Float32} + Integer (differentiable T).
@@ -577,6 +579,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _repeat_counts, _rand(rng, 2, 3)),
             (false, :none, false, _repeat_extends, _rand(rng, 2, 3)),
             (false, :none, false, _repeat_inner_outer, _rand(rng, 2, 3)),
+            (false, :none, false, _repeat_nothing, _rand(rng, 2, 3)),
             # Diagonal + lgetfield(:diag) + broadcast — exercises the full pipeline
             (false, :none, false, _diagonal_field_bcast, _rand_pos(rng, 16)),
             # sum(f, x) with non-smooth f (abs)

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -183,6 +183,10 @@ end
         _array_sum(x) = sum(Array(x))     # GPU→CPU transfer
         _diagonal_sum(x) = sum(Diagonal(x)) # GPU Diagonal construction
         _diagonal_field_bcast(x) = sum(exp.(Diagonal(x).diag))  # Diagonal + lgetfield + broadcast
+        # Diagonal(v).diag === v, so a mutation of v after wrapping has to be visible through
+        # the wrapper: the two share one cotangent buffer.
+        _diagonal_mutate(v) = (D=Diagonal(v); v.=v .* 2; sum(D.diag))
+        _diagonal_fill(v, c) = (D=Diagonal(v); fill!(v, c); sum(D.diag .^ 2))
         _sum_f_abs(x) = sum(abs, x)          # sum(f, x) with non-smooth f
         _sum_f_abs2(x) = sum(abs2, x)        # sum(f, x) real abs2
         _sum_adj_pow3(x) = real(sum(y -> y^3, x'))  # sum(f, Adjoint)
@@ -714,6 +718,8 @@ end
             (false, :none, false, _repeat_nothing, _rand(rng, 2, 3)),
             # Diagonal + lgetfield(:diag) + broadcast — exercises the full pipeline
             (false, :none, false, _diagonal_field_bcast, _rand_pos(rng, 16)),
+            (false, :none, false, _diagonal_mutate, CuArray([1.0, 2.0, 3.0])),
+            (false, :none, false, _diagonal_fill, CuArray([1.0, 2.0, 3.0]), 5.0),
             # sum(f, x) with non-smooth f (abs)
             (false, :none, false, _sum_f_abs, _rand(rng, 16)),
             # sum(f, Adjoint) — tests sum(f, x) dispatch when input is an Adjoint wrapper

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -546,6 +546,17 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             # cumprod — explicit rule (real and complex, nonzero inputs)
             (false, :none, false, _cumprod_sum, _rand_pos(rng, 16)),
             (false, :none, false, _cumprod_cx_sum, _rand(rng, ComplexF64, 16)),
+            # A zero: every prefix from it on is zero, but the zero's own derivative is the
+            # rest of its prefix, and a second zero takes the tail to zero.
+            (false, :none, false, _cumprod_sum, CuArray([2.0, 0.0, 3.0])),
+            (false, :none, false, _cumprod_sum, CuArray([2.0, 0.0, 3.0, 0.0, 5.0])),
+            (
+                false,
+                :none,
+                false,
+                _cumprod_cx_sum,
+                CuArray(ComplexF64[1 + 2im, 0, 3 - 1im]),
+            ),
             # accumulate(+) — explicit rule (real and complex)
             (false, :none, false, _accumulate_plus_sum, _rand(rng, 16)),
             (false, :none, false, _accumulate_plus_cx_sum, _rand(rng, ComplexF64, 16)),
@@ -560,6 +571,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _prod_cx_d1, _rand(rng, ComplexF64, 4, 3)),
             (false, :none, false, _cumsum_d1, _rand(rng, 4, 3)),
             (false, :none, false, _cumprod_d1, _rand_pos(rng, 4, 3)),
+            (false, :none, false, _cumprod_d1, CuArray([1.0 2.0; 0.0 4.0])),
             (false, :none, false, _accumulate_plus_d1, _rand(rng, 4, 3)),
             (false, :none, false, _accumulate_init, 1.0f0, _rand(rng, Float32, 6)),
             (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -178,6 +178,13 @@ end
         _accumulate_nodiff_init(a, idx) = sum(accumulate(+, idx; init=a))
         _accumulate_nodiff_init_d1(a, idx) = sum(accumulate(+, idx; dims=1, init=a))
         _accumulate_nodiff_init_outdim(a, idx) = sum(accumulate(+, idx; dims=2, init=a))
+        # `reverse` refuses an empty array while `cumsum` accepts one, so an empty input
+        # reached the pullback and only the pullback.  The 0x3 reduced along dim 2 is not an
+        # empty reduction at all — it is simply an empty array — so both need covering.
+        _cumsum_empty(y) = sum(cumsum(y; dims=1))
+        _cumsum_empty_d2(y) = sum(cumsum(y; dims=2))
+        _cumprod_empty(y) = sum(cumprod(y; dims=1))
+        _accumulate_empty(y) = sum(accumulate(+, y))
         # Without `dims` CUDA scans an N-d array in linear order, not column by column.
         # Passing the captured value as an argument is what the refusal message recommends;
         # a capture the kernel cannot thread must not be silently zeroed instead.
@@ -768,6 +775,10 @@ end
             (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),
             (false, :none, false, _accumulate_init_widens, _rand(rng, Float64, 6)),
             (false, :none, false, _accumulate_init_outdim, 1.0f0, _rand(rng, Float32, 6)),
+            (false, :none, false, _cumsum_empty, CuArray{Float32}(undef, 0, 3)),
+            (false, :none, false, _cumsum_empty_d2, CuArray{Float32}(undef, 0, 3)),
+            (false, :none, false, _cumprod_empty, CuArray{Float32}(undef, 0, 3)),
+            (false, :none, false, _accumulate_empty, CuArray{Float32}(undef, 0)),
             (false, :none, false, _accumulate_nodiff_init, 1.0, CuArray(Int32[1, 2, 3])),
             (false, :none, false, _accumulate_nodiff_init_d1, 1.0, CuArray(Int32[1, 2, 3])),
             (

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -11,6 +11,7 @@ using Mooncake.TestUtils:
     test_tangent_interface,
     test_tangent_splitting,
     test_rule,
+    test_rule_throws,
     test_frule_interface,
     test_rrule_interface
 using LinearAlgebra, Statistics
@@ -1602,65 +1603,317 @@ end
         # explicit catch-all rule that blocks an unimplemented differentiation path.
         # If a case gains a proper rule in the future, move it back into test_cases above
         # and delete it from here.
-        @testset "state carried by a mapped function is refused, not zeroed" begin
-            # Partials thread through GPU array elements and float scalars only, so anything
-            # the function itself carries — a closure capture, a callable struct's field, a
-            # Ref argument — would come back an exact zero.  Both modes refuse it.  This is
-            # the boundary the sum(f, x) guard was written for; it never fired, because
-            # rdata_type was applied to a primal type and threw inside fields_type.
-            x = _rand(rng, Float64, 4)
-            for f in (
-                (a, z) -> sum((t -> a * t).(z)),
-                (a, z) -> sum((t -> exp(a * t)).(z)),
-                (a, z) -> (w=similar(z); w.=(t -> a * t).(z); sum(w)),
-                (a, z) -> sum((t -> a * t).(z) .+ z),
-                (a, z) -> sum(map(t -> a * t, z)),
-                (a, z) -> sum(t -> a * t, z),
-                (a, z) -> sum(_CapScale(a).(z)),
-                (a, z) -> sum(((t, r) -> r[] * t).(z, Ref(a))),
-            )
-                @test_throws r"does not support" Mooncake.value_and_gradient!!(
-                    Mooncake.build_rrule(f, 3.0, x), f, 3.0, x
-                )
-                @test_throws r"does not support" Mooncake.value_and_derivative!!(
-                    Mooncake.build_frule(f, 3.0, x),
-                    Mooncake.Dual(f, Mooncake.zero_tangent(f)),
-                    Mooncake.Dual(3.0, 1.0),
-                    Mooncake.Dual(x, Mooncake.zero_tangent(x)),
-                )
+        # Every guard that refuses a call outright, one entry each. `kw` says what the
+        # refusal must carry: `msg` a pattern the message matches, `err` an exception type,
+        # `mode` a single direction where only one guard exists, and `primal` for calls the
+        # primal rejects before AD sees them. Cases that gain a real rule move up into
+        # test_cases; cases whose guard is not reached through AD stay below.
+        @testset "guards that refuse a call" begin
+            x64 = _rand(rng, Float64, 4)
+            x32 = _rand(rng, Float32, 4)
+            M32 = _rand(rng, Float32, 4, 3)
+            cx32 = CuArray(randn(rng, ComplexF32, 4))
+            counted = CuArray([1.0, -2.0, 3.0, 4.0])
+            host_cx = _host_rand(rng, ComplexF64, 3, 3)
+            gpu_cx = _rand(rng, ComplexF64, 3, 3)
+            cpu_vec = _host_rand(rng, Float32, 4)
+            cpu_mat = _host_rand(rng, Float32, 4, 2)
+            x16 = _rand(rng, Float16, 4, 3)
+            y16 = _rand(rng, Float16, 2, 3)
+            m_row = _rand(rng, Float32, 1, 3)
+            m_scalar = randn(StableRNG(28), Float32)
+            @testset "$name" for (seed, name, f, args, kw) in [
+                # Partials thread through GPU array elements and float scalars only, so
+                # anything the mapped function itself carries — a closure capture, a
+                # callable struct's field, a Ref argument — would come back an exact zero.
+                # This is the boundary the sum(f, x) guard was written for; it never fired,
+                # because rdata_type was applied to a primal type and threw in fields_type.
+                (
+                    200,
+                    "capture, broadcast",
+                    (a, z) -> sum((t -> a * t).(z)),
+                    (3.0, x64),
+                    (; msg=r"does not support"),
+                ),
+                (
+                    201,
+                    "capture, nonlinear",
+                    (a, z) -> sum((t -> exp(a * t)).(z)),
+                    (3.0, x64),
+                    (; msg=r"does not support"),
+                ),
+                (
+                    202,
+                    "capture, in-place",
+                    (a, z) -> (w=similar(z); w.=(t -> a * t).(z); sum(w)),
+                    (3.0, x64),
+                    (; msg=r"does not support"),
+                ),
+                (
+                    203,
+                    "capture, fused with z",
+                    (a, z) -> sum((t -> a * t).(z) .+ z),
+                    (3.0, x64),
+                    (; msg=r"does not support"),
+                ),
+                (
+                    204,
+                    "capture, map",
+                    (a, z) -> sum(map(t -> a * t, z)),
+                    (3.0, x64),
+                    (; msg=r"does not support"),
+                ),
+                (
+                    205,
+                    "capture, sum(f, x)",
+                    (a, z) -> sum(t -> a * t, z),
+                    (3.0, x64),
+                    (; msg=r"does not support"),
+                ),
+                (
+                    206,
+                    "callable struct field",
+                    (a, z) -> sum(_CapScale(a).(z)),
+                    (3.0, x64),
+                    (; msg=r"does not support"),
+                ),
+                (
+                    207,
+                    "Ref argument",
+                    (a, z) -> sum(((t, r) -> r[] * t).(z, Ref(a))),
+                    (3.0, x64),
+                    (; msg=r"does not support"),
+                ),
+                # Mismatched GPU element types are caught before any kernel launch.
+                (
+                    208,
+                    "mixed-eltype broadcast",
+                    _bcast_cx_mixed,
+                    (x32, cx32),
+                    (; msg=r"GPU broadcast over arrays with mixed element types"),
+                ),
+                # Scalar indexing would silently run a one-element GPU op per index.
+                (209, "scalar getindex", z -> z[1], (x32,), (; msg=r"scalar indexing")),
+                (
+                    210,
+                    "scalar setindex!",
+                    z -> (z[1]=0.0f0; sum(z)),
+                    (x32,),
+                    (; msg=r"scalar indexing"),
+                ),
+                # `init` is folded into a backend-defined number of partial reductions, so
+                # for the non-idempotent ops it changes the value itself, not just its
+                # derivative: count gives 98.0 where the count is 3.
+                (
+                    211,
+                    "count init, predicate",
+                    (i, z) -> count(>(0.0), z; init=i),
+                    (1.0, counted),
+                    (; msg=r"not its identity"),
+                ),
+                (
+                    212,
+                    "count init, mask",
+                    (i, z) -> count(z .> 0; init=i),
+                    (1.0, counted),
+                    (; msg=r"not its identity"),
+                ),
+                (
+                    213,
+                    "sum init",
+                    z -> sum(z; init=1.0f0),
+                    (x32,),
+                    (; msg=r"not its identity"),
+                ),
+                (
+                    214,
+                    "sum init, dims",
+                    z -> sum(sum(z; dims=1, init=5.0)),
+                    (x32,),
+                    (; msg=r"not its identity"),
+                ),
+                (
+                    215,
+                    "prod init, dims",
+                    z -> sum(prod(z; dims=1, init=2.0)),
+                    (x32,),
+                    (; msg=r"not its identity"),
+                ),
+                (
+                    216,
+                    "sum init over an index array",
+                    z -> Float32(sum(CuArray([1, 2, 3]); init=1.0)) * sum(z),
+                    (x32,),
+                    (; msg=r"not its identity"),
+                ),
+                (
+                    217,
+                    "reduce init",
+                    z -> reduce(+, z; init=1.0f0),
+                    (x32,),
+                    (; msg=r"not its identity"),
+                ),
+                # Before the keyword claims these escaped to GPUArrays' reduction kernel and
+                # failed inside cufunction; an unsupported op or a `dims` the mapped rule
+                # cannot do yet has to say so itself.
+                (
+                    218,
+                    "reduce, unsupported op",
+                    z -> reduce(max, z; init=0.0f0),
+                    (x32,),
+                    (; msg=r"only supports op"),
+                ),
+                (
+                    219,
+                    "mapreduce, dims",
+                    z -> sum(mapreduce(abs2, +, z; dims=1)),
+                    (M32,),
+                    (; msg=r"not yet differentiable"),
+                ),
+                (
+                    220,
+                    "accumulate, non-+",
+                    z -> sum(accumulate(*, z)),
+                    (x32,),
+                    (; msg=r"supports only op=\+ over a float or complex array"),
+                ),
+                (
+                    221,
+                    "accumulate, non-+, dims",
+                    z -> sum(accumulate(*, z; dims=1)),
+                    (x32,),
+                    (; msg=r"supports only op=\+ over a float or complex array"),
+                ),
+                # One entry per @eval claim family; other functions in the same loop share
+                # the generated code verbatim.
+                (
+                    222,
+                    "kwcall sum(f, x; dims)",
+                    z -> sum(sum(abs2, z; dims=1)),
+                    (x32,),
+                    (; msg=r"not yet differentiable"),
+                ),
+                (
+                    223,
+                    "mapped maximum",
+                    z -> maximum(abs, z),
+                    (x32,),
+                    (; msg=r"not yet differentiable"),
+                ),
+                (
+                    224,
+                    "mapped maximum, kwcall",
+                    z -> sum(maximum(abs, z; dims=1)),
+                    (x32,),
+                    (; msg=r"not yet differentiable"),
+                ),
+                (
+                    225,
+                    "sort, kwcall",
+                    z -> sum(sort(z; rev=true)),
+                    (x32,),
+                    (; msg=r"not yet differentiable"),
+                ),
+                (
+                    226,
+                    "sort, positional",
+                    z -> sum(sort(z)),
+                    (x32,),
+                    (; msg=r"not yet differentiable"),
+                ),
+                # cu() downcasts ComplexF64 to ComplexF32, so the adjoint matvec sees two
+                # element types; the rule detects that before any cuBLAS call.
+                (
+                    227,
+                    "matvec eltype mismatch",
+                    _cu_cx_slice_adj_mul,
+                    (host_cx, gpu_cx),
+                    (; msg=r"GPU gemv with mismatched element types"),
+                ),
+                # One Vararg guard per function covers array/scalar mixing at any arity.
+                (
+                    228,
+                    "vcat GPU with host",
+                    _vcat_cu_sum,
+                    (x32, cpu_vec),
+                    (; msg=r"mix of GPU"),
+                ),
+                (
+                    229,
+                    "hcat GPU with host",
+                    _hcat_cu_sum,
+                    (M32, cpu_mat),
+                    (; msg=r"mix of GPU"),
+                ),
+                (
+                    230,
+                    "cat GPU with a scalar",
+                    _cat_cu_sum(1),
+                    (x32, 1.0f0),
+                    (; msg=r"mix of GPU"),
+                ),
+                # A strided Float16 view stays a genuine SubArray, which
+                # CuMaybeWrappedArray excludes, so the mixed-device guard catches it rather
+                # than the interpreter reaching cufunction's untraceable try/finally.
+                (
+                    231,
+                    "Float16 strided view",
+                    (a, b) -> sum(vcat(view(a, 1:2, :), b)),
+                    (x16, y16),
+                    (; msg=r"mix of GPU"),
+                ),
+                # Keywords the primal itself rejects must surface the primal's own error,
+                # not a field error from the frule reading a tangent slot that is absent.
+                (
+                    232,
+                    "varm, missing dims",
+                    _varm_arraymean_missing_dims,
+                    (M32, m_row),
+                    (; err=UndefKeywordError, primal=true),
+                ),
+                (
+                    233,
+                    "varm, stray dims",
+                    _varm_scalarmean_stray_dims,
+                    (M32, m_scalar),
+                    (; err=MethodError, primal=true),
+                ),
+                (
+                    234,
+                    "sum, bad keyword",
+                    _sum_kw_badkw,
+                    (M32,),
+                    (; err=MethodError, primal=true),
+                ),
+                (
+                    235,
+                    "maximum, bad keyword",
+                    _max_badkw,
+                    (M32,),
+                    (; err=MethodError, primal=true),
+                ),
+                # Forward mode alone refuses a differentiated `init` the rule treats as a
+                # constant; reverse mode reports a zero derivative for it instead.
+                (
+                    236,
+                    "differentiated init, float",
+                    _sum_kw_init_active,
+                    (0.0f0, M32),
+                    (; msg=r"init.*constant", mode=Mooncake.ForwardMode),
+                ),
+                (
+                    237,
+                    "differentiated init, index array",
+                    _nodiff_sum_init,
+                    (0.0, x32),
+                    (; msg=r"init.*constant", mode=Mooncake.ForwardMode),
+                ),
+            ]
+                test_rule_throws(StableRNG(seed), f, args...; kw...)
             end
         end
 
         @testset "unsupported operations throw ArgumentError" begin
-            # Mixed-precision GPU broadcast (Float32 array .+ ComplexF32 array) is not
-            # supported.  The materialize frule/rrule detects mismatched GPU element types
-            # and throws before any kernel launch.
-            @testset "mixed-eltype GPU broadcast" begin
-                f = _bcast_cx_mixed
-                x = _rand(rng, Float32, 4)
-                y = CuArray(randn(rng, ComplexF32, 4))
-                @test_throws r"GPU broadcast over arrays with mixed element types" value_and_gradient!!(
-                    Mooncake.build_rrule(f, x, y), f, x, y
-                )
-            end
-
-            # Scalar getindex/setindex! on CuArray — throw to prevent silent scalar GPU ops.
-            @testset "scalar getindex CuArray not differentiable" begin
-                f = x -> x[1]
-                x = _rand(rng, Float32, 4)
-                @test_throws r"scalar indexing of CuArray is not differentiable" value_and_gradient!!(
-                    Mooncake.build_rrule(f, x), f, x
-                )
-            end
-            @testset "scalar setindex! CuArray not differentiable" begin
-                f = x -> (x[1]=0.0f0; sum(x))
-                x = _rand(rng, Float32, 4)
-                @test_throws r"scalar indexing of CuArray is not differentiable" value_and_gradient!!(
-                    Mooncake.build_rrule(f, x), f, x
-                )
-            end
-
-            # accumulate with unsupported op — catch-all rule throws ArgumentError.
             @testset "freeing the input itself still differentiates" begin
                 # Not a test_rule case: the function frees its own argument, so it cannot be
                 # called twice.  The fdata must outlive the free — reverse mode accumulates
@@ -1672,91 +1925,6 @@ end
                 )
                 @test v == 20.0
                 @test Array(dx) == [2.0, 2.0, 2.0, 2.0]
-            end
-
-            @testset "count refuses a non-identity init" begin
-                # The count is summed with `init` folded into a backend-defined number of
-                # partial reductions, so a nonzero one changes the value, not just its
-                # derivative: 98.0 where the count is 3, with sensitivity 95.
-                x = CuArray([1.0, -2.0, 3.0, 4.0])
-                for f in
-                    ((i, z) -> count(>(0.0), z; init=i), (i, z) -> count(z .> 0; init=i))
-                    @test_throws r"not its identity" Mooncake.value_and_gradient!!(
-                        Mooncake.build_rrule(f, 1.0, x), f, 1.0, x
-                    )
-                    @test_throws r"not its identity" Mooncake.value_and_derivative!!(
-                        Mooncake.build_frule(f, 1.0, x),
-                        Mooncake.Dual(f, Mooncake.zero_tangent(f)),
-                        Mooncake.Dual(1.0, 1.0),
-                        Mooncake.Dual(x, Mooncake.zero_tangent(x)),
-                    )
-                end
-            end
-
-            @testset "keyword reduce/mapreduce spellings report their own limits" begin
-                # Before these claims the keyword forms escaped to GPUArrays' reduction
-                # kernel and failed there; an unsupported op or a `dims` the mapped rule
-                # cannot do yet must say so itself.
-                x = _rand(rng, Float32, 4)
-                M = _rand(rng, Float32, 4, 3)
-                fmax = z -> reduce(max, z; init=0.0f0)
-                @test_throws r"only supports op" Mooncake.value_and_gradient!!(
-                    Mooncake.build_rrule(fmax, x), fmax, x
-                )
-                fdims = z -> sum(mapreduce(abs2, +, z; dims=1))
-                @test_throws r"not yet differentiable" Mooncake.value_and_gradient!!(
-                    Mooncake.build_rrule(fdims, M), fdims, M
-                )
-                finit = z -> reduce(+, z; init=1.0f0)
-                @test_throws r"not its identity" Mooncake.value_and_gradient!!(
-                    Mooncake.build_rrule(finit, x), finit, x
-                )
-            end
-
-            @testset "accumulate non-+ CuArray not differentiable" begin
-                x = _rand(rng, Float32, 4)
-                for f in (x -> sum(accumulate(*, x)), x -> sum(accumulate(*, x; dims=1)))
-                    @test_throws r"supports only op=\+ over a float or complex array" value_and_gradient!!(
-                        Mooncake.build_rrule(f, x), f, x
-                    )
-                end
-            end
-
-            # Keyword and mapped-form reductions without real rules fall back to
-            # friendly errors instead of dying inside cufunction (#1273).
-            @testset "keyword/mapped reduction fallbacks throw ArgumentError" begin
-                x = _rand(rng, Float32, 4)
-                dx = Mooncake.zero_tangent(x)
-                # One entry per @eval claim family; other functions in the same
-                # loop share the generated code verbatim.
-                for f in (
-                    z -> sum(sum(abs2, z; dims=1)),     # kwcall sum(f, x; dims)
-                    z -> maximum(abs, z),               # mapped, positional
-                    z -> sum(maximum(abs, z; dims=1)),  # mapped, kwcall
-                    z -> sum(sort(z; rev=true)),        # catch-all, kwcall
-                    z -> sum(sort(z)),                  # catch-all, positional
-                )
-                    @test_throws r"not yet differentiable" value_and_gradient!!(
-                        Mooncake.build_rrule(f, x), f, x
-                    )
-                    @test_throws r"not yet differentiable" Mooncake.value_and_derivative!!(
-                        Mooncake.build_frule(f, x),
-                        Mooncake.Dual(f, Mooncake.NoTangent()),
-                        Mooncake.Dual(x, dx),
-                    )
-                end
-            end
-
-            # Complex slice-adjoint-matvec: cu(x[:, 1])' * cy — cu() downcasts ComplexF64
-            # to ComplexF32, producing a type mismatch with cy::CuMatrix{ComplexF64}.
-            # The generic_matvecmul! frule/rrule detects the mismatch before any cuBLAS call.
-            @testset "complex slice-adjoint-matvec type mismatch" begin
-                f = _cu_cx_slice_adj_mul
-                x = _host_rand(rng, ComplexF64, 3, 3)
-                cy = _rand(rng, ComplexF64, 3, 3)
-                @test_throws r"GPU gemv with mismatched element types" value_and_gradient!!(
-                    Mooncake.build_rrule(f, x, cy), f, x, cy
-                )
             end
 
             @testset "mixed GPU/CPU cat guards" begin
@@ -1776,22 +1944,6 @@ end
                 tgpu3 = Mooncake.zero_tangent(gpu3)
                 s = 1.0f0
                 wc = Base.get_world_counter()
-
-                @test_throws r"mix of GPU" value_and_gradient!!(
-                    Mooncake.build_rrule(_vcat_cu_sum, gpu1, cpu_vec),
-                    _vcat_cu_sum,
-                    gpu1,
-                    cpu_vec,
-                )
-                @test_throws r"mix of GPU" value_and_gradient!!(
-                    Mooncake.build_rrule(_hcat_cu_sum, gpu2, cpu_mat),
-                    _hcat_cu_sum,
-                    gpu2,
-                    cpu_mat,
-                )
-                @test_throws r"mix of GPU" value_and_gradient!!(
-                    Mooncake.build_rrule(_cat_cu_sum(1), gpu1, s), _cat_cu_sum(1), gpu1, s
-                )
 
                 @test Mooncake.is_primitive(
                     Mooncake.MinimalCtx,
@@ -1918,18 +2070,6 @@ end
                 @test val ≈ sum(vcat(x16, y16))
                 @test all(==(one(Float16)), Array(dx))
                 @test all(==(one(Float16)), Array(dy))
-
-                # Float16 SubArrays are excluded from CuMaybeWrappedArray. A strided view
-                # stays a genuine SubArray (unlike the contiguous 1-D view above, which
-                # CUDA.jl collapses to a plain CuArray) and the N-arg mixed-device guard
-                # does not count it as GPU either, so it errors with "mix of GPU" rather
-                # than reaching the interpreter's untraceable `cufunction` try/finally.
-                x16_mat = _rand(rng, Float16, 4, 3)
-                y16_mat = _rand(rng, Float16, 2, 3)
-                f_view(x, y) = sum(vcat(view(x, 1:2, :), y))
-                @test_throws r"mix of GPU" value_and_gradient!!(
-                    Mooncake.build_rrule(f_view, x16_mat, y16_mat), f_view, x16_mat, y16_mat
-                )
             end
 
             @testset "_unwrap_cat_dim rejects unsupported dims types" begin
@@ -2134,19 +2274,6 @@ end
                     m;
                     is_primitive=false,
                     perf_flag=:none,
-                )
-            end
-            @testset "kwarg sets the primal rejects throw under AD" begin
-                x = _rand(rng, Float32, 4, 3)
-                m = _rand(rng, Float32, 1, 3)
-                rule = Mooncake.build_rrule(_varm_arraymean_missing_dims, x, m)
-                @test_throws UndefKeywordError Mooncake.value_and_gradient!!(
-                    rule, _varm_arraymean_missing_dims, x, m
-                )
-                m_scalar = randn(StableRNG(28), Float32)
-                rule2 = Mooncake.build_rrule(_varm_scalarmean_stray_dims, x, m_scalar)
-                @test_throws MethodError Mooncake.value_and_gradient!!(
-                    rule2, _varm_scalarmean_stray_dims, x, m_scalar
                 )
             end
             @testset "empty array, scalar mean, corrected=true (Float32)" begin
@@ -2446,17 +2573,6 @@ end
             ]
                 test_rule(StableRNG(seed), f, x; is_primitive=false, perf_flag=:none)
             end
-            @testset "kwarg sets the primal rejects throw under AD" begin
-                # The float-typed bad kwarg gives the frule a tangent NamedTuple
-                # without an `init` field: reading `dkw.init` unguarded would
-                # throw a field error instead of the primal's MethodError.
-                x = _rand(rng, Float32, 4, 3)
-                @test_throws MethodError Mooncake.value_and_derivative!!(
-                    Mooncake.build_frule(_sum_kw_badkw, x),
-                    Mooncake.Dual(_sum_kw_badkw, Mooncake.NoTangent()),
-                    Mooncake.Dual(x, Mooncake.zero_tangent(x)),
-                )
-            end
             @testset "init is a non-differentiated constant" begin
                 # Not a test_rule case: finite differences see the backend's init
                 # folding (nonzero ∂/∂init) while the rule deliberately treats
@@ -2467,45 +2583,6 @@ end
                     rule, _sum_kw_init_active, a, x
                 )
                 @test da == 0.0f0
-                frule = Mooncake.build_frule(_sum_kw_init_active, a, x)
-                @test_throws r"init.*constant" Mooncake.value_and_derivative!!(
-                    frule,
-                    Mooncake.Dual(_sum_kw_init_active, Mooncake.NoTangent()),
-                    Mooncake.Dual(a, 1.0f0),
-                    Mooncake.Dual(x, Mooncake.zero_tangent(x)),
-                )
-            end
-            @testset "init over a non-differentiable array is rejected" begin
-                # The output is a Float64 here, so a zero derivative w.r.t. init would be
-                # silently wrong rather than merely conservative.
-                a, x = 0.0, _rand(rng, Float32, 4)
-                @test_throws r"init.*constant" Mooncake.value_and_derivative!!(
-                    Mooncake.build_frule(_nodiff_sum_init, a, x),
-                    Mooncake.Dual(_nodiff_sum_init, Mooncake.NoTangent()),
-                    Mooncake.Dual(a, 1.0),
-                    Mooncake.Dual(x, Mooncake.zero_tangent(x)),
-                )
-            end
-            @testset "a non-identity init is refused in both modes" begin
-                # + and * are not idempotent, so the backend's folding changes the value
-                # itself: sum(CuArray([1, 2, 3]); init=1.0) is 101.0, not 7.0.  Reading the
-                # value rather than a tangent is what lets reverse mode refuse it too.
-                x = _rand(rng, Float32, 4)
-                for f in (
-                    z -> sum(z; init=1.0f0),
-                    z -> sum(sum(z; dims=1, init=5.0)),
-                    z -> sum(prod(z; dims=1, init=2.0)),
-                    z -> Float32(sum(CuArray([1, 2, 3]); init=1.0)) * sum(z),
-                )
-                    @test_throws r"not its identity" Mooncake.value_and_gradient!!(
-                        Mooncake.build_rrule(f, x), f, x
-                    )
-                    @test_throws r"not its identity" Mooncake.value_and_derivative!!(
-                        Mooncake.build_frule(f, x),
-                        Mooncake.Dual(f, Mooncake.zero_tangent(f)),
-                        Mooncake.Dual(x, Mooncake.zero_tangent(x)),
-                    )
-                end
             end
             @testset "a constant init still differentiates in reverse" begin
                 # Reverse mode cannot tell this literal from an init the caller wants a
@@ -2628,15 +2705,6 @@ end
                     Array(value_and_gradient!!(Mooncake.build_rrule(f, x), f, x)[2][2])
                 end
                 @test grads[1] == grads[2] == Float32[0, 1, 0]
-            end
-            @testset "an unsupported keyword fails like the primal" begin
-                # The value has to come from the primal call, not from findmax, which
-                # accepts only `dims` and would silently ignore the rest.
-                x = _rand(rng, Float32, 4, 3)
-                @test_throws MethodError _max_badkw(x)
-                @test_throws MethodError Mooncake.value_and_gradient!!(
-                    Mooncake.build_rrule(_max_badkw, x), _max_badkw, x
-                )
             end
             @testset "ties pick the lowest linear index" begin
                 # Not reachable from test_rule's random inputs. findmax names the

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -501,6 +501,10 @@ end
         # Float64 array narrows the result and its tangent has to follow.
         _max_init_widens(x) = maximum(x; init=0.0f0)
         _prod_init_widens(x) = sum(prod(x; dims=1, init=1.0f0))
+        # The mirror of the above: an `init` wider than the array.  GPUArrays takes the
+        # output eltype from `init`, so the exclusive product and the zero it falls back to
+        # are two different types unless the zero is taken from the quotient itself.
+        _prod_init_wider(x) = sum(prod(x; dims=1, init=1.0))
         # An index or mask array has no derivative, but `init` competes with its elements.
         _max_idx_init(a, x) = maximum(CuArray([1, 2, 3]); init=a) * sum(x)
         _max_idx_init_d1(a, x) = sum(maximum(CuArray([1 2; 3 4]); dims=1, init=a)) * sum(x)
@@ -775,6 +779,8 @@ end
             (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),
             (false, :none, false, _accumulate_init_widens, _rand(rng, Float64, 6)),
             (false, :none, false, _accumulate_init_outdim, 1.0f0, _rand(rng, Float32, 6)),
+            (false, :none, false, _prod_init_wider, _rand(rng, Float32, 2, 2)),
+            (false, :none, false, _prod_init_wider, CuArray(Float32[1 0; 3 2])),
             (false, :none, false, _cumsum_empty, CuArray{Float32}(undef, 0, 3)),
             (false, :none, false, _cumsum_empty_d2, CuArray{Float32}(undef, 0, 3)),
             (false, :none, false, _cumprod_empty, CuArray{Float32}(undef, 0, 3)),
@@ -2906,6 +2912,7 @@ end
                 @testset "$name" for (seed, name, f) in [
                     (96, "maximum", _max_init_widens),
                     (97, "prod dims=1", _prod_init_widens),
+                    (98, "prod dims=1, wider init", _prod_init_wider),
                 ]
                     test_rule(
                         StableRNG(seed),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -164,6 +164,14 @@ end
         # Without `dims` CUDA scans an N-d array in linear order, not column by column.
         # Passing the captured value as an argument is what the refusal message recommends;
         # a capture the kernel cannot thread must not be silently zeroed instead.
+        # An in-place broadcast overwrites dest, so a non-differentiable result has to consume
+        # dest's cotangent; letting it through credits dest's own history for a value that
+        # does not depend on it.  The mid-chain case is the sharp one: the leak showed up as
+        # exactly 2cos(x) where the derivative is cos(x).
+        _bcast_kill(x) = (y=x .* 2; y.=y .> 0; sum(y))
+        _bcast_kill_mid(x) = (y=x .* 1; y.=sin.(y); s=sum(y); y.=y .> 0; s + sum(y))
+        _bcast_kill_view(x) = (y=x .* 2; v=view(y, 3:4); v.=v .> 0; sum(y))
+        _bcast_kill_cast(x) = (y=x .* 2; y.=Float64.(y .> 0); sum(y))
         _hoisted_capture(a, x) = sum(((t, c) -> c * t).(x, a))
         _int_capture(x) = (n=3; sum((t -> n * t).(x)))
         _accumulate_flat(x) = sum(accumulate(+, x))
@@ -586,6 +594,10 @@ end
             (false, :none, false, _accumulate_init, 1.0f0, _rand(rng, Float32, 6)),
             (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),
             (false, :none, false, _accumulate_init_widens, _rand(rng, Float64, 6)),
+            (false, :none, false, _bcast_kill, CuArray([0.3, -0.7, 1.2, 2.5])),
+            (false, :none, false, _bcast_kill_mid, CuArray([0.3, -0.7, 1.2, 2.5])),
+            (false, :none, false, _bcast_kill_view, CuArray([0.3, -0.7, 1.2, 2.5])),
+            (false, :none, false, _bcast_kill_cast, CuArray([0.3, -0.7, 1.2, 2.5])),
             (false, :none, false, _hoisted_capture, 3.0, _rand(rng, 4)),
             (false, :none, false, _int_capture, _rand(rng, 4)),
             (false, :none, false, _accumulate_flat, _rand(rng, 4, 3)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -199,9 +199,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _nodiff_sum_dims(x) = (i=CuArray([1 2; 3 4]); sum(x) * Float32(sum(sum(i; dims=1))))
         _nodiff_sum_mask(x) = (m=CuArray([true, false, true]); sum(x) * Float32(sum(m)))
         # A float `init` makes the output differentiable, and GPUArrays folds init into a
-        # backend-defined number of partial reductions, so its derivative is rejected
-        # rather than silently zeroed.
+        # backend-defined number of partial reductions, so the frule rejects its derivative.
         _nodiff_sum_init(a, x) = sum(x) * Float32(sum(CuArray([1, 2, 3]); init=a))
+        _nodiff_sum_init_const(x) = sum(x) * Float32(sum(CuArray([1, 2, 3]); init=0.0))
         # The other reductions over an index or mask array. `count` returns an Integer for
         # any array, so the float case has no derivative either.
         _nodiff_prod(x) = (i=CuArray([1, 2, 3]); sum(x) * Float32(prod(i)))
@@ -2146,9 +2146,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             end
             @testset "init over a non-differentiable array is rejected" begin
                 # The output is a Float64 here, so a zero derivative w.r.t. init would be
-                # silently wrong rather than merely conservative.  Reverse mode never sees
-                # an init tangent, but init is the only gradient path over an index array,
-                # so a nonzero output cotangent is the same error seen from the far side.
+                # silently wrong rather than merely conservative.
                 a, x = 0.0, _rand(rng, Float32, 4)
                 @test_throws r"init.*constant" Mooncake.value_and_derivative!!(
                     Mooncake.build_frule(_nodiff_sum_init, a, x),
@@ -2156,9 +2154,15 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                     Mooncake.Dual(a, 1.0),
                     Mooncake.Dual(x, Mooncake.zero_tangent(x)),
                 )
-                @test_throws r"init.*constant" Mooncake.value_and_gradient!!(
-                    Mooncake.build_rrule(_nodiff_sum_init, a, x), _nodiff_sum_init, a, x
-                )
+            end
+            @testset "a constant init still differentiates in reverse" begin
+                # Reverse mode cannot tell this literal from an init the caller wants a
+                # gradient for, so it must not reject either: ∂/∂x is well defined here.
+                x = _rand(rng, Float32, 4)
+                rule = Mooncake.build_rrule(_nodiff_sum_init_const, x)
+                v, (_, dx) = Mooncake.value_and_gradient!!(rule, _nodiff_sum_init_const, x)
+                @test v ≈ _nodiff_sum_init_const(x)
+                @test all(Array(dx) .≈ 6.0f0)
             end
         end
 

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -266,6 +266,13 @@ end
         _bcast_cast_chain_sq(x) = sum(Float64.(Float32.(x)) .^ 2)
         _bcast_cast_chain_same(x) = sum(Float32.(Float32.(x)) .^ 2)
         _bcast_cast_chain_cx(z) = sum(abs2.(ComplexF64.(ComplexF32.(z))))
+        # `x .= scalar` reaches materialize! as a zero-dimensional Broadcasted, whose style
+        # is DefaultArrayStyle rather than CuArrayStyle; before the claim covered it the
+        # call decomposed and tracing died inside cufunction.
+        _bcast_setscalar(x) = (y=x .* 2; y.=0.0f0; sum(y))
+        _bcast_setscalar_live(x) = (y=x .* 2; s=sum(y); y.=1.0f0; s + sum(y))
+        _bcast_setscalar_expr(x) = (y=x .* 2; y.=3.0f0 .* 2; sum(y))
+        _bcast_setscalar_arg(c, x) = (y=x .* 2; y.=c; sum(y))
         _bcast_zero_dof_nested(x, c, b) = sum(x .+ c .* Float64.(b .> 0))
         _bcast_all_scalar_leaf(x, s) = sum(x .* (s .+ 1.0))
         _inplace_zero_dof_nested!(dest, x, c, b) =
@@ -785,6 +792,10 @@ end
             (false, :none, false, _bcast_cast_chain_sq, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_cast_chain_same, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_cast_chain_cx, _rand(rng, ComplexF64, 4)),
+            (false, :none, false, _bcast_setscalar, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_setscalar_live, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_setscalar_expr, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_setscalar_arg, 1.5f0, _rand(rng, Float32, 4)),
             (
                 false,
                 :none,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -327,6 +327,14 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _max_init_d1(a, x) = sum(maximum(x; dims=1, init=a))
         _min_init(a, x) = minimum(x; init=a)
         _max_badkw(x) = maximum(x; bad=1.0)
+        # GPUArrays takes the output eltype from typeof(init), so a Float32 init over a
+        # Float64 array narrows the result and its tangent has to follow.
+        _max_init_widens(x) = maximum(x; init=0.0f0)
+        _prod_init_widens(x) = sum(prod(x; dims=1, init=1.0f0))
+        # An index or mask array has no derivative, but `init` competes with its elements.
+        _max_idx_init(a, x) = maximum(CuArray([1, 2, 3]); init=a) * sum(x)
+        _max_idx_init_d1(a, x) = sum(maximum(CuArray([1 2; 3 4]); dims=1, init=a)) * sum(x)
+        _min_idx_init(a, x) = minimum(CuArray([1, 2, 3]); init=a) * sum(x)
         _host_rand = (rng, size...) -> randn(rng, size...)
         @testset "_new_ interface" begin
             # Test the `_new_` frule!!/rrule!! interfaces directly.
@@ -2221,6 +2229,45 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                     is_primitive=false,
                     perf_flag=:none,
                 )
+            end
+            # An index array contributes nothing, so `init` carries the whole gradient.
+            @testset "$name" for (seed, name, f, a) in [
+                (90, "index array, init wins", _max_idx_init, 10.0),
+                (91, "index array, init loses", _max_idx_init, -10.0),
+                (92, "index array, init wins, dims=1", _max_idx_init_d1, 10.0),
+                (93, "index array, minimum", _min_idx_init, -10.0),
+            ]
+                test_rule(
+                    StableRNG(seed),
+                    f,
+                    a,
+                    _rand(rng, Float32, 4);
+                    is_primitive=false,
+                    perf_flag=:none,
+                )
+            end
+            @testset "a narrowing init narrows the tangent too" begin
+                @testset "$name" for (seed, name, f) in [
+                    (96, "maximum", _max_init_widens),
+                    (97, "prod dims=1", _prod_init_widens),
+                ]
+                    test_rule(
+                        StableRNG(seed),
+                        f,
+                        _rand(rng, Float64, 4, 3);
+                        is_primitive=false,
+                        perf_flag=:none,
+                    )
+                end
+            end
+            @testset "a NaN slice keeps the keyword-free gradient" begin
+                # `won` is a negated comparison because NaN == NaN is false, which would
+                # zero the whole slice and disagree with the positional rule.
+                x = CuArray(Float32[1, NaN, 3])
+                grads = map((_max_bare, _max_nodims)) do f
+                    Array(value_and_gradient!!(Mooncake.build_rrule(f, x), f, x)[2][2])
+                end
+                @test grads[1] == grads[2] == Float32[0, 1, 0]
             end
             @testset "an unsupported keyword fails like the primal" begin
                 # The value has to come from the primal call, not from findmax, which

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -318,6 +318,14 @@ end
         _bcast_setscalar_live(x) = (y=x .* 2; s=sum(y); y.=1.0f0; s + sum(y))
         _bcast_setscalar_expr(x) = (y=x .* 2; y.=3.0f0 .* 2; sum(y))
         _bcast_setscalar_arg(c, x) = (y=x .* 2; y.=c; sum(y))
+        # An Int right-hand side seeds no dual, so the kernel hands back the scalar itself
+        # rather than an array of duals; writing it with `copyto!` indexed one element.
+        _bcast_setscalar_int(x) = (y=x .* 2; y.=1; sum(y))
+        # A float range is refused: it may have been built from differentiated endpoints and
+        # nothing at the leaf can tell.  An integer range carries no derivative and is
+        # threaded as a constant, and materialising a float one restores the gradient.
+        _bcast_int_range(x) = sum(x .* (1:4))
+        _bcast_materialised_range(x) = sum(x .* CuArray(collect(0.0f0:0.25f0:0.75f0)))
         # A scalar leaf narrower than the array's eltype: the kernel's partials carry the
         # promoted type, but the leaf's rdata has to follow the leaf, or it lands in a slot
         # of the wrong type.
@@ -897,6 +905,9 @@ end
             (false, :none, false, _bcast_setscalar_live, _rand(rng, Float32, 4)),
             (false, :none, false, _bcast_setscalar_expr, _rand(rng, Float32, 4)),
             (false, :none, false, _bcast_setscalar_arg, 1.5f0, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_setscalar_int, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_int_range, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_materialised_range, _rand(rng, Float32, 4)),
             (false, :none, false, _bcast_narrow_scalar, 1.5f0, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_narrow_scalar_add, 1.5f0, _rand(rng, Float64, 4)),
             (
@@ -2169,6 +2180,20 @@ end
                     _max_badkw,
                     (M32,),
                     (; err=MethodError, primal=true),
+                ),
+                (
+                    280,
+                    "float range leaf",
+                    z -> sum(z .* (0.0f0:0.25f0:0.75f0)),
+                    (_rand(rng, Float32, 4),),
+                    (; msg=r"Materialise the range first"),
+                ),
+                (
+                    281,
+                    "range from a differentiated endpoint",
+                    (a, z) -> sum(z .* range(a, 1.0f0; length=4)),
+                    (0.0f0, _rand(rng, Float32, 4)),
+                    (; msg=r"would silently be zero"),
                 ),
                 # A reinterpret that changes the underlying real field would hand back a
                 # tangent whose elements are bit-halves of the primal's.

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -223,6 +223,11 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _geam_add(a, b) = sum(a + b)
         _geam_sub_adj(a, b) = sum(a' - b)
         _geam_add_cx(a, b) = real(sum(a + b'))
+        # A complex alpha against a transposed operand: the pullback folds the two
+        # conjugations together instead of conjugating alpha.
+        _mul_adj_alpha(c, a, b) = real(sum(mul!(c, a', b', 2.0 + 3.0im, -1.0 + 0.5im)))
+        _mulv_adj_alpha(y, a, x) = real(sum(mul!(y, a', x, 2.0 + 3.0im, -1.0 + 0.5im)))
+        _mulv_alpha(y, a, x) = real(sum(mul!(y, a, x, 2.0 + 3.0im, -1.0 + 0.5im)))
         # repeat: positional counts and the keyword spelling (separate rules).
         _repeat_counts(x) = sum(repeat(x, 2, 3))
         _repeat_extends(x) = sum(repeat(x, 2, 3, 2))
@@ -962,6 +967,49 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             # unrelated to our rules, so stability checks are not meaningful on GPU.
             test_rule(
                 StableRNG(123), fargs...; perf_flag=:none, is_primitive, interface_only
+            )
+        end
+
+        # Reverse mode only: a complex alpha carries a tangent, so it cannot dispatch the
+        # gemm/gemv frules, which take alpha as NoTangent.
+        @testset "$name" for (seed, name, fargs) in [
+            (
+                71,
+                "mul! matrix, complex alpha, both operands adjoint",
+                (
+                    _mul_adj_alpha,
+                    _rand(rng, ComplexF64, 4, 4),
+                    _rand(rng, ComplexF64, 4, 4),
+                    _rand(rng, ComplexF64, 4, 4),
+                ),
+            ),
+            (
+                72,
+                "mul! vector, complex alpha, adjoint operand",
+                (
+                    _mulv_adj_alpha,
+                    _rand(rng, ComplexF64, 4),
+                    _rand(rng, ComplexF64, 4, 4),
+                    _rand(rng, ComplexF64, 4),
+                ),
+            ),
+            (
+                73,
+                "mul! vector, complex alpha",
+                (
+                    _mulv_alpha,
+                    _rand(rng, ComplexF64, 4),
+                    _rand(rng, ComplexF64, 4, 4),
+                    _rand(rng, ComplexF64, 4),
+                ),
+            ),
+        ]
+            test_rule(
+                StableRNG(seed),
+                fargs...;
+                is_primitive=false,
+                perf_flag=:none,
+                mode=Mooncake.ReverseMode,
             )
         end
 

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -209,6 +209,17 @@ end
         _gather_mask_bits(x) = sum(x[BitVector([true, false, true, false])])
         _gather_mask_cx(x) = real(sum(x[CuArray(Bool[true, false, true, false])]))
         _gather_mask_none(x) = sum(x[CuArray(falses(4))]) + sum(x)
+        # A view carries an offset into its parent's allocation, while its tangent starts at
+        # the beginning of a buffer of its own; deriving the tangent from the primal's offset
+        # shifts every gradient by that many elements.  The weighted case pins which element
+        # each cotangent reached, and the parent fixtures are longer than the views so the
+        # offsets are nonzero.
+        _view_sum(a) = sum(view(a, 1:3))
+        _view_weighted(a) = sum(view(a, 1:3) .* CuArray(Float32[1, 2, 3]))
+        _view_reshaped(a) = sum(reshape(a, 2, 3) .* CuArray(Float32[1 3 5; 2 4 6]))
+        _view_of_view(a) = sum(view(view(a, 2:5), 1:2))
+        _view_cols(m) = sum(view(m, :, 1) .* CuArray(Float32[1, 2, 3]))
+        _view_weighted_cx(a) = real(sum(view(a, 1:3) .* CuArray(ComplexF32[1, 2im, 3])))
         _gather_sum_cx(x, idx) = real(sum(x[idx]))
         # unsafe_free! releases the primal early; in reverse mode the fdata is still the
         # accumulator earlier pullbacks write into, so it has to outlive the call.
@@ -725,6 +736,12 @@ end
             (false, :none, false, _gather_mask_bits, _rand(rng, Float32, 4)),
             (false, :none, false, _gather_mask_cx, _rand(rng, ComplexF32, 4)),
             (false, :none, false, _gather_mask_none, _rand(rng, Float32, 4)),
+            (false, :none, false, _view_sum, view(_rand(rng, Float32, 8), 3:8)),
+            (false, :none, false, _view_weighted, view(_rand(rng, Float32, 8), 3:8)),
+            (false, :none, false, _view_reshaped, view(_rand(rng, Float32, 8), 3:8)),
+            (false, :none, false, _view_of_view, view(_rand(rng, Float32, 8), 3:8)),
+            (false, :none, false, _view_cols, view(_rand(rng, Float32, 3, 4), :, 2:3)),
+            (false, :none, false, _view_weighted_cx, view(_rand(rng, ComplexF32, 8), 3:8)),
             (
                 false,
                 :none,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -238,6 +238,13 @@ end
         _cu_sum(x) = sum(cu(x))
         _array_sum(x) = sum(Array(x))     # GPU→CPU transfer
         _diagonal_sum(x) = sum(Diagonal(x)) # GPU Diagonal construction
+        # Both rules assume the argument's fdata is the array itself.  A wrapper's is an
+        # FData over its parent, and `Diagonal(::CuMatrix)` is `Diagonal(diag(A))`, whose
+        # `.diag` is not the argument at all — so these spellings have to decompose.
+        _cu_adjoint(m) = sum(cu(m'))
+        _cu_transpose(m) = sum(cu(transpose(m)))
+        _cu_diagonal(v) = sum(cu(Diagonal(v)))
+        _diagonal_of_matrix(m) = sum(Diagonal(m))
         _diagonal_field_bcast(x) = sum(exp.(Diagonal(x).diag))  # Diagonal + lgetfield + broadcast
         # Diagonal(v).diag === v, so a mutation of v after wrapping has to be visible through
         # the wrapper: the two share one cotangent buffer.
@@ -610,6 +617,10 @@ end
             # GPU→CPU transfer (Array)
             (false, :none, false, _array_sum, _rand(rng, 16)),
             # GPU Diagonal construction
+            (false, :none, false, _cu_adjoint, _rand(rng, Float32, 2, 3)),
+            (false, :none, false, _cu_transpose, _rand(rng, Float32, 2, 3)),
+            (false, :none, false, _cu_diagonal, _rand(rng, Float32, 3)),
+            (false, :none, false, _diagonal_of_matrix, _rand(rng, Float32, 2, 3)),
             (false, :none, false, _diagonal_sum, _rand(rng, 16)),
             # sum(::CuComplexArray) — 1-arg widened rule, sum itself is the primitive
             (false, :none, true, sum, _rand(rng, ComplexF64, 16)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -274,6 +274,13 @@ end
         # reporting float arrays.
         _nodiff_diff(x) = (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(diff(i))))
         _nodiff_sortperm(x) = (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(sortperm(i))))
+        # Scans over an index array carry no derivative either, whatever the operator, so the
+        # indices they build can be used to gather.  Distinct indices here: a repeated one
+        # exercises the gather rule's scatter, which is a separate matter.
+        _cumsum_idx_gather(x) = sum(x[cumsum(CuArray([1, 1, 1]))])
+        _cumsum_idx_kw(x) = sum(x[cumsum(CuArray([1, 1, 1]); dims=1)])
+        _accumulate_idx_gather(x) = sum(x[accumulate(+, CuArray([1, 1, 1]))])
+        _cumsum_mask_gather(x) = sum(x[cumsum(CuArray([true, true, true]))])
         # sortperm returns Int indices, so it is zero-derivative for a float array too, and
         # the gather that uses them carries the gradient.  The weighted case is asymmetric,
         # so a permutation applied the wrong way round would not pass.
@@ -718,6 +725,10 @@ end
             (false, :none, false, _count_init_identity, _rand(rng, 8)),
             (false, :none, false, _nodiff_diff, _rand(rng, 8)),
             (false, :none, false, _nodiff_sortperm, _rand(rng, 8)),
+            (false, :none, false, _cumsum_idx_gather, _rand(rng, Float32, 4)),
+            (false, :none, false, _cumsum_idx_kw, _rand(rng, Float32, 4)),
+            (false, :none, false, _accumulate_idx_gather, _rand(rng, Float32, 4)),
+            (false, :none, false, _cumsum_mask_gather, _rand(rng, Float32, 4)),
             (false, :none, false, _sortperm_gather, CuArray(Float32[0.3, 0.7, 0.2, 0.9])),
             (false, :none, false, _sortperm_rev, CuArray(Float32[0.3, 0.7, 0.2, 0.9])),
             (

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -168,6 +168,11 @@ end
         _accumulate_init(a, x) = sum(accumulate(+, x; init=a))
         _accumulate_init_d1(a, x) = sum(accumulate(+, x; dims=1, init=a))
         _accumulate_init_widens(x) = sum(accumulate(+, x; init=1.0f0))
+        # Scanning along a dimension the array does not have copies the input and returns
+        # before `init` is applied, so the primal does not depend on it and neither may the
+        # derivative — the array's adjoint already took that path, only `init` had not.
+        _accumulate_init_outdim(a, x) = sum(accumulate(+, x; dims=2, init=a))
+        _accumulate_init_outdim3(a, m) = sum(accumulate(+, m; dims=3, init=a))
         # Without `dims` CUDA scans an N-d array in linear order, not column by column.
         # Passing the captured value as an argument is what the refusal message recommends;
         # a capture the kernel cannot thread must not be silently zeroed instead.
@@ -715,6 +720,15 @@ end
             (false, :none, false, _accumulate_init, 1.0f0, _rand(rng, Float32, 6)),
             (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),
             (false, :none, false, _accumulate_init_widens, _rand(rng, Float64, 6)),
+            (false, :none, false, _accumulate_init_outdim, 1.0f0, _rand(rng, Float32, 6)),
+            (
+                false,
+                :none,
+                false,
+                _accumulate_init_outdim3,
+                1.0f0,
+                _rand(rng, Float32, 2, 3),
+            ),
             (false, :none, false, _bcast_kill, CuArray([0.3, -0.7, 1.2, 2.5])),
             (false, :none, false, _bcast_kill_mid, CuArray([0.3, -0.7, 1.2, 2.5])),
             (false, :none, false, _bcast_kill_view, CuArray([0.3, -0.7, 1.2, 2.5])),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -2061,13 +2061,18 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             end
             @testset "init over a non-differentiable array is rejected" begin
                 # The output is a Float64 here, so a zero derivative w.r.t. init would be
-                # silently wrong rather than merely conservative.
+                # silently wrong rather than merely conservative.  Reverse mode never sees
+                # an init tangent, but init is the only gradient path over an index array,
+                # so a nonzero output cotangent is the same error seen from the far side.
                 a, x = 0.0, _rand(rng, Float32, 4)
                 @test_throws r"init.*constant" Mooncake.value_and_derivative!!(
                     Mooncake.build_frule(_nodiff_sum_init, a, x),
                     Mooncake.Dual(_nodiff_sum_init, Mooncake.NoTangent()),
                     Mooncake.Dual(a, 1.0),
                     Mooncake.Dual(x, Mooncake.zero_tangent(x)),
+                )
+                @test_throws r"init.*constant" Mooncake.value_and_gradient!!(
+                    Mooncake.build_rrule(_nodiff_sum_init, a, x), _nodiff_sum_init, a, x
                 )
             end
         end

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -243,6 +243,10 @@ end
         # the wrapper: the two share one cotangent buffer.
         _diagonal_mutate(v) = (D=Diagonal(v); v.=v .* 2; sum(D.diag))
         _diagonal_fill(v, c) = (D=Diagonal(v); fill!(v, c); sum(D.diag .^ 2))
+        # A real value filling a complex array is owed only dL/dRe, so the summed cotangent
+        # has to be projected before it is narrowed back to the value's own type.
+        _fill_real_into_cx(z, c) = (fill!(z, c); real(sum(z .* (1.0f0 + 2.0f0im))))
+        _fill_cx_into_cx(z, c) = (fill!(z, c); real(sum(z .* (1.0f0 + 2.0f0im))))
         _sum_f_abs(x) = sum(abs, x)          # sum(f, x) with non-smooth f
         _sum_f_abs2(x) = sum(abs2, x)        # sum(f, x) real abs2
         _sum_adj_pow3(x) = real(sum(y -> y^3, x'))  # sum(f, Adjoint)
@@ -967,6 +971,22 @@ end
             (false, :none, false, _diagonal_field_bcast, _rand_pos(rng, 16)),
             (false, :none, false, _diagonal_mutate, CuArray([1.0, 2.0, 3.0])),
             (false, :none, false, _diagonal_fill, CuArray([1.0, 2.0, 3.0]), 5.0),
+            (
+                false,
+                :none,
+                false,
+                _fill_real_into_cx,
+                CuArray(ComplexF32[0, 0, 0, 0]),
+                2.0f0,
+            ),
+            (
+                false,
+                :none,
+                false,
+                _fill_cx_into_cx,
+                CuArray(ComplexF32[0, 0, 0, 0]),
+                2.0f0 + 0.5f0im,
+            ),
             # sum(f, x) with non-smooth f (abs)
             (false, :none, false, _sum_f_abs, _rand(rng, 16)),
             # sum(f, Adjoint) — tests sum(f, x) dispatch when input is an Adjoint wrapper

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -533,6 +533,13 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             # prod — explicit rule (real and complex)
             (false, :none, false, _prod, _rand_pos(rng, 16)),
             (false, :none, false, _prod_cx, _rand(rng, ComplexF64, 16)),
+            # An exact zero is where reading the derivative off as y/xᵢ used to break: the
+            # zero's own derivative is the product of the rest, and a second zero in the
+            # slice takes the whole slice to zero.  prod is a polynomial, so finite
+            # differences pin these exactly.
+            (false, :none, false, _prod, CuArray([1.0, 0.0, 3.0])),
+            (false, :none, false, _prod, CuArray([1.0, 0.0, 0.0])),
+            (false, :none, false, _prod_cx, CuArray(ComplexF64[1 + 2im, 0, 3 - 1im])),
             # cumsum — explicit rule (real and complex)
             (false, :none, false, _cumsum_sum, _rand(rng, 16)),
             (false, :none, false, _cumsum_cx_sum, _rand(rng, ComplexF64, 16)),
@@ -545,6 +552,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             # The `dims` spellings. prod has its own rule per reduced slice, so it gets the
             # complex arm and both output branches; the others forward to the rules above.
             (false, :none, false, _prod_d1, _rand_pos(rng, 4, 3)),
+            (false, :none, false, _prod_d1, CuArray([1.0 2.0; 0.0 4.0])),
+            (false, :none, false, _prod_d1, CuArray([0.0 2.0; 0.0 4.0])),
+            (false, :none, false, _prod_colon, CuArray([1.0 0.0; 3.0 4.0])),
             (false, :none, false, _prod_d2, _rand_pos(rng, 4, 3)),
             (false, :none, false, _prod_colon, _rand_pos(rng, 4, 3)),
             (false, :none, false, _prod_cx_d1, _rand(rng, ComplexF64, 4, 3)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -191,7 +191,7 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         end
         # Device arrays with no derivative information: the index upload goes through
         # unsafe_copyto!(CuArray{Int}, Array{Int}), the zeros through the fill kernel.
-        _nodiff_index_copy(x) = (i=CuArray([1, 2]); sum(x) * Float32(length(i)))
+        _nodiff_index_copy(x) = (i=CuArray([1, 2]); sum(x[i]))
         _nodiff_fill(x) = (i=CUDA.zeros(Int64, 2); fill!(i, 3); sum(x))
         # CuMatrix +/- lowers to cuBLAS.geam!; the wrapper arms pick the 'T'/'C' flags.
         _geam_add(a, b) = sum(a + b)

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -296,6 +296,13 @@ end
         _bcast_cast_top(x) = sum(Float64.(x))
         _bcast_cast_top_narrow(x) = sum(Float32.(x))
         _bcast_cast_top_chain(x) = sum(Float64.(Float32.(x)))
+        # A complex leaf reaches the kernel as `Complex{<:NDual}`, one dual per degree of
+        # freedom, so a complex cast has to convert the parts rather than the whole; a real
+        # leaf widened to complex keeps its derivative in the real part.
+        _bcast_cast_cx_narrow(z) = real(sum(ComplexF32.(z) .* (1 + 2im)))
+        _bcast_cast_cx_widen(z) = real(sum(ComplexF64.(z) .* (1 + 2im)))
+        _bcast_cast_cx_abs2(z) = sum(abs2.(ComplexF32.(z)))
+        _bcast_cast_real_to_cx(x) = real(sum(ComplexF64.(x) .* (1 + 2im)))
         _bcast_cast_top_nodiff(x) =
             (i=CuArray(Int32[1, 2, 3, 4]); sum(Float64.(i)) * sum(x))
         # `x .= scalar` reaches materialize! as a zero-dimensional Broadcasted, whose style
@@ -840,6 +847,10 @@ end
             (false, :none, false, _view_of_view, view(_rand(rng, Float32, 8), 3:8)),
             (false, :none, false, _view_cols, view(_rand(rng, Float32, 3, 4), :, 2:3)),
             (false, :none, false, _view_weighted_cx, view(_rand(rng, ComplexF32, 8), 3:8)),
+            (false, :none, false, _bcast_cast_cx_narrow, _rand(rng, ComplexF64, 4)),
+            (false, :none, false, _bcast_cast_cx_widen, _rand(rng, ComplexF32, 4)),
+            (false, :none, false, _bcast_cast_cx_abs2, _rand(rng, ComplexF64, 4)),
+            (false, :none, false, _bcast_cast_real_to_cx, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_cast_top, _rand(rng, Float32, 4)),
             (false, :none, false, _bcast_cast_top_narrow, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_cast_top_chain, _rand(rng, Float32, 4)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -314,6 +314,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _max_nodims(x) = maximum(x; dims=:)
         _max_d1(x) = sum(maximum(x; dims=1))
         _min_d1(x) = sum(minimum(x; dims=1))
+        _max_init(a, x) = maximum(x; init=a)
+        _max_init_d1(a, x) = sum(maximum(x; dims=1, init=a))
+        _min_init(a, x) = minimum(x; init=a)
+        _max_badkw(x) = maximum(x; bad=1.0)
         _host_rand = (rng, size...) -> randn(rng, size...)
         @testset "_new_ interface" begin
             # Test the `_new_` frule!!/rrule!! interfaces directly.
@@ -2180,6 +2184,33 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
                 (65, "minimum(x; dims=1)", _min_d1, _rand(rng, Float32, 4, 3)),
             ]
                 test_rule(StableRNG(seed), f, x; is_primitive=false, perf_flag=:none)
+            end
+            # `init` reaches the value and both derivatives: 1 on each slice it wins, 0
+            # elsewhere.  test_rule's finite differences check the value and both arms; the
+            # margins keep the perturbation from crossing the kink.
+            @testset "$name" for (seed, name, f, a) in [
+                (66, "maximum, init wins", _max_init, 2.0f0),
+                (67, "maximum, init loses", _max_init, -2.0f0),
+                (68, "maximum, init wins, dims=1", _max_init_d1, 2.0f0),
+                (69, "minimum, init wins", _min_init, -2.0f0),
+            ]
+                test_rule(
+                    StableRNG(seed),
+                    f,
+                    a,
+                    _rand(rng, Float32, 4, 3);
+                    is_primitive=false,
+                    perf_flag=:none,
+                )
+            end
+            @testset "an unsupported keyword fails like the primal" begin
+                # The value has to come from the primal call, not from findmax, which
+                # accepts only `dims` and would silently ignore the rest.
+                x = _rand(rng, Float32, 4, 3)
+                @test_throws MethodError _max_badkw(x)
+                @test_throws MethodError Mooncake.value_and_gradient!!(
+                    Mooncake.build_rrule(_max_badkw, x), _max_badkw, x
+                )
             end
             @testset "ties pick the lowest linear index" begin
                 # Not reachable from test_rule's random inputs. findmax names the

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -1414,6 +1414,32 @@ end
             @test all(x -> x isa Mooncake.NoRData, pb(Mooncake.NoRData()))
         end
 
+        @testset "norm frule!! rescales an overflowing dot" begin
+            # dot(px, dx) overflows once norm(px)*norm(dx) leaves the eltype's range,
+            # while the JVP it divides down to is still representable. Float16 saturates
+            # at 65504, so ones(65536) reaches it; the reverse rule already scales by
+            # 1/y first and was never affected.
+            for (x, dx) in (
+                (CUDA.fill(Float16(1), 65536), CUDA.fill(Float16(1), 65536)),
+                (CUDA.fill(1.0f19, 100), CUDA.fill(1.0f19, 100)),
+                (CUDA.fill(1e160, 100), CUDA.fill(1e160, 100)),
+            )
+                @test !isfinite(dot(x, dx))  # the input the guard exists for
+                d = _MooncakeCUDAExt.frule!!(
+                    Mooncake.Dual(norm, Mooncake.NoTangent()), Mooncake.Dual(x, dx)
+                )
+                # dx === x here, so the JVP is norm(x) itself.
+                @test Mooncake.tangent(d) ≈ norm(x) rtol = 1.0f-3
+            end
+            # A well-scaled input must still take the single-dot path unchanged.
+            x = _rand(rng, Float32, 64)
+            dx = _rand(rng, Float32, 64)
+            d = _MooncakeCUDAExt.frule!!(
+                Mooncake.Dual(norm, Mooncake.NoTangent()), Mooncake.Dual(x, dx)
+            )
+            @test Mooncake.tangent(d) == real(dot(x, dx)) / norm(x)
+        end
+
         @testset "unsafe_free! frule!! / rrule!!" begin
             # unsafe_free! releases GPU memory early; pure side-effect, no gradient.
             # frule!!: returns Dual(nothing, NoTangent()); both primal and tangent freed.

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -150,6 +150,11 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _cumsum_d1(x) = sum(cumsum(x; dims=1))
         _cumprod_d1(x) = sum(cumprod(x; dims=1))
         _accumulate_plus_d1(x) = sum(accumulate(+, x; dims=1))
+        # accumulate's `init` adds to every output element, so its derivative is the output
+        # length, and a narrower init narrows the result and its tangent.
+        _accumulate_init(a, x) = sum(accumulate(+, x; init=a))
+        _accumulate_init_d1(a, x) = sum(accumulate(+, x; dims=1, init=a))
+        _accumulate_init_widens(x) = sum(accumulate(+, x; init=1.0f0))
         # vector indexing — gather/scatter-add
         _gather_sum(x, idx) = sum(x[idx])
         _gather_sum_cx(x, idx) = real(sum(x[idx]))
@@ -542,6 +547,9 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _cumsum_d1, _rand(rng, 4, 3)),
             (false, :none, false, _cumprod_d1, _rand_pos(rng, 4, 3)),
             (false, :none, false, _accumulate_plus_d1, _rand(rng, 4, 3)),
+            (false, :none, false, _accumulate_init, 1.0f0, _rand(rng, Float32, 6)),
+            (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),
+            (false, :none, false, _accumulate_init_widens, _rand(rng, Float64, 6)),
             # vector indexing — gather forward, scatter-add pullback
             (
                 false,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -407,6 +407,7 @@ end
         _max_init(a, x) = maximum(x; init=a)
         _max_init_d1(a, x) = sum(maximum(x; dims=1, init=a))
         _min_init(a, x) = minimum(x; init=a)
+        _min_init_d1(a, x) = sum(minimum(x; dims=1, init=a))
         _max_badkw(x) = maximum(x; bad=1.0)
         _max_nan_init(x) = maximum(x; init=-1.0f0)
         # GPUArrays takes the output eltype from typeof(init), so a Float32 init over a
@@ -2549,6 +2550,44 @@ end
                     is_primitive=false,
                     perf_flag=:none,
                 )
+            end
+            # An empty reduced extent has a well-defined primal — every slice takes
+            # `init` — but no argmax to report, and findmax/findmin used to read out of
+            # bounds there, throwing a device-side BoundsError in both modes.  `init`
+            # takes the whole derivative, one unit per output slice.
+            @testset "$name" for (seed, name, f, a) in [
+                (97, "empty slice, dims=1", _max_init_d1, -9.0f0),
+                (98, "empty slice, Colon", _max_init, -9.0f0),
+                (99, "empty slice, minimum, dims=1", _min_init_d1, 9.0f0),
+            ]
+                test_rule(
+                    StableRNG(seed),
+                    f,
+                    a,
+                    CuArray(zeros(Float32, 0, 3));
+                    is_primitive=false,
+                    perf_flag=:none,
+                )
+            end
+            # The same reduction without `init` returns the eltype's identity, so
+            # test_rule cannot cover it: its finite differences subtract two infinite
+            # outputs and compare the resulting NaN against the rule's correct zero.
+            # What regressed was that AD threw at all, so check the value and the shape.
+            @testset "empty slice, no init" begin
+                e = CuArray(zeros(Float32, 0, 3))
+                @testset "$f" for (f, expected) in
+                                  ((_max_bare, -Inf32), (_max_d1, -Inf32), (_min_d1, Inf32))
+                    val, grads = value_and_gradient!!(Mooncake.build_rrule(f, e), f, e)
+                    @test val == expected
+                    @test size(grads[2]) == (0, 3)
+                    d = Mooncake.value_and_derivative!!(
+                        Mooncake.build_frule(f, e),
+                        Mooncake.Dual(f, Mooncake.NoTangent()),
+                        Mooncake.Dual(e, CuArray(zeros(Float32, 0, 3))),
+                    )
+                    @test Mooncake.primal(d) == expected
+                    @test Mooncake.tangent(d) == 0.0f0
+                end
             end
             # An index array contributes nothing, so `init` carries the whole gradient.
             @testset "$name" for (seed, name, f, a) in [

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -2912,7 +2912,6 @@ end
                 @testset "$name" for (seed, name, f) in [
                     (96, "maximum", _max_init_widens),
                     (97, "prod dims=1", _prod_init_widens),
-                    (98, "prod dims=1, wider init", _prod_init_wider),
                 ]
                     test_rule(
                         StableRNG(seed),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -258,6 +258,9 @@ end
         # predicate whose value can flip within a finite-difference step would leave
         # test_rule comparing a zero rule derivative against a 1/h estimate.
         _nodiff_count_float(x) = sum(x) * Float32(count(isfinite, x))
+        # count's keyword spellings sum `init` like `sum` does, so a non-identity one
+        # corrupts the count itself: count(>(0.0), x; init=1.0) is 98.0 where the count is 3.
+        _count_init_identity(x) = Float64(count(>(0.0), x; init=0)) * sum(x)
         # Orderings over an index array: no derivative, and the catch-all error rules keep
         # reporting float arrays.
         _nodiff_diff(x) = (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(diff(i))))
@@ -695,6 +698,7 @@ end
             (false, :none, false, _nodiff_min_dims, _rand(rng, 8)),
             (false, :none, false, _nodiff_count, _rand(rng, 8)),
             (false, :none, false, _nodiff_count_float, _rand(rng, 8)),
+            (false, :none, false, _count_init_identity, _rand(rng, 8)),
             (false, :none, false, _nodiff_diff, _rand(rng, 8)),
             (false, :none, false, _nodiff_sortperm, _rand(rng, 8)),
             (false, :none, false, _sortperm_gather, CuArray(Float32[0.3, 0.7, 0.2, 0.9])),
@@ -1588,6 +1592,25 @@ end
             end
 
             # accumulate with unsupported op — catch-all rule throws ArgumentError.
+            @testset "count refuses a non-identity init" begin
+                # The count is summed with `init` folded into a backend-defined number of
+                # partial reductions, so a nonzero one changes the value, not just its
+                # derivative: 98.0 where the count is 3, with sensitivity 95.
+                x = CuArray([1.0, -2.0, 3.0, 4.0])
+                for f in
+                    ((i, z) -> count(>(0.0), z; init=i), (i, z) -> count(z .> 0; init=i))
+                    @test_throws r"not its identity" Mooncake.value_and_gradient!!(
+                        Mooncake.build_rrule(f, 1.0, x), f, 1.0, x
+                    )
+                    @test_throws r"not its identity" Mooncake.value_and_derivative!!(
+                        Mooncake.build_frule(f, 1.0, x),
+                        Mooncake.Dual(f, Mooncake.zero_tangent(f)),
+                        Mooncake.Dual(1.0, 1.0),
+                        Mooncake.Dual(x, Mooncake.zero_tangent(x)),
+                    )
+                end
+            end
+
             @testset "keyword reduce/mapreduce spellings report their own limits" begin
                 # Before these claims the keyword forms escaped to GPUArrays' reduction
                 # kernel and failed there; an unsupported op or a `dims` the mapped rule

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -265,10 +265,13 @@ end
         # C === A is cuBLAS's in-place geam: dC is then the buffer dA accumulates into.
         _geam_alias(x, y) = sum(CUDA.cuBLAS.geam!('N', 'N', 1.0f0, x, 1.0f0, y, x))
         # A complex alpha against a transposed operand: the pullback folds the two
-        # conjugations together instead of conjugating alpha.
+        # conjugations together instead of conjugating alpha.  Scalars passed as arguments
+        # check the alpha/beta derivatives themselves.
         _mul_adj_alpha(c, a, b) = real(sum(mul!(c, a', b', 2.0 + 3.0im, -1.0 + 0.5im)))
         _mulv_adj_alpha(y, a, x) = real(sum(mul!(y, a', x, 2.0 + 3.0im, -1.0 + 0.5im)))
         _mulv_alpha(y, a, x) = real(sum(mul!(y, a, x, 2.0 + 3.0im, -1.0 + 0.5im)))
+        _mul_scalars(c, a, b, al, be) = sum(mul!(c, a, b, al, be))
+        _mulv_scalars(y, a, x, al, be) = sum(mul!(y, a, x, al, be))
         # repeat: positional counts and the keyword spelling (separate rules).
         _repeat_counts(x) = sum(repeat(x, 2, 3))
         _repeat_extends(x) = sum(repeat(x, 2, 3, 2))
@@ -432,6 +435,30 @@ end
                 _rand(rng, 16, 32),
                 _rand(rng, 16, 8),
                 _rand(rng, 8, 32),
+            ),
+            # mul!(C, A, B, alpha, beta) with the scalars as differentiable arguments: their
+            # cotangents are the inner products against A*B and C_old.
+            (
+                false,
+                :none,
+                false,
+                _mul_scalars,
+                _rand(rng, 4, 5),
+                _rand(rng, 4, 3),
+                _rand(rng, 3, 5),
+                2.0,
+                0.5,
+            ),
+            (
+                false,
+                :none,
+                false,
+                _mulv_scalars,
+                _rand(rng, 4),
+                _rand(rng, 4, 3),
+                _rand(rng, 3),
+                2.0,
+                0.5,
             ),
             # mul! (matrix × vector, Float64)
             (false, :none, false, mul!, _rand(rng, 16), _rand(rng, 16, 8), _rand(rng, 8)),
@@ -1103,8 +1130,6 @@ end
             )
         end
 
-        # Reverse mode only: a complex alpha carries a tangent, so it cannot dispatch the
-        # gemm/gemv frules, which take alpha as NoTangent.
         @testset "$name" for (seed, name, fargs) in [
             (
                 71,
@@ -1137,13 +1162,7 @@ end
                 ),
             ),
         ]
-            test_rule(
-                StableRNG(seed),
-                fargs...;
-                is_primitive=false,
-                perf_flag=:none,
-                mode=Mooncake.ReverseMode,
-            )
+            test_rule(StableRNG(seed), fargs...; is_primitive=false, perf_flag=:none)
         end
 
         # Direct unit tests for CuPtr{T} + Integer frule!! / rrule!!.

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -273,6 +273,12 @@ end
         _bcast_setscalar_live(x) = (y=x .* 2; s=sum(y); y.=1.0f0; s + sum(y))
         _bcast_setscalar_expr(x) = (y=x .* 2; y.=3.0f0 .* 2; sum(y))
         _bcast_setscalar_arg(c, x) = (y=x .* 2; y.=c; sum(y))
+        # A scalar leaf narrower than the array's eltype: the kernel's partials carry the
+        # promoted type, but the leaf's rdata has to follow the leaf, or it lands in a slot
+        # of the wrong type.
+        _bcast_narrow_scalar(c, x) = sum(c .* x)
+        _bcast_narrow_scalar_add(c, x) = sum(c .+ x .^ 2)
+        _bcast_narrow_scalar_cx(c, z) = real(sum(c .* z))
         _bcast_zero_dof_nested(x, c, b) = sum(x .+ c .* Float64.(b .> 0))
         _bcast_all_scalar_leaf(x, s) = sum(x .* (s .+ 1.0))
         _inplace_zero_dof_nested!(dest, x, c, b) =
@@ -796,6 +802,24 @@ end
             (false, :none, false, _bcast_setscalar_live, _rand(rng, Float32, 4)),
             (false, :none, false, _bcast_setscalar_expr, _rand(rng, Float32, 4)),
             (false, :none, false, _bcast_setscalar_arg, 1.5f0, _rand(rng, Float32, 4)),
+            (false, :none, false, _bcast_narrow_scalar, 1.5f0, _rand(rng, Float64, 4)),
+            (false, :none, false, _bcast_narrow_scalar_add, 1.5f0, _rand(rng, Float64, 4)),
+            (
+                false,
+                :none,
+                false,
+                _bcast_narrow_scalar_cx,
+                1.5f0 + 0.5f0im,
+                _rand(rng, ComplexF64, 4),
+            ),
+            (
+                false,
+                :none,
+                false,
+                _bcast_narrow_scalar_cx,
+                1.5f0,
+                _rand(rng, ComplexF64, 4),
+            ),
             (
                 false,
                 :none,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -247,7 +247,6 @@ end
         # the destination to restore, so both reach the reverse sweep after the free.
         _free_nodiff(x) = (i=CuArray([1, 2, 3]); CUDA.unsafe_free!(i); sum(x))
         _free_gathered_idx(x) = (i=CuArray([1, 2, 3]); s=sum(x[i]); CUDA.unsafe_free!(i); s)
-        _free_mask(x) = (m=CuArray([true, false, true]); CUDA.unsafe_free!(m); sum(x))
         _cu_sum(x) = sum(cu(x))
         _array_sum(x) = sum(Array(x))     # GPU→CPU transfer
         _diagonal_sum(x) = sum(Diagonal(x)) # GPU Diagonal construction
@@ -305,10 +304,13 @@ end
         # A complex leaf reaches the kernel as `Complex{<:NDual}`, one dual per degree of
         # freedom, so a complex cast has to convert the parts rather than the whole; a real
         # leaf widened to complex keeps its derivative in the real part.
-        _bcast_cast_cx_narrow(z) = real(sum(ComplexF32.(z) .* (1 + 2im)))
-        _bcast_cast_cx_widen(z) = real(sum(ComplexF64.(z) .* (1 + 2im)))
-        _bcast_cast_cx_abs2(z) = sum(abs2.(ComplexF32.(z)))
-        _bcast_cast_real_to_cx(x) = real(sum(ComplexF64.(x) .* (1 + 2im)))
+        # The cast must stay at the root of its own broadcast: nested inside another one it
+        # is materialised before the kernel sees it, and these passed before the fix.  The
+        # complex weight multiplies the scalar sum, so the cotangent still pins the
+        # convention -- 1 - 2im, not 1 + 2im.
+        _bcast_cast_cx_narrow(z) = real(sum(ComplexF32.(z)) * (1 + 2im))
+        _bcast_cast_cx_widen(z) = real(sum(ComplexF64.(z)) * (1 + 2im))
+        _bcast_cast_real_to_cx(x) = real(sum(ComplexF64.(x)) * (1 + 2im))
         _bcast_cast_top_nodiff(x) =
             (i=CuArray(Int32[1, 2, 3, 4]); sum(Float64.(i)) * sum(x))
         # `x .= scalar` reaches materialize! as a zero-dimensional Broadcasted, whose style
@@ -666,7 +668,6 @@ end
             (false, :none, false, _free_intermediate, _rand(rng, 4)),
             (false, :none, false, _free_nodiff, _rand(rng, Float32, 3)),
             (false, :none, false, _free_gathered_idx, _rand(rng, Float32, 3)),
-            (false, :none, false, _free_mask, _rand(rng, Float32, 3)),
             (false, :none, false, _cu_sum, _host_rand(rng, 16)),
             # `cu` of an argument that is already on the device: the cotangent must come back
             # to the device buffer rather than being pulled to the host.
@@ -891,7 +892,6 @@ end
             (false, :none, false, _view_weighted_cx, view(_rand(rng, ComplexF32, 8), 3:8)),
             (false, :none, false, _bcast_cast_cx_narrow, _rand(rng, ComplexF64, 4)),
             (false, :none, false, _bcast_cast_cx_widen, _rand(rng, ComplexF32, 4)),
-            (false, :none, false, _bcast_cast_cx_abs2, _rand(rng, ComplexF64, 4)),
             (false, :none, false, _bcast_cast_real_to_cx, _rand(rng, Float64, 4)),
             (false, :none, false, _bcast_cast_top, _rand(rng, Float32, 4)),
             (false, :none, false, _bcast_cast_top_narrow, _rand(rng, Float64, 4)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -141,6 +141,15 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _cumprod_cx_sum(x) = real(sum(cumprod(x)))
         _accumulate_plus_sum(x) = sum(accumulate(+, x))
         _accumulate_plus_cx_sum(x) = real(sum(accumulate(+, x)))
+        # The `dims` spellings, which Base requires for anything past one dimension. These
+        # go through Core.kwcall, so they need their own claims.
+        _prod_d1(x) = sum(prod(x; dims=1))
+        _prod_d2(x) = sum(prod(x; dims=2))
+        _prod_colon(x) = prod(x; dims=:)
+        _prod_cx_d1(x) = real(sum(prod(x; dims=1)))
+        _cumsum_d1(x) = sum(cumsum(x; dims=1))
+        _cumprod_d1(x) = sum(cumprod(x; dims=1))
+        _accumulate_plus_d1(x) = sum(accumulate(+, x; dims=1))
         # vector indexing — gather/scatter-add
         _gather_sum(x, idx) = sum(x[idx])
         _gather_sum_cx(x, idx) = real(sum(x[idx]))
@@ -516,6 +525,15 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             # accumulate(+) — explicit rule (real and complex)
             (false, :none, false, _accumulate_plus_sum, _rand(rng, 16)),
             (false, :none, false, _accumulate_plus_cx_sum, _rand(rng, ComplexF64, 16)),
+            # The `dims` spellings. prod has its own rule per reduced slice, so it gets the
+            # complex arm and both output branches; the others forward to the rules above.
+            (false, :none, false, _prod_d1, _rand_pos(rng, 4, 3)),
+            (false, :none, false, _prod_d2, _rand_pos(rng, 4, 3)),
+            (false, :none, false, _prod_colon, _rand_pos(rng, 4, 3)),
+            (false, :none, false, _prod_cx_d1, _rand(rng, ComplexF64, 4, 3)),
+            (false, :none, false, _cumsum_d1, _rand(rng, 4, 3)),
+            (false, :none, false, _cumprod_d1, _rand_pos(rng, 4, 3)),
+            (false, :none, false, _accumulate_plus_d1, _rand(rng, 4, 3)),
             # vector indexing — gather forward, scatter-add pullback
             (
                 false,
@@ -1388,11 +1406,12 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
 
             # accumulate with unsupported op — catch-all rule throws ArgumentError.
             @testset "accumulate non-+ CuArray not differentiable" begin
-                f = x -> sum(accumulate(*, x))
                 x = _rand(rng, Float32, 4)
-                @test_throws r"accumulate on CuArray only supports op=\+" value_and_gradient!!(
-                    Mooncake.build_rrule(f, x), f, x
-                )
+                for f in (x -> sum(accumulate(*, x)), x -> sum(accumulate(*, x; dims=1)))
+                    @test_throws r"accumulate on CuArray only supports op=\+" value_and_gradient!!(
+                        Mooncake.build_rrule(f, x), f, x
+                    )
+                end
             end
 
             # Keyword and mapped-form reductions without real rules fall back to

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -247,6 +247,12 @@ end
         # has to be projected before it is narrowed back to the value's own type.
         _fill_real_into_cx(z, c) = (fill!(z, c); real(sum(z .* (1.0f0 + 2.0f0im))))
         _fill_cx_into_cx(z, c) = (fill!(z, c); real(sum(z .* (1.0f0 + 2.0f0im))))
+        # A float array built only from index arrays carries a tangent type even though no
+        # partials flow into it, so the rule owes a zeroed array rather than NoFData.  The
+        # Bool output of a comparison is the case the branch was written for and stays.
+        _bcast_nodiff_ratio(x) = (i=CuArray(Int32[1, 2, 3, 4]); sum(i ./ 2) * sum(x))
+        _bcast_nodiff_float(x) = (i=CuArray(Int32[1, 2, 3, 4]); sum(float.(i)) * sum(x))
+        _bcast_nodiff_bool(x) = (i=CuArray(Int32[1, 2, 3, 4]); sum(i .> 2) * sum(x))
         _sum_f_abs(x) = sum(abs, x)          # sum(f, x) with non-smooth f
         _sum_f_abs2(x) = sum(abs2, x)        # sum(f, x) real abs2
         _sum_adj_pow3(x) = real(sum(y -> y^3, x'))  # sum(f, Adjoint)
@@ -971,6 +977,9 @@ end
             (false, :none, false, _diagonal_field_bcast, _rand_pos(rng, 16)),
             (false, :none, false, _diagonal_mutate, CuArray([1.0, 2.0, 3.0])),
             (false, :none, false, _diagonal_fill, CuArray([1.0, 2.0, 3.0]), 5.0),
+            (false, :none, false, _bcast_nodiff_ratio, _rand(rng, Float64, 4)),
+            (false, :none, false, _bcast_nodiff_float, _rand(rng, Float64, 4)),
+            (false, :none, false, _bcast_nodiff_bool, _rand(rng, Float64, 4)),
             (
                 false,
                 :none,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -209,7 +209,16 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _nodiff_min_dims(x) =
             (i=CuArray([1 2; 3 4]); sum(x) * Float32(sum(minimum(i; dims=1))))
         _nodiff_count(x) = (i=CuArray([1, 2, 3]); sum(x) * Float32(count(>(1), i)))
-        _nodiff_count_float(x) = sum(x) * Float32(count(>(0.0f0), x))
+        # `isfinite`, not a threshold predicate: count is piecewise constant in x, so a
+        # predicate whose value can flip within a finite-difference step would leave
+        # test_rule comparing a zero rule derivative against a 1/h estimate.
+        _nodiff_count_float(x) = sum(x) * Float32(count(isfinite, x))
+        # Orderings over an index array: no derivative, and the catch-all error rules keep
+        # reporting float arrays.
+        _nodiff_diff(x) = (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(diff(i))))
+        _nodiff_sortperm(x) = (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(sortperm(i))))
+        _nodiff_sort_rev(x) =
+            (i=CuArray([3, 1, 2]); sum(x) * Float32(sum(sort(i; rev=true))))
         # CuMatrix +/- lowers to cuBLAS.geam!; the wrapper arms pick the 'T'/'C' flags.
         _geam_add(a, b) = sum(a + b)
         _geam_sub_adj(a, b) = sum(a' - b)
@@ -532,6 +541,27 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _nodiff_min_dims, _rand(rng, 8)),
             (false, :none, false, _nodiff_count, _rand(rng, 8)),
             (false, :none, false, _nodiff_count_float, _rand(rng, 8)),
+            (false, :none, false, _nodiff_diff, _rand(rng, 8)),
+            (false, :none, false, _nodiff_sortperm, _rand(rng, 8)),
+            (false, :none, false, _nodiff_sort_rev, _rand(rng, 8)),
+            # geam! called directly (is_primitive=true): the only case that reaches the
+            # restore of C and the consumption of its cotangent, since `+`/`-` always
+            # allocate a fresh C.  alpha/beta are passed as Bool, which has no tangent, so
+            # test_rule cannot hand them the nonzero tangent the rule rejects — the same
+            # way MulAddMul supplies them to the gemm! rules.
+            (
+                false,
+                :none,
+                true,
+                CUDA.cuBLAS.geam!,
+                'N',
+                'N',
+                true,
+                _rand(rng, Float32, 3, 3),
+                true,
+                _rand(rng, Float32, 3, 3),
+                _rand(rng, Float32, 3, 3),
+            ),
             # cuBLAS.geam! via CuMatrix +/-, including a wrapper arm and complex.
             (false, :none, false, _geam_add, _rand(rng, 3, 3), _rand(rng, 3, 3)),
             (false, :none, false, _geam_sub_adj, _rand(rng, 3, 3), _rand(rng, 3, 3)),

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -199,6 +199,16 @@ end
         _gather_dup_cartesian(m) = sum(
             m[CuArray([CartesianIndex(1, 1), CartesianIndex(1, 1), CartesianIndex(2, 2)])]
         )
+        # A logical mask selects by position, not by value.  The weighted case is what
+        # separates a correct scatter from one that credits index 1 for every hit.
+        _gather_mask(x) = sum(x[CuArray(Bool[true, false, true, false])])
+        _gather_mask_weighted(x) = sum(
+            x[CuArray(Bool[true, false, true, false])] .* CuArray(Float32[1, 2])
+        )
+        _gather_mask_host(x) = sum(x[Bool[true, false, true, false]])
+        _gather_mask_bits(x) = sum(x[BitVector([true, false, true, false])])
+        _gather_mask_cx(x) = real(sum(x[CuArray(Bool[true, false, true, false])]))
+        _gather_mask_none(x) = sum(x[CuArray(falses(4))]) + sum(x)
         _gather_sum_cx(x, idx) = real(sum(x[idx]))
         # unsafe_free! releases the primal early; in reverse mode the fdata is still the
         # accumulator earlier pullbacks write into, so it has to outlive the call.
@@ -709,6 +719,12 @@ end
             (false, :none, false, _gather_dup_host, _rand(rng, Float32, 4)),
             (false, :none, false, _gather_dup_cx, _rand(rng, ComplexF32, 4)),
             (false, :none, false, _gather_dup_cartesian, _rand(rng, Float32, 2, 2)),
+            (false, :none, false, _gather_mask, _rand(rng, Float32, 4)),
+            (false, :none, false, _gather_mask_weighted, _rand(rng, Float32, 4)),
+            (false, :none, false, _gather_mask_host, _rand(rng, Float32, 4)),
+            (false, :none, false, _gather_mask_bits, _rand(rng, Float32, 4)),
+            (false, :none, false, _gather_mask_cx, _rand(rng, ComplexF32, 4)),
+            (false, :none, false, _gather_mask_none, _rand(rng, Float32, 4)),
             (
                 false,
                 :none,

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -17,6 +17,12 @@ using LinearAlgebra, Statistics
 
 const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
 
+# A callable struct carrying a differentiable field, for the captured-state tests.
+struct _CapScale{T}
+    a::T
+end
+(s::_CapScale)(t) = s.a * t
+
 @testset "cuda" begin
     cuda = CUDA.functional()
     if cuda
@@ -156,6 +162,10 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         _accumulate_init_d1(a, x) = sum(accumulate(+, x; dims=1, init=a))
         _accumulate_init_widens(x) = sum(accumulate(+, x; init=1.0f0))
         # Without `dims` CUDA scans an N-d array in linear order, not column by column.
+        # Passing the captured value as an argument is what the refusal message recommends;
+        # a capture the kernel cannot thread must not be silently zeroed instead.
+        _hoisted_capture(a, x) = sum(((t, c) -> c * t).(x, a))
+        _int_capture(x) = (n=3; sum((t -> n * t).(x)))
         _accumulate_flat(x) = sum(accumulate(+, x))
         _accumulate_flat_init(a, x) = sum(accumulate(+, x; init=a))
         # vector indexing — gather/scatter-add
@@ -576,6 +586,8 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
             (false, :none, false, _accumulate_init, 1.0f0, _rand(rng, Float32, 6)),
             (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),
             (false, :none, false, _accumulate_init_widens, _rand(rng, Float64, 6)),
+            (false, :none, false, _hoisted_capture, 3.0, _rand(rng, 4)),
+            (false, :none, false, _int_capture, _rand(rng, 4)),
             (false, :none, false, _accumulate_flat, _rand(rng, 4, 3)),
             (false, :none, false, _accumulate_flat_init, 1.0f0, _rand(rng, Float32, 4, 3)),
             # vector indexing — gather forward, scatter-add pullback
@@ -1419,6 +1431,35 @@ const _MooncakeCUDAExt = Base.get_extension(Mooncake, :MooncakeCUDAExt)
         # explicit catch-all rule that blocks an unimplemented differentiation path.
         # If a case gains a proper rule in the future, move it back into test_cases above
         # and delete it from here.
+        @testset "state carried by a mapped function is refused, not zeroed" begin
+            # Partials thread through GPU array elements and float scalars only, so anything
+            # the function itself carries — a closure capture, a callable struct's field, a
+            # Ref argument — would come back an exact zero.  Both modes refuse it.  This is
+            # the boundary the sum(f, x) guard was written for; it never fired, because
+            # rdata_type was applied to a primal type and threw inside fields_type.
+            x = _rand(rng, Float64, 4)
+            for f in (
+                (a, z) -> sum((t -> a * t).(z)),
+                (a, z) -> sum((t -> exp(a * t)).(z)),
+                (a, z) -> (w=similar(z); w.=(t -> a * t).(z); sum(w)),
+                (a, z) -> sum((t -> a * t).(z) .+ z),
+                (a, z) -> sum(map(t -> a * t, z)),
+                (a, z) -> sum(t -> a * t, z),
+                (a, z) -> sum(_CapScale(a).(z)),
+                (a, z) -> sum(((t, r) -> r[] * t).(z, Ref(a))),
+            )
+                @test_throws r"does not support" Mooncake.value_and_gradient!!(
+                    Mooncake.build_rrule(f, 3.0, x), f, 3.0, x
+                )
+                @test_throws r"does not support" Mooncake.value_and_derivative!!(
+                    Mooncake.build_frule(f, 3.0, x),
+                    Mooncake.Dual(f, Mooncake.zero_tangent(f)),
+                    Mooncake.Dual(3.0, 1.0),
+                    Mooncake.Dual(x, Mooncake.zero_tangent(x)),
+                )
+            end
+        end
+
         @testset "unsupported operations throw ArgumentError" begin
             # Mixed-precision GPU broadcast (Float32 array .+ ComplexF32 array) is not
             # supported.  The materialize frule/rrule detects mismatched GPU element types

--- a/test/ext/cuda/cuda.jl
+++ b/test/ext/cuda/cuda.jl
@@ -173,6 +173,11 @@ end
         # derivative — the array's adjoint already took that path, only `init` had not.
         _accumulate_init_outdim(a, x) = sum(accumulate(+, x; dims=2, init=a))
         _accumulate_init_outdim3(a, m) = sum(accumulate(+, m; dims=3, init=a))
+        # An index array carries no derivative, but a float `init` widens the output and
+        # adds to every element of it, so it collects the whole cotangent.
+        _accumulate_nodiff_init(a, idx) = sum(accumulate(+, idx; init=a))
+        _accumulate_nodiff_init_d1(a, idx) = sum(accumulate(+, idx; dims=1, init=a))
+        _accumulate_nodiff_init_outdim(a, idx) = sum(accumulate(+, idx; dims=2, init=a))
         # Without `dims` CUDA scans an N-d array in linear order, not column by column.
         # Passing the captured value as an argument is what the refusal message recommends;
         # a capture the kernel cannot thread must not be silently zeroed instead.
@@ -721,6 +726,16 @@ end
             (false, :none, false, _accumulate_init_d1, 1.0f0, _rand(rng, Float32, 4, 3)),
             (false, :none, false, _accumulate_init_widens, _rand(rng, Float64, 6)),
             (false, :none, false, _accumulate_init_outdim, 1.0f0, _rand(rng, Float32, 6)),
+            (false, :none, false, _accumulate_nodiff_init, 1.0, CuArray(Int32[1, 2, 3])),
+            (false, :none, false, _accumulate_nodiff_init_d1, 1.0, CuArray(Int32[1, 2, 3])),
+            (
+                false,
+                :none,
+                false,
+                _accumulate_nodiff_init_outdim,
+                1.0,
+                CuArray(Int32[1, 2, 3]),
+            ),
             (
                 false,
                 :none,
@@ -1970,6 +1985,23 @@ end
                     _max_badkw,
                     (M32,),
                     (; err=MethodError, primal=true),
+                ),
+                # mapreduce delegates to the keyword-free rule, so a differentiated `init`
+                # would be dropped instead of folded, and an `init` of another type would
+                # change an output type the delegate cannot produce.
+                (
+                    250,
+                    "mapreduce, differentiated init",
+                    (c, z) -> mapreduce(abs2, +, z; init=c),
+                    (0.0f0, x32),
+                    (; msg=r"init.*constant", mode=Mooncake.ForwardMode),
+                ),
+                (
+                    251,
+                    "mapreduce, init widens the output",
+                    z -> mapreduce(abs2, +, z; init=0.0),
+                    (x32,),
+                    (; msg=r"init::Float64 where the reduction produces"),
                 ),
                 # Forward mode alone refuses a differentiated `init` the rule treats as a
                 # constant; reverse mode reports a zero derivative for it instead.

--- a/test/rules/blas_Float64.jl
+++ b/test/rules/blas_Float64.jl
@@ -33,6 +33,24 @@
         end
     end
 
+    @testset "nrm2 frule!! rescales an overflowing accumulator" begin
+        # X[i]*dX[i] overflows once norm(X)*norm(dX) leaves T's range, while the JVP it
+        # divides down to is still representable. The pullback scales by dy/y first and
+        # was never affected, so only forward mode returned Inf here.
+        @testset "$T" for (T, v) in ((Float32, 1.0f19), (Float64, 1e160))
+            x = fill(v, 100)
+            dx = fill(v, 100)
+            d = Mooncake.frule!!(
+                Mooncake.Dual(BLAS.nrm2, Mooncake.NoTangent()),
+                Mooncake.Dual(100, Mooncake.NoTangent()),
+                Mooncake.Dual(x, dx),
+                Mooncake.Dual(1, Mooncake.NoTangent()),
+            )
+            # dx === x here, so the JVP is norm(x) itself.
+            @test Mooncake.tangent(d) ≈ BLAS.nrm2(100, x, 1) rtol = 1e-5
+        end
+    end
+
     TestUtils.run_rule_test_cases(StableRNG, Val(:blas_basic))
 end
 

--- a/test/rules/blas_Float64.jl
+++ b/test/rules/blas_Float64.jl
@@ -33,24 +33,6 @@
         end
     end
 
-    @testset "nrm2 frule!! rescales an overflowing accumulator" begin
-        # X[i]*dX[i] overflows once norm(X)*norm(dX) leaves T's range, while the JVP it
-        # divides down to is still representable. The pullback scales by dy/y first and
-        # was never affected, so only forward mode returned Inf here.
-        @testset "$T" for (T, v) in ((Float32, 1.0f19), (Float64, 1e160))
-            x = fill(v, 100)
-            dx = fill(v, 100)
-            d = Mooncake.frule!!(
-                Mooncake.Dual(BLAS.nrm2, Mooncake.NoTangent()),
-                Mooncake.Dual(100, Mooncake.NoTangent()),
-                Mooncake.Dual(x, dx),
-                Mooncake.Dual(1, Mooncake.NoTangent()),
-            )
-            # dx === x here, so the JVP is norm(x) itself.
-            @test Mooncake.tangent(d) ≈ BLAS.nrm2(100, x, 1) rtol = 1e-5
-        end
-    end
-
     TestUtils.run_rule_test_cases(StableRNG, Val(:blas_basic))
 end
 


### PR DESCRIPTION
- `A ± B` on `CuMatrix`: rule at the `cuBLAS.geam!` foreign-call boundary.
- `repeat`: one pullback for all overloads, reshaping each dimension into
  `(inner, size, outer)`.
- Gather with `CartesianIndex` vectors; `unsafe_copyto!`, `fill!` and reductions over index
  and mask arrays.
- `tangent_type` and `has_equal_data_internal` whitelisted non-differentiable eltypes as
  `Union{Integer,Bool}`, so `CuArray{CartesianIndex}` got an unbuildable tangent.
- Keyword reductions reject a nonzero `init` tangent: a float `init` makes the output
  differentiable, so zeroing it is silently wrong.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1275 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1275/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 160.0 ns │     1.82 │        1.88 │    0.75 │        3.76 │   6.95 │
│                  _sum_1000 │ 972.0 ns │      6.9 │        1.02 │  2000.0 │        42.8 │   1.06 │
│               sum_sin_1000 │  7.66 μs │     3.28 │        1.32 │     1.4 │        10.3 │   1.66 │
│              _sum_sin_1000 │  6.59 μs │     3.42 │        1.76 │   252.0 │        12.0 │    2.0 │
│                   kron_sum │ 211.0 μs │     12.6 │        3.06 │     8.4 │       339.0 │   19.2 │
│              kron_view_sum │ 289.0 μs │     11.0 │        5.05 │    24.8 │       321.0 │   12.2 │
│      naive_map_sin_cos_exp │   2.6 μs │     2.75 │        1.43 │ missing │        6.86 │   1.91 │
│            map_sin_cos_exp │  2.24 μs │     3.59 │         1.7 │    1.49 │        6.82 │   2.75 │
│      broadcast_sin_cos_exp │  2.52 μs │      3.0 │        1.47 │    4.15 │        1.33 │   1.96 │
│                 simple_mlp │ 364.0 μs │     4.71 │        2.56 │    2.11 │        8.37 │   2.78 │
│                     gp_lml │ 176.0 μs │     11.0 │        2.41 │     6.3 │     missing │   5.79 │
│ turing_broadcast_benchmark │  1.63 ms │     7.11 │        3.62 │ missing │        39.7 │   2.46 │
│         large_single_block │ 421.0 ns │     5.75 │        1.95 │  4260.0 │        32.6 │   2.05 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->