### PR TITLE
readme: document licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,9 @@ scope guide further work. Rules for operations outside Julia Base, broad redesig
 general debugging support, and the documented [known
 limitations](https://chalk-lab.github.io/Mooncake.jl/stable/known_limitations/) are not
 part of the current programme of work.
+
+## Licensing
+
+Mooncake is licensed under the [MIT License](LICENSE). Its required and optional
+dependencies are licensed separately and may impose additional terms on redistributed
+applications or binaries. See [`Project.toml`](Project.toml) for the dependency list.


### PR DESCRIPTION
<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1293 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1293/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 171.0 ns │     1.64 │        1.58 │    1.46 │        7.44 │   6.98 │
│                  _sum_1000 │ 982.0 ns │      6.7 │        1.01 │  1180.0 │        37.5 │   1.21 │
│               sum_sin_1000 │  7.16 μs │     3.56 │        1.39 │    1.86 │        12.2 │   2.25 │
│              _sum_sin_1000 │  5.77 μs │     3.75 │         2.0 │   212.0 │        15.1 │   2.51 │
│                   kron_sum │ 214.0 μs │     3.68 │        3.17 │    6.18 │       362.0 │    9.7 │
│              kron_view_sum │ 295.0 μs │     3.41 │        5.04 │    12.6 │       306.0 │   5.75 │
│      naive_map_sin_cos_exp │  2.34 μs │     3.06 │        1.54 │ missing │        8.46 │   2.65 │
│            map_sin_cos_exp │  2.35 μs │     3.41 │        1.63 │    1.83 │        7.11 │    3.2 │
│      broadcast_sin_cos_exp │  2.47 μs │     3.05 │        1.53 │    3.71 │        1.76 │    2.5 │
│                 simple_mlp │ 365.0 μs │     4.78 │        2.63 │    1.71 │        9.24 │   3.21 │
│                     gp_lml │ 396.0 μs │     4.04 │        1.67 │     4.8 │     missing │   3.15 │
│ turing_broadcast_benchmark │  1.63 ms │     7.03 │        3.64 │ missing │        39.6 │   2.46 │
│         large_single_block │ 421.0 ns │     5.83 │        1.93 │  8090.0 │        38.1 │   2.26 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->