### PR TITLE
interpreter: Reset constant fdata between rule calls

### DIFF
--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -886,6 +886,7 @@ end
 @inline get_shared_data_field(shared_data, n) = getfield(shared_data, n)
 @inline function get_zeroed_shared_data_field(shared_data, n)
     x = getfield(shared_data, n)
+    # Captured fdata containing `Ptr` is unsupported because it cannot be reset generically.
     t = set_to_zero!!(zero_tangent(primal(x), tangent(x)))
     return CoDual(primal(x), fdata(t))
 end

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -854,10 +854,11 @@ then the output of this function is
 shared_data_tuple(p::SharedDataPairs)::Tuple = tuple(map(last, p.pairs)...)
 
 """
-    shared_data_stmts(p::SharedDataPairs)::Vector{IDInstPair}
+    shared_data_stmts(p::SharedDataPairs, zero_coduals=false)::Vector{IDInstPair}
 
 Produce a sequence of id-statement pairs which will extract the data from
 `shared_data_tuple(p)` such that the correct value is associated to the correct `ID`.
+If `zero_coduals` is `true`, reset the fdata of captured `CoDual`s as they are extracted.
 
 For example, if `p.pairs` is
 ```julia
@@ -871,13 +872,23 @@ IDInstPair[
 ]
 ```
 """
-function shared_data_stmts(p::SharedDataPairs)::Vector{IDInstPair}
-    return map(enumerate(p.pairs)) do (n, p)
-        return (p[1], new_inst(Expr(:call, get_shared_data_field, Argument(1), n)))
+function shared_data_stmts(p::SharedDataPairs, zero_coduals::Bool=false)::Vector{IDInstPair}
+    return map(enumerate(p.pairs)) do (n, pair)
+        getter = if zero_coduals && pair[2] isa CoDual && !(tangent(pair[2]) isa NoFData)
+            get_zeroed_shared_data_field
+        else
+            get_shared_data_field
+        end
+        return (pair[1], new_inst(Expr(:call, getter, Argument(1), n)))
     end
 end
 # maybe manually inline this
 @inline get_shared_data_field(shared_data, n) = getfield(shared_data, n)
+@inline function get_zeroed_shared_data_field(shared_data, n)
+    x = getfield(shared_data, n)
+    t = set_to_zero!!(zero_tangent(primal(x), tangent(x)))
+    return CoDual(primal(x), fdata(t))
+end
 
 """
 The block stack is the stack used to keep track of which basic blocks are visited on the
@@ -2339,7 +2350,7 @@ function forwards_pass_ir(
     # reverse-passes. These are assigned to the `ID`s given by the `SharedDataPairs`.
     # Push the entry id onto the block stack if needed. Create `LazyZeroRData` for each
     # argument, and put it in the `Ref` for use on the reverse-pass.
-    sds = shared_data_stmts(info.shared_data_pairs)
+    sds = shared_data_stmts(info.shared_data_pairs, true)
     if pred_is_unique_pred[blocks[1].id]
         push_block_stack_insts = IDInstPair[]
     else

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -41,7 +41,7 @@ const STALE_RVS_FNS = Function[stale_rvs_mid]
 stale_rvs_dyn(x) = (STALE_RVS_FNS[1])(x)
 
 @testset "s2s_reverse_mode_ad" begin
-    @testset "const global fdata is reset between rule calls" begin
+    @testset "const global fdata is reset between rule calls (#1282)" begin
         f = S2SGlobals.const_vector_phi
         rule = build_rrule(f, [0.3, 0.5], false)
 

--- a/test/interpreter/reverse_mode.jl
+++ b/test/interpreter/reverse_mode.jl
@@ -5,6 +5,12 @@ non_const_global = 5.0
 const const_float = 5.0
 const const_int = 5
 const const_bool = true
+const const_vector = [1.0, 2.0]
+
+function const_vector_phi(p, flag)
+    A = LowerTriangular([p[1] 0.0; p[2] p[1]] + I)
+    return sum(abs2, A \ (flag ? p : const_vector))
+end
 
 # used for regression test for issue 184
 struct A
@@ -35,6 +41,21 @@ const STALE_RVS_FNS = Function[stale_rvs_mid]
 stale_rvs_dyn(x) = (STALE_RVS_FNS[1])(x)
 
 @testset "s2s_reverse_mode_ad" begin
+    @testset "const global fdata is reset between rule calls" begin
+        f = S2SGlobals.const_vector_phi
+        rule = build_rrule(f, [0.3, 0.5], false)
+
+        function gradient(p)
+            dp = zeros(length(p))
+            y, pb = rule(zero_fcodual(f), CoDual(p, dp), zero_fcodual(false))
+            pb(one(primal(y)))
+            return dp
+        end
+
+        gradient([0.3, 0.5])
+        @test gradient([1.5, 2.0]) ≈ [-0.18944, -0.1536]
+    end
+
     @testset "SharedDataPairs" begin
         m = SharedDataPairs()
         id = Mooncake.add_data!(m, 5.0)


### PR DESCRIPTION
Captured constant `CoDual`s retained mutable fdata across rule calls, corrupting later gradients for read-only globals. Reset their fdata when the forward closure extracts shared data.

Fixes #1282.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1283 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1283/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 140.0 ns │     1.51 │        1.64 │    2.07 │        11.4 │   8.44 │
│                  _sum_1000 │ 852.0 ns │     6.03 │        1.02 │  1420.0 │        37.5 │   1.27 │
│               sum_sin_1000 │  5.79 μs │      2.6 │        1.21 │    2.02 │        11.4 │   2.09 │
│              _sum_sin_1000 │   3.6 μs │     3.87 │        2.63 │   332.0 │        18.6 │   3.42 │
│                   kron_sum │ 158.0 μs │     4.03 │         3.6 │    8.26 │       605.0 │   17.5 │
│              kron_view_sum │ 206.0 μs │     3.66 │        5.55 │    16.0 │       568.0 │   9.58 │
│      naive_map_sin_cos_exp │  1.78 μs │     2.86 │        1.47 │ missing │        9.12 │   2.39 │
│            map_sin_cos_exp │  1.73 μs │     3.46 │        1.61 │    2.17 │        8.09 │    3.0 │
│      broadcast_sin_cos_exp │  1.87 μs │     3.05 │        1.49 │    7.85 │        1.81 │   2.32 │
│                 simple_mlp │ 254.0 μs │     5.18 │        2.86 │    1.71 │        12.9 │   3.42 │
│                     gp_lml │ 194.0 μs │      6.9 │        2.39 │    5.53 │     missing │   5.39 │
│ turing_broadcast_benchmark │  1.32 ms │     7.37 │        3.82 │ missing │        50.7 │   2.27 │
│         large_single_block │ 370.0 ns │     11.8 │        2.11 │  7530.0 │        72.2 │   3.76 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->