### PR TITLE
rules: support non-strided SubArray tangents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.51"
+version = "0.5.52"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeLogExpFunctionsExt.jl
+++ b/ext/MooncakeLogExpFunctionsExt.jl
@@ -13,8 +13,8 @@ import Mooncake:
     primal,
     tangent,
     @is_primitive,
-    densify,
-    accumulate_densified!,
+    densify_tangent,
+    increment_densified_tangent!!,
     zero_fcodual,
     NoRData,
     extract,
@@ -179,9 +179,9 @@ function rrule!!(
     _x, _dx = arrayify(x)
     y = logsumexp(_x; primal(kwargs)...)
     function logsumexp_pb!!(dy::P)
-        dense = densify(_dx)
+        dense = densify_tangent(_dx)
         dense .+= dy .* exp.(_x .- y)
-        accumulate_densified!(_dx, dense)
+        increment_densified_tangent!!(_dx, dense)
         return NoRData(), NoRData(), NoRData(), NoRData()
     end
     return zero_fcodual(y), logsumexp_pb!!
@@ -197,9 +197,9 @@ function rrule!!(
     y = logsumexp(_x; primal(kwargs)...)
     dy = zero(y)
     function logsumexp_pb!!(::NoRData)
-        dense = densify(_dx)
+        dense = densify_tangent(_dx)
         dense .+= dy .* exp.(_x .- y)
-        accumulate_densified!(_dx, dense)
+        increment_densified_tangent!!(_dx, dense)
         return NoRData(), NoRData(), NoRData(), NoRData()
     end
     return CoDual(y, dy), logsumexp_pb!!
@@ -210,9 +210,9 @@ function rrule!!(
     _x, _dx = arrayify(x)
     y = logsumexp(_x)
     function logsumexp_pb!!(dy::P)
-        dense = densify(_dx)
+        dense = densify_tangent(_dx)
         dense .+= dy .* exp.(_x .- y)
-        accumulate_densified!(_dx, dense)
+        increment_densified_tangent!!(_dx, dense)
         return NoRData(), NoRData()
     end
     return zero_fcodual(y), logsumexp_pb!!
@@ -240,9 +240,9 @@ function rrule!!(
     old_out = copy(y)
     logsumexp!(y, _x)
     function logsumexp!_pb!!(::NoRData)
-        dense = densify(_dx)
+        dense = densify_tangent(_dx)
         dense .+= _dy .* exp.(_x .- y)
-        accumulate_densified!(_dx, dense)
+        increment_densified_tangent!!(_dx, dense)
         copyto!(y, old_out)
         fill!(_dy, zero(P))
         return NoRData(), NoRData(), NoRData()

--- a/src/rules/blas.jl
+++ b/src/rules/blas.jl
@@ -115,35 +115,42 @@ function arrayify(x::A, dx::DA) where {A,DA}
 end
 
 """
-    densify(dx)
+    densify_tangent(dx)
 
-Somewhere dense to accumulate a contribution destined for the tangent `dx`.
+Return structurally unrestricted storage in which to increment the tangent `dx`.
 
 [`arrayify`](@ref) returns tangents wrapped in the primal's own structural type, whose
 off-structure entries are not parameters: the primal reads a constant there whatever the
 storage holds. A rule whose adjoint is a dense expression must therefore accumulate here
-and hand the result to [`accumulate_densified!`](@ref), which adds back only the part `dx`
-can represent. A strided tangent is already dense, so the common case costs nothing.
+and hand the result to [`increment_densified_tangent!!`](@ref), which adds back only the
+part `dx` can represent. A tangent backed by strided storage is structurally unrestricted,
+even if indexing makes the view itself non-strided, so the common case costs nothing.
 """
-densify(dx::StridedArray) = dx
-function densify(dx::Union{UpperTriangular,LowerTriangular,Diagonal,Symmetric})
+densify_tangent(dx::StridedArray) = dx
+densify_tangent(dx::SubArray{T,N,A}) where {T,N,A<:StridedArray{T}} = dx
+function densify_tangent(dx::Union{UpperTriangular,LowerTriangular,Diagonal,Symmetric})
     return zeros(eltype(dx), size(dx))
 end
 
 """
-    accumulate_densified!(dx, dense)
+    increment_densified_tangent!!(dx, dense)
 
-Add the part of `dense` that the structured tangent `dx` can represent. See
-[`densify`](@ref).
+Increment `dx` by the part of `dense` that it can represent. If [`densify_tangent`](@ref)
+returned `dx` itself, the increment is already complete.
 """
-accumulate_densified!(::StridedArray, dense) = nothing
-function accumulate_densified!(
+increment_densified_tangent!!(::StridedArray, dense) = nothing
+function increment_densified_tangent!!(
+    ::SubArray{T,N,A}, dense
+) where {T,N,A<:StridedArray{T}}
+    return nothing
+end
+function increment_densified_tangent!!(
     dx::T, dense
 ) where {T<:Union{UpperTriangular,LowerTriangular}}
     parent(dx) .+= T(dense)
     return nothing
 end
-function accumulate_densified!(dx::Diagonal, dense)
+function increment_densified_tangent!!(dx::Diagonal, dense)
     dx.diag .+= view(dense, diagind(dense))
     return nothing
 end
@@ -151,7 +158,7 @@ end
 # `Symmetric` is the one wrapper for which this is not masking: with `uplo == 'U'`, the
 # stored `A[i, j]` is read at both `S[i, j]` and `S[j, i]` when `i < j`, so its adjoint
 # picks up both. Dropping the fold would silently halve those gradients rather than throw.
-function accumulate_densified!(dx::Symmetric, dense)
+function increment_densified_tangent!!(dx::Symmetric, dense)
     folded = dense .+ transpose(dense)
     folded[diagind(folded)] .= view(dense, diagind(dense))
     parent(dx) .+= dx.uplo == 'U' ? UpperTriangular(folded) : LowerTriangular(folded)

--- a/src/rules/performance_patches.jl
+++ b/src/rules/performance_patches.jl
@@ -119,17 +119,18 @@ const KronFactor{T} = Union{
 }
 
 # Both `kron` pullbacks contract `dy` against one factor to accumulate into the other. The
-# contraction is dense, so it goes through `densify` / `accumulate_densified!`. Read
-# as `P x M x Q x N`, both contractions read the same element of `dy`, so a single pass in
-# memory order serves both. A `gemv` per `(q, n)` block is slower at every shape measured:
-# the blocks are small enough that BLAS call overhead dominates.
+# contraction is dense, so it goes through `densify_tangent` /
+# `increment_densified_tangent!!`. Read as `P x M x Q x N`, both contractions read the same
+# element of `dy`, so a single pass in memory order serves both. A `gemv` per `(q, n)` block
+# is slower at every shape measured: the blocks are small enough that BLAS call overhead
+# dominates.
 function _kron_pb!(dx1, dx2, dy, px1, px2)
     T = eltype(px1)
     M, N = size(px1)
     P, Q = size(px2)
     W = reshape(dy, P, M, Q, N)
-    t1 = densify(dx1)
-    t2 = densify(dx2)
+    t1 = densify_tangent(dx1)
+    t2 = densify_tangent(dx2)
     @inbounds for n in 1:N, q in 1:Q, i in 1:M
         acc = zero(T)
         x1 = px1[i, n]
@@ -140,8 +141,8 @@ function _kron_pb!(dx1, dx2, dy, px1, px2)
         end
         t1[i, n] += acc
     end
-    accumulate_densified!(dx1, t1)
-    accumulate_densified!(dx2, t2)
+    increment_densified_tangent!!(dx1, t1)
+    increment_densified_tangent!!(dx2, t2)
     return nothing
 end
 

--- a/test/integration_testing/logexpfunctions/logexpfunctions.jl
+++ b/test/integration_testing/logexpfunctions/logexpfunctions.jl
@@ -53,6 +53,14 @@ sr(n::Int) = StableRNG(n)
                 (:none, false, x -> logsumexp(x; dims=2), fill(1.0, 2, 2)),
                 # subarray/view inputs, see #1035
                 (:none, false, x -> logsumexp(x; dims=2), view(fill(1.0, 3, 3), 1:2, 1:2)),
+                # Non-strided SubArray, see #1296.
+                (
+                    :none,
+                    false,
+                    (x, inds) -> logsumexp(view(x,:,:,inds,:); dims=(3, 4))[1],
+                    randn(sr(23), P, 2, 3, 5, 2),
+                    [1, 3, 4],
+                ),
                 (:none, true, logsumexp!, rand(sr(6), P, 5), randn(sr(7), P, 5, 4)),
                 (
                     :none,


### PR DESCRIPTION
`logsumexp` failed for gather-indexed views:

```julia
using LogExpFunctions, Mooncake
A = randn(2, 3, 5, 2)
i = [1, 3, 4]
f(A, i) = logsumexp(view(A, :, :, i, :); dims=(3, 4))[1]
Mooncake.value_and_gradient!!(Mooncake.build_rrule(f, A, i), f, A, i)
```

Treat views backed by strided storage as structurally unrestricted.

Closes #1296.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1297 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1297/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 171.0 ns │     1.76 │        1.58 │     1.4 │        7.32 │   7.09 │
│                  _sum_1000 │ 961.0 ns │     7.18 │        1.02 │  1180.0 │        39.0 │   1.22 │
│               sum_sin_1000 │  7.16 μs │     3.61 │        1.38 │    2.81 │        12.3 │   2.39 │
│              _sum_sin_1000 │  6.01 μs │     3.77 │        1.91 │   200.0 │        14.5 │   2.47 │
│                   kron_sum │ 216.0 μs │     3.94 │        3.21 │    6.06 │       370.0 │   10.1 │
│              kron_view_sum │ 298.0 μs │     3.54 │        5.01 │    12.7 │       315.0 │   5.82 │
│      naive_map_sin_cos_exp │  2.52 μs │     2.89 │        1.43 │ missing │        7.77 │   2.48 │
│            map_sin_cos_exp │  2.41 μs │     3.46 │        1.58 │    2.07 │        6.97 │   3.11 │
│      broadcast_sin_cos_exp │  2.62 μs │     2.89 │        1.42 │    4.62 │         1.7 │   2.36 │
│                 simple_mlp │ 387.0 μs │      4.5 │        2.53 │    1.81 │        8.73 │   3.04 │
│                     gp_lml │ 392.0 μs │     4.12 │        1.76 │    4.16 │     missing │   3.27 │
│ turing_broadcast_benchmark │  1.62 ms │     7.07 │        3.66 │ missing │        41.2 │   2.45 │
│         large_single_block │ 421.0 ns │     5.76 │        1.93 │  7150.0 │        37.9 │   2.55 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->