### PR TITLE
Preserve primitive rules in forward-over-reverse

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.46"
+version = "0.5.47"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/ir_utils.jl
+++ b/src/interpreter/ir_utils.jl
@@ -49,16 +49,22 @@ is used to represent all instructions in the working-IR layer.
 const InstVector = Vector{NewInstruction}
 
 """
-    new_inst(stmt, type=Any, flag=CC.IR_FLAG_REFINED)::NewInstruction
+    new_inst(stmt, type=Any, flag=CC.IR_FLAG_REFINED; noinline=false)::NewInstruction
 
 Create a `NewInstruction` with fields:
 - `stmt` = `stmt`
 - `type` = `type`
 - `info` = `CC.NoCallInfo()`
 - `line` = `Int32(1)`
-- `flag` = `flag`
+- `flag` = `flag`, with `CC.IR_FLAG_NOINLINE` added when `noinline=true`
 """
-function new_inst(@nospecialize(stmt), @nospecialize(type)=Any, flag=CC.IR_FLAG_REFINED)
+function new_inst(
+    @nospecialize(stmt),
+    @nospecialize(type)=Any,
+    flag=CC.IR_FLAG_REFINED;
+    noinline::Bool=false,
+)
+    noinline && (flag |= CC.IR_FLAG_NOINLINE)
     return NewInstruction(stmt, type, CC.NoCallInfo(), Int32(1), flag)
 end
 

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -917,6 +917,8 @@ codegen which produces the forwards- and reverse-passes.
     ssa rather than each argument.
 - `debug_mode`: if `true`, run in "debug mode" -- wraps all rule calls in `DebugRRule`. This
     is applied recursively, so that debug mode is also switched on in derived rules.
+- `noinline_primitive_rules`: preserve primitive rule-call boundaries when the generated
+    reverse rule will subsequently be differentiated by forward mode.
 - `is_used_dict`: for each `ID` associated to a line of code, is `false` if line is not used
     anywhere in any other line of code.
 - `lazy_zero_rdata_ref_id`: for any arguments whose type doesn't permit the construction of
@@ -939,6 +941,7 @@ struct ADInfo
     arg_rdata_ref_ids::Dict{Argument,ID}
     ssa_rdata_ref_ids::Dict{ID,ID}
     debug_mode::Bool
+    noinline_primitive_rules::Bool
     is_used_dict::Dict{ID,Bool}
     lazy_zero_rdata_ref_id::ID
     fwd_ret_type::Type
@@ -955,7 +958,8 @@ function ADInfo(
     debug_mode::Bool,
     zero_lazy_rdata_ref::Ref{<:Tuple},
     fwd_ret_type::Type,
-    rvs_ret_type::Type,
+    rvs_ret_type::Type;
+    noinline_primitive_rules::Bool=false,
 )
     shared_data_pairs = SharedDataPairs()
     block_stack = BlockStack()
