### PR TITLE
interpreter: Skip empty captured fdata resets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.49"
+version = "0.5.50"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/reverse_mode.jl
+++ b/src/interpreter/reverse_mode.jl
@@ -874,7 +874,7 @@ IDInstPair[
 """
 function shared_data_stmts(p::SharedDataPairs, zero_coduals::Bool=false)::Vector{IDInstPair}
     return map(enumerate(p.pairs)) do (n, pair)
-        getter = if zero_coduals && pair[2] isa CoDual && !(tangent(pair[2]) isa NoFData)
+        getter = if zero_coduals && pair[2] isa CoDual && _may_have_fdata(tangent(pair[2]))
             get_zeroed_shared_data_field
         else
             get_shared_data_field

--- a/src/tangents/fwds_rvs_data.jl
+++ b/src/tangents/fwds_rvs_data.jl
@@ -22,6 +22,14 @@ struct FData{T<:NamedTuple}
     data::T
 end
 
+# `ErrorException("x")` has `FData((msg=NoFData(),))`, so an `FData`
+# wrapper does not necessarily contain state to reset.
+_may_have_fdata(::NoFData) = false
+_may_have_fdata(x::FData) = any(_may_have_fdata, x.data)
+_may_have_fdata(x::Union{Tuple,NamedTuple}) = any(_may_have_fdata, x)
+_may_have_fdata(x::PossiblyUninitTangent) = is_init(x) && _may_have_fdata(val(x))
+_may_have_fdata(x) = true
+
 # Recursively copy the wrapped data
 _copy(x::P) where {P<:FData} = P(_copy(x.data))
 

--- a/test/rules/high_order_derivative_patches.jl
+++ b/test/rules/high_order_derivative_patches.jl
@@ -3,6 +3,10 @@ struct _RefCaptureWrap{F}
 end
 (w::_RefCaptureWrap)(x) = w.f(x)
 Mooncake.tangent_type(::Type{<:_RefCaptureWrap}) = Mooncake.NoTangent
+
+const _EMPTY_FDATA_EXCEPTION = ErrorException("x")
+_throw_empty_fdata_exception(x) = x < 0 ? throw(_EMPTY_FDATA_EXCEPTION) : x^2
+
 function _compute_grad(rule, f, x::Vector{Float64}, x_fdata::Vector{Float64})
     fill!(x_fdata, 0.0)
     _, pb!! = rule(zero_fcodual(f), CoDual(x, x_fdata))
@@ -190,6 +194,12 @@ end
 end
 
 @testset "native HVP interface (prepare_hvp_cache + value_and_hvp!!)" begin
+    @testset "captured constant with empty structural fdata" begin
+        # The closure-captured variant follows a separate failing path tracked in #1286.
+        f = _throw_empty_fdata_exception
+        @test value_and_hvp!!(prepare_hvp_cache(f, 1.0), f, 1.0, 1.0) == (1.0, 2.0, 2.0)
+    end
+
     @testset "gradient correctness for x^4" begin
         f(x) = x[1]^4.0
         x = [2.0]


### PR DESCRIPTION
Structural fdata may contain only `NoFData`. Resetting such captures during HVP reaches unsupported open-`NamedTuple` tangent construction. Detect empty fdata at rule construction while preserving resets for stateful captures.

Fix https://github.com/chalk-lab/Mooncake.jl/issues/1286

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1287 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1287/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 230.0 ns │     1.43 │        1.44 │    1.43 │        6.84 │   5.36 │
│                  _sum_1000 │ 972.0 ns │     6.99 │        1.03 │  1430.0 │        37.9 │   1.21 │
│               sum_sin_1000 │  7.17 μs │     3.56 │         1.4 │    1.95 │        11.9 │   2.33 │
│              _sum_sin_1000 │  6.32 μs │     3.67 │        1.86 │   228.0 │        13.7 │   2.27 │
│                   kron_sum │ 228.0 μs │      4.2 │        3.25 │    6.86 │       345.0 │   10.0 │
│              kron_view_sum │ 309.0 μs │     3.35 │        4.95 │    12.4 │       298.0 │   6.21 │
│      naive_map_sin_cos_exp │   2.4 μs │     2.98 │        1.51 │ missing │        8.17 │   2.52 │
│            map_sin_cos_exp │  2.41 μs │     3.48 │        1.66 │    2.08 │        7.01 │   3.23 │
│      broadcast_sin_cos_exp │  2.43 μs │     3.25 │        1.58 │    4.69 │        1.89 │   2.55 │
│                 simple_mlp │ 371.0 μs │     4.71 │         2.6 │    1.74 │        9.59 │    3.2 │
│                     gp_lml │ 399.0 μs │     4.15 │        1.66 │     4.0 │     missing │   3.28 │
│ turing_broadcast_benchmark │  1.62 ms │     7.12 │         3.7 │ missing │        40.6 │   2.48 │
│         large_single_block │ 421.0 ns │     6.59 │        1.93 │  7110.0 │        40.9 │   2.45 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->