### PR TITLE
Project structured tangents in `logsumexp` and `kron`

### DIFF
--- a/ext/MooncakeLogExpFunctionsExt.jl
+++ b/ext/MooncakeLogExpFunctionsExt.jl
@@ -13,6 +13,8 @@ import Mooncake:
     primal,
     tangent,
     @is_primitive,
+    densify,
+    accumulate_densified!,
     zero_fcodual,
     NoRData,
     extract,
@@ -177,7 +179,9 @@ function rrule!!(
     _x, _dx = arrayify(x)
     y = logsumexp(_x; primal(kwargs)...)
     function logsumexp_pb!!(dy::P)
-        _dx .+= dy .* exp.(_x .- y)
+        dense = densify(_dx)
+        dense .+= dy .* exp.(_x .- y)
+        accumulate_densified!(_dx, dense)
         return NoRData(), NoRData(), NoRData(), NoRData()
     end
     return zero_fcodual(y), logsumexp_pb!!
@@ -193,7 +197,9 @@ function rrule!!(
     y = logsumexp(_x; primal(kwargs)...)
     dy = zero(y)
     function logsumexp_pb!!(::NoRData)
-        _dx .+= dy .* exp.(_x .- y)
+        dense = densify(_dx)
+        dense .+= dy .* exp.(_x .- y)
+        accumulate_densified!(_dx, dense)
         return NoRData(), NoRData(), NoRData(), NoRData()
     end
     return CoDual(y, dy), logsumexp_pb!!
@@ -204,7 +210,9 @@ function rrule!!(
     _x, _dx = arrayify(x)
     y = logsumexp(_x)
     function logsumexp_pb!!(dy::P)
-        _dx .+= dy .* exp.(_x .- y)
+        dense = densify(_dx)
+        dense .+= dy .* exp.(_x .- y)
+        accumulate_densified!(_dx, dense)
         return NoRData(), NoRData()
     end
     return zero_fcodual(y), logsumexp_pb!!
@@ -232,7 +240,9 @@ function rrule!!(
     old_out = copy(y)
     logsumexp!(y, _x)
     function logsumexp!_pb!!(::NoRData)
-        _dx .+= _dy .* exp.(_x .- y)
+        dense = densify(_dx)
+        dense .+= _dy .* exp.(_x .- y)
+        accumulate_densified!(_dx, dense)
         copyto!(y, old_out)
         fill!(_dy, zero(P))
         return NoRData(), NoRData(), NoRData()

--- a/src/rules/blas.jl
+++ b/src/rules/blas.jl
@@ -109,6 +109,50 @@ function arrayify(x::A, dx::DA) where {A,DA}
 end
 
 """
+    densify(dx)
+
+Somewhere dense to accumulate a contribution destined for the tangent `dx`.
+
+[`arrayify`](@ref) returns tangents wrapped in the primal's own structural type, whose
+off-structure entries are not parameters: the primal reads a constant there whatever the
+storage holds. A rule whose adjoint is a dense expression must therefore accumulate here
+and hand the result to [`accumulate_densified!`](@ref), which adds back only the part `dx`
+can represent. A strided tangent is already dense, so the common case costs nothing.
+"""
+densify(dx::StridedArray) = dx
+function densify(dx::Union{UpperTriangular,LowerTriangular,Diagonal,Symmetric})
+    return zeros(eltype(dx), size(dx))
+end
+
+"""
+    accumulate_densified!(dx, dense)
+
+Add the part of `dense` that the structured tangent `dx` can represent. See
+[`densify`](@ref).
+"""
+accumulate_densified!(::StridedArray, dense) = nothing
+function accumulate_densified!(
+    dx::T, dense
+) where {T<:Union{UpperTriangular,LowerTriangular}}
+    parent(dx) .+= T(dense)
+    return nothing
+end
+function accumulate_densified!(dx::Diagonal, dense)
+    dx.diag .+= view(dense, diagind(dense))
+    return nothing
+end
+
+# `Symmetric` is the one wrapper for which this is not masking: with `uplo == 'U'`, the
+# stored `A[i, j]` is read at both `S[i, j]` and `S[j, i]` when `i < j`, so its adjoint
+# picks up both. Dropping the fold would silently halve those gradients rather than throw.
+function accumulate_densified!(dx::Symmetric, dense)
+    folded = dense .+ transpose(dense)
+    folded[diagind(folded)] .= view(dense, diagind(dense))
+    parent(dx) .+= dx.uplo == 'U' ? UpperTriangular(folded) : LowerTriangular(folded)
+    return nothing
+end
+
+"""
     matrixify(x_dx::Union{Dual{<:AbstractVecOrMat{<:BlasFloat}},
                           CoDual{<:AbstractVecOrMat{<:BlasFloat}}})
 

--- a/src/rules/performance_patches.jl
+++ b/src/rules/performance_patches.jl
@@ -101,21 +101,8 @@ const KronFactor{T} = Union{
     LowerTriangular{T,<:StridedMatrix{T}},
 }
 
-# `kron` reads its factors through whatever structure they carry, so `arrayify` hands back
-# tangents wrapped the same way. Entries outside that structure are not parameters -- the
-# primal reads zeros there whatever the storage holds -- so `_kron_pb!`'s dense contraction
-# is accumulated in a scratch and the off-structure half discarded, as the `lacpy!` pullback
-# discards it. A strided tangent is its own scratch, so it costs nothing there.
-kron_scratch(dx::StridedMatrix) = dx
-kron_scratch(dx::Union{UpperTriangular,LowerTriangular}) = zero(parent(dx))
-
-kron_project!(::StridedMatrix, scratch) = nothing
-function kron_project!(dx::T, scratch) where {T<:Union{UpperTriangular,LowerTriangular}}
-    parent(dx) .+= T(scratch)
-    return nothing
-end
-
-# Both `kron` pullbacks contract `dy` against one factor to accumulate into the other. Read
+# Both `kron` pullbacks contract `dy` against one factor to accumulate into the other. The
+# contraction is dense, so it goes through `densify` / `accumulate_densified!`. Read
 # as `P x M x Q x N`, both contractions read the same element of `dy`, so a single pass in
 # memory order serves both. A `gemv` per `(q, n)` block is slower at every shape measured:
 # the blocks are small enough that BLAS call overhead dominates.
@@ -124,8 +111,8 @@ function _kron_pb!(dx1, dx2, dy, px1, px2)
     M, N = size(px1)
     P, Q = size(px2)
     W = reshape(dy, P, M, Q, N)
-    t1 = kron_scratch(dx1)
-    t2 = kron_scratch(dx2)
+    t1 = densify(dx1)
+    t2 = densify(dx2)
     @inbounds for n in 1:N, q in 1:Q, i in 1:M
         acc = zero(T)
         x1 = px1[i, n]
@@ -136,8 +123,8 @@ function _kron_pb!(dx1, dx2, dy, px1, px2)
         end
         t1[i, n] += acc
     end
-    kron_project!(dx1, t1)
-    kron_project!(dx2, t2)
+    accumulate_densified!(dx1, t1)
+    accumulate_densified!(dx2, t2)
     return nothing
 end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -865,6 +865,11 @@ function test_rrule_interface(f_f̄, x_x̄...; rrule)
     @test Mooncake._verify_fdata_value(IdDict{Any,Nothing}(), y_ȳ.x, y_ȳ.dx) === nothing
 
     # Run the reverse-pass. Throw a meaningful exception if it doesn't run at all.
+    # The seed below is zero, and for an array-returning rule the whole cotangent is the
+    # rule's own freshly-zeroed fdata, so the pullback never sees a non-zero one. Writing
+    # zero outside a structured tangent (`UpperTriangular` and friends) is permitted, so
+    # this cannot catch a rule that fails to project its adjoint onto the tangent's
+    # structure. Only a correctness test can: it seeds a random cotangent instead.
     ȳ = Mooncake.rdata(zero_tangent(primal(y_ȳ), tangent(y_ȳ)))
     f̄_new, x̄_new... = try
         pb!!(ȳ)

--- a/test/integration_testing/logexpfunctions/logexpfunctions.jl
+++ b/test/integration_testing/logexpfunctions/logexpfunctions.jl
@@ -2,7 +2,7 @@ using Pkg
 Pkg.activate(@__DIR__)
 Pkg.develop(; path=joinpath(@__DIR__, "..", "..", ".."))
 
-using AllocCheck, LogExpFunctions, Mooncake, StableRNGs, Test
+using AllocCheck, LinearAlgebra, LogExpFunctions, Mooncake, StableRNGs, Test
 using Mooncake.TestUtils: test_rule
 
 sr(n::Int) = StableRNG(n)
@@ -42,6 +42,11 @@ sr(n::Int) = StableRNG(n)
                 (:allocs, true, logsumexp, view(randn(sr(1), P, 5), 1:4)),
                 # edge case with two equal inputs: see #881 for discussion
                 (:allocs, true, logsumexp, [1.0, 1.0]),
+                # Structured tangents: the adjoint is dense, so it has to be projected
+                # onto what the wrapper stores. `Symmetric` folds rather than masks.
+                (:none, true, logsumexp, UpperTriangular(randn(sr(20), P, 4, 4))),
+                (:none, true, logsumexp, Diagonal(randn(sr(21), P, 4))),
+                (:none, true, logsumexp, Symmetric(randn(sr(22), P, 4, 4))),
                 (:none, false, x -> logsumexp(x; dims=1), randn(sr(4), P, 5, 4)),
                 (:none, false, x -> logsumexp(x; dims=1), fill(1.0, 2, 2)),
                 (:none, false, x -> logsumexp(x; dims=2), randn(sr(5), P, 5, 4)),


### PR DESCRIPTION
`logsumexp` is primitive on `AbstractArray{<:IEEEFloat}`, so a structured
argument reaches it, but its four pullbacks wrote a dense adjoint straight
onto the wrapped tangent. `UpperTriangular`, `LowerTriangular`, `Diagonal`
and `Symmetric` all threw; gradients now match finite differences.

Adds `densify` / `accumulate_densified!` beside `arrayify` and routes both
`logsumexp` and `kron` through them. `Symmetric` folds rather than masks:
treating it like the others would have halved gradients silently.

Stacked on #1280 — retarget to main once that merges.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1281 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1281/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 230.0 ns │     1.52 │        1.43 │    1.48 │        6.67 │    5.4 │
│                  _sum_1000 │ 982.0 ns │     6.87 │        1.01 │  1300.0 │        37.9 │    1.2 │
│               sum_sin_1000 │  6.92 μs │     3.57 │        1.39 │    2.52 │        12.2 │   2.34 │
│              _sum_sin_1000 │   5.6 μs │     4.06 │        2.07 │   215.0 │        15.2 │   2.55 │
│                   kron_sum │ 212.0 μs │      4.3 │        3.13 │    6.96 │       365.0 │   11.9 │
│              kron_view_sum │ 299.0 μs │      3.3 │        5.05 │    12.2 │       331.0 │   6.55 │
│      naive_map_sin_cos_exp │  2.41 μs │     2.95 │        1.51 │ missing │        8.33 │   2.51 │
│            map_sin_cos_exp │  2.22 μs │     3.78 │         1.7 │    2.08 │        7.73 │   3.26 │
│      broadcast_sin_cos_exp │  2.36 μs │     3.19 │         1.6 │    5.52 │        1.84 │   2.42 │
│                 simple_mlp │ 373.0 μs │     4.54 │        2.55 │     1.8 │        10.2 │   3.19 │
│                     gp_lml │ 404.0 μs │     4.08 │        1.66 │     4.0 │     missing │   3.21 │
│ turing_broadcast_benchmark │  1.62 ms │     7.07 │        3.64 │ missing │        42.8 │   2.48 │
│         large_single_block │ 421.0 ns │     7.02 │        1.93 │  7910.0 │        38.2 │    2.5 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->