@@ -970,6 +974,7 @@ function ADInfo(
         Dict((k, ID()) for k in keys(arg_types)),
         Dict((k, ID()) for k in keys(ssa_insts)),
         debug_mode,
+        noinline_primitive_rules,
         is_used_dict,
         add_data!(shared_data_pairs, zero_lazy_rdata_ref),
         fwd_ret_type,
@@ -986,7 +991,8 @@ function ADInfo(
     blocks::Vector{CFGBlock},
     debug_mode::Bool,
     fwd_ret_type::Type,
-    rvs_ret_type::Type,
+    rvs_ret_type::Type;
+    noinline_primitive_rules::Bool=false,
 )
     arg_types = Dict{Argument,Any}(
         map(((n, t),) -> (Argument(n) => CC.widenconst(t)), enumerate(ir.argtypes))
@@ -1004,7 +1010,8 @@ function ADInfo(
         debug_mode,
         zero_lazy_rdata_ref,
         fwd_ret_type,
-        rvs_ret_type,
+        rvs_ret_type;
+        noinline_primitive_rules,
     )
 end
 
@@ -1513,7 +1520,10 @@ function make_ad_stmts!(stmt::Expr, line::ID, info::ADInfo)
         # Construct signature, and determine how the rrule is to be computed.
         sig = Tuple{arg_types...}
         interp = info.interp
-        raw_rule = if is_primitive(context_type(interp), ReverseMode, sig, interp.world)
+        is_primitive_call = is_primitive(
+            context_type(interp), ReverseMode, sig, interp.world
+        )
+        raw_rule = if is_primitive_call
             build_primitive_rrule(sig) # intrinsic / builtin / thing we provably have rule for
         elseif is_invoke
             mi = get_mi(stmt.args[1])
@@ -1589,7 +1599,16 @@ function make_ad_stmts!(stmt::Expr, line::ID, info::ADInfo)
         fwds = vcat(
             codual_args,
             IDInstPair[
-                (rule_call_id, new_inst(rule_call)),
+                # FoR must resolve primitive-rule calls to static invokes without opening
+                # their bodies before the forward transform. Full inlining remains
+                # available afterwards.
+                (
+                    rule_call_id,
+                    new_inst(
+                        rule_call;
+                        noinline=(info.noinline_primitive_rules && is_primitive_call),
+                    ),
+                ),
                 (raw_output_id, new_inst(raw_output)),
                 pb_stmt,
                 (output_id, new_inst(output)),
@@ -2110,6 +2129,7 @@ function generate_ir(
     debug_mode=false,
     do_inline=true,
     do_optimize=true,
+    noinline_primitive_rules=false,
 )
     # Reset id count. This ensures that the IDs generated are the same each time this
     # function runs.
@@ -2163,7 +2183,15 @@ function generate_ir(
     primal_blocks = _remove_unreachable_cfg_blocks!(_ircode_to_cfg_blocks(ir))
 
     # Compute global info.
-    info = ADInfo(interp, ir, primal_blocks, debug_mode, fwd_ret_type, rvs_ret_type)
+    info = ADInfo(
+        interp,
+        ir,
+        primal_blocks,
+        debug_mode,
+        fwd_ret_type,
+        rvs_ret_type;
+        noinline_primitive_rules,
+    )
 
     # For each primal block, translate all statements. Running this will, in general, push
     # items to `info.shared_data_pairs`.

--- a/src/rules/high_order_derivative_patches.jl
+++ b/src/rules/high_order_derivative_patches.jl
@@ -146,8 +146,10 @@ function _compile_for_rule(
 ) where {C}
     @nospecialize sig_or_mi sig
 
-    # Derive unoptimized forwards- and reverse-pass IR.
-    dri = generate_ir(interp, sig_or_mi; debug_mode, do_optimize=false)
+    # Keep primitive rules as static call boundaries until after the forward transform.
+    dri = generate_ir(
+        interp, sig_or_mi; debug_mode, do_optimize=false, noinline_primitive_rules=true
+    )
 
     # Optimize and build the primal DerivedRule.
     raw_rule = let

--- a/src/rules/lapack.jl
+++ b/src/rules/lapack.jl
@@ -153,8 +153,7 @@ function rrule!!(
     uplo, trans, diag = primal(_uplo), primal(_trans), primal(_diag)
     A, dA = arrayify(_A)
     B, dB = arrayify(_B)
-    # Keep `copy` in the IR so forward-over-reverse AD can dispatch to its `frule!!`.
-    B_copy = Base.@noinline copy(B)
+    B_copy = copy(B)
 
     # Run primal.
     trtrs!(uplo, trans, diag, A, B)

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -983,6 +983,8 @@ end
         @test ni.type === Float64
         @test ni.info isa CC.NoCallInfo
         @test ni.flag == CC.IR_FLAG_REFINED
+        @test new_inst(nothing; noinline=true).flag ==
+            CC.IR_FLAG_REFINED | CC.IR_FLAG_NOINLINE
     end
     @testset "is_reachable_return_node" begin
         @test Mooncake.is_reachable_return_node(ReturnNode(5)) == true


### PR DESCRIPTION
Delay inlining until after forward transformation, fixing HVPs and removing LAPACK workaround while retaining tests.

Fix https://github.com/chalk-lab/Mooncake.jl/issues/1276; Fix #1246 properly. 

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1277 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1277/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 150.0 ns │     1.53 │        1.61 │   0.667 │        3.27 │   6.61 │
│                  _sum_1000 │ 842.0 ns │     6.15 │        1.03 │  4300.0 │        42.0 │   1.13 │
│               sum_sin_1000 │  5.79 μs │     2.51 │        1.18 │     1.8 │        10.7 │   1.73 │
│              _sum_sin_1000 │  3.59 μs │     3.97 │        2.66 │   492.0 │        17.7 │   3.11 │
│                   kron_sum │ 186.0 μs │     11.6 │        3.57 │    7.42 │       481.0 │   22.3 │
│              kron_view_sum │ 193.0 μs │     14.4 │        6.07 │    32.3 │       579.0 │   16.8 │
│      naive_map_sin_cos_exp │  1.74 μs │     3.05 │        1.53 │ missing │        8.41 │   2.17 │
│            map_sin_cos_exp │  1.68 μs │     3.69 │        1.66 │    1.68 │        7.42 │   2.85 │
│      broadcast_sin_cos_exp │  1.75 μs │      3.3 │        1.65 │    5.02 │        1.52 │   2.25 │
│                 simple_mlp │ 281.0 μs │     5.32 │        2.84 │     1.9 │        13.5 │   3.12 │
│                     gp_lml │ 153.0 μs │     11.7 │        2.79 │    5.08 │     missing │   5.71 │
│ turing_broadcast_benchmark │  1.32 ms │     7.47 │        3.82 │ missing │        55.5 │   2.25 │
│         large_single_block │ 380.0 ns │     10.8 │        2.22 │  3660.0 │        34.5 │   2.03 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->