### PR TITLE
docs: clarify mutable aliasing limitations

### DIFF
--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -74,6 +74,49 @@ Observe that while it has correctly computed the identity function, the gradient
 
 The takeaway: do not attempt to differentiate functions which modify global state. Reading globals is fine; mutating globals is not.
 
+## Mutable aliases across inactive paths
+
+Mooncake may silently return incorrect derivatives when mutable storage is reachable through a differentiable argument and an inactive path. Inactive paths include fields of `NoTangent` parents and globals, both treated as constants. Paths can receive separate derivative storage, so mutation changes the shared primal without updating every derivative. Reverse and `frule!!`-based forward modes are affected. Reading globals is safe only while aliased storage remains unmodified. See [issue #1295](https://github.com/chalk-lab/Mooncake.jl/issues/1295).
+
+Here `box.x` and `x` refer to the same vector, but `box` is inactive:
+
+```jldoctest opaque-alias
+julia> struct OpaqueBox
+           x::Vector{Float64}
+       end
+
+julia> Mooncake.tangent_type(::Type{OpaqueBox}) = NoTangent;
+
+julia> function mutate_through_box(box, x)
+           box.x[1] *= 2
+           return x[1]
+       end;
+
+julia> x = [3.0]; box = OpaqueBox(x);
+
+julia> cache = Mooncake.prepare_gradient_cache(mutate_through_box, box, x);
+
+julia> Mooncake.value_and_gradient!!(cache, mutate_through_box, box, x)
+(6.0, (NoTangent(), NoTangent(), [1.0]))
+```
+
+A global alias has the same problem even when its binding is constant:
+
+```jldoctest global-alias
+julia> const GLOBAL_ALIAS = [3.0];
+
+julia> function mutate_through_global(x)
+           GLOBAL_ALIAS[1] *= 2
+           return x[1]
+       end;
+
+julia> cache = Mooncake.prepare_gradient_cache(mutate_through_global, GLOBAL_ALIAS);
+
+julia> Mooncake.value_and_gradient!!(cache, mutate_through_global, GLOBAL_ALIAS)
+(6.0, (NoTangent(), [1.0]))
+```
+
+Both examples report `[1.0]`; the correct derivative is `[2.0]` because the mutation doubles the aliased input. Until mixed active/inactive aliases are rejected or supported, do not mutate them.
 
 ## Passing Differentiable Data as a Type
 

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -74,49 +74,52 @@ Observe that while it has correctly computed the identity function, the gradient
 
 The takeaway: do not attempt to differentiate functions which modify global state. Reading globals is fine; mutating globals is not.
 
-## Mutable aliases across inactive paths
+## Mutable aliases involving `NoTangent` parents or globals
 
-Mooncake may silently return incorrect derivatives when mutable storage is reachable through a differentiable argument and an inactive path. Inactive paths include fields of `NoTangent` parents and globals, both treated as constants. Paths can receive separate derivative storage, so mutation changes the shared primal without updating every derivative. Reverse and `frule!!`-based forward modes are affected. Reading globals is safe only while aliased storage remains unmodified. See [issue #1295](https://github.com/chalk-lab/Mooncake.jl/issues/1295).
+Mooncake may silently return incorrect derivatives when the same mutable storage is differentiated directly and also reachable through a `NoTangent` parent or global. Reverse and `frule!!`-based forward modes are affected. See [issue #1295](https://github.com/chalk-lab/Mooncake.jl/issues/1295).
 
-Here `box.x` and `x` refer to the same vector, but `box` is inactive:
+A `NoTangent` parent:
 
 ```jldoctest opaque-alias
-julia> struct OpaqueBox
+julia> struct Box
            x::Vector{Float64}
        end
 
-julia> Mooncake.tangent_type(::Type{OpaqueBox}) = NoTangent;
+julia> Mooncake.tangent_type(::Type{Box}) = NoTangent;
 
-julia> function mutate_through_box(box, x)
+julia> function f(state)
+           box, x = state
            box.x[1] *= 2
            return x[1]
        end;
 
-julia> x = [3.0]; box = OpaqueBox(x);
+julia> x = [3.0]; state = (Box(x), x);
 
-julia> cache = Mooncake.prepare_gradient_cache(mutate_through_box, box, x);
+julia> rule = Mooncake.build_rrule(f, state);
 
-julia> Mooncake.value_and_gradient!!(cache, mutate_through_box, box, x)
-(6.0, (NoTangent(), NoTangent(), [1.0]))
+julia> Mooncake.value_and_gradient!!(rule, f, state)
+(6.0, (NoTangent(), (NoTangent(), [1.0])))
 ```
 
-A global alias has the same problem even when its binding is constant:
+`state` exposes one vector as `x` and `box.x`. Mooncake differentiates `x`, but reading through the `NoTangent` `Box` creates separate derivative storage. Mutation through `box.x` updates only that storage, so Mooncake returns `[1.0]`. This program should be rejected.
+
+A global:
 
 ```jldoctest global-alias
-julia> const GLOBAL_ALIAS = [3.0];
+julia> const X = [3.0];
 
-julia> function mutate_through_global(x)
-           GLOBAL_ALIAS[1] *= 2
+julia> function g(x)
+           X[1] *= 2
            return x[1]
        end;
 
-julia> cache = Mooncake.prepare_gradient_cache(mutate_through_global, GLOBAL_ALIAS);
+julia> rule = Mooncake.build_rrule(g, X);
 
-julia> Mooncake.value_and_gradient!!(cache, mutate_through_global, GLOBAL_ALIAS)
+julia> Mooncake.value_and_gradient!!(rule, g, X)
 (6.0, (NoTangent(), [1.0]))
 ```
 
-Both examples report `[1.0]`; the correct derivative is `[2.0]` because the mutation doubles the aliased input. Until mixed active/inactive aliases are rejected or supported, do not mutate them.
+`X` and `x` are the same vector. Mooncake treats `X` as constant and initializes its derivative storage separately from `x`'s. Mutation through `X` updates only the global storage, so Mooncake returns `[1.0]`. This program should be rejected.
 
 ## Passing Differentiable Data as a Type
 


### PR DESCRIPTION
Document that mutations can produce incorrect derivatives when mutable storage is shared between an active argument and an inactive path, including a `NoTangent` parent or global. Add minimal examples for both cases and clarify that read-only global access remains safe.

Fixes #1295.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1298 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1298/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 201.0 ns │     1.49 │        1.55 │    1.35 │        5.23 │   6.78 │
│                  _sum_1000 │  1.08 μs │     6.06 │        1.05 │  1050.0 │        40.4 │   1.18 │
│               sum_sin_1000 │  7.43 μs │     2.51 │        1.12 │    2.69 │        11.8 │   2.05 │
│              _sum_sin_1000 │  4.62 μs │     3.83 │        2.67 │   254.0 │        18.4 │   3.21 │
│                   kron_sum │ 191.0 μs │     3.33 │        3.36 │    6.76 │       509.0 │   12.4 │
│              kron_view_sum │ 263.0 μs │      3.0 │        5.28 │    15.1 │       456.0 │   6.78 │
│      naive_map_sin_cos_exp │  2.24 μs │     2.75 │         1.5 │ missing │        9.08 │   2.34 │
│            map_sin_cos_exp │  2.24 μs │     3.33 │        1.62 │    2.05 │        7.77 │   2.94 │
│      broadcast_sin_cos_exp │  2.34 μs │     2.92 │        1.52 │    5.06 │         1.8 │    2.3 │
│                 simple_mlp │ 346.0 μs │     4.85 │        2.88 │    1.69 │        9.57 │   3.53 │
│                     gp_lml │ 364.0 μs │     4.21 │        1.75 │     3.9 │     missing │   3.41 │
│ turing_broadcast_benchmark │  1.62 ms │     7.61 │        4.05 │ missing │        43.9 │   2.21 │
│         large_single_block │ 471.0 ns │     5.27 │        1.96 │  7060.0 │        38.7 │   2.29 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->