### PR TITLE
Preserve declared `NamedTuple` types when copying

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.52"
+version = "0.5.53"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -443,9 +443,14 @@ function _copy_to_output!!(dst::P, src::P) where {P<:_BuiltinArrays}
 end
 
 # Tuple, NamedTuple
-function _copy_to_output!!(dst::P, src::P) where {P<:Union{Tuple,NamedTuple}}
+function _copy_to_output!!(dst::P, src::P) where {P<:Tuple}
     isbitstype(P) && return src
     return map(_copy_to_output!!, dst, src)
+end
+
+function _copy_to_output!!(dst::P, src::P) where {P<:NamedTuple}
+    isbitstype(P) && return src
+    return P(map(_copy_to_output!!, values(dst), values(src)))
 end
 
 # Handling structs
@@ -543,7 +548,8 @@ function _copy_output(x::P) where {P<:_BuiltinArrays}
 end
 
 # Tuple, NamedTuple
-_copy_output(x::Union{Tuple,NamedTuple}) = map(_copy_output, x)::typeof(x)
+_copy_output(x::Tuple) = map(_copy_output, x)::typeof(x)
+_copy_output(x::NamedTuple) = typeof(x)(map(_copy_output, values(x)))
 
 # mutable composite types, bitstype
 function _copy_output(x::P) where {P}

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -503,9 +503,30 @@ end
                     @test TestUtils.has_equal_data(original, test_copy)
                     @test TestUtils.has_equal_data(original, test_inplace_copy)
                     @test typeof(test_copy) == typeof(original)
+                    @test typeof(test_inplace_copy) == typeof(original)
                 end
             catch err
                 @test isa(err, Mooncake.ValueAndPullbackReturnTypeError)
+            end
+        end
+
+        @testset "NamedTuple copy preserves field types: $T" for T in (
+            Any, AbstractVector, Union{Nothing,Vector{Float64}}
+        )
+            src = @NamedTuple{values::T}(([1.0],))
+            @testset "fresh copy" begin
+                dst = Mooncake._copy_output(src)
+                @test typeof(dst) === typeof(src)
+                @test dst.values == src.values
+                @test dst.values !== src.values
+            end
+            @testset "destination reuse" begin
+                dst = deepcopy(src)
+                src.values .= 2.0
+                result = Mooncake._copy_to_output!!(dst, src)
+                @test typeof(result) === typeof(src)
+                @test result.values === dst.values
+                @test result.values == src.values
             end
         end
 


### PR DESCRIPTION
Copying a named tuple with an abstract field currently throws:

```julia
Mooncake._copy_output(@NamedTuple{values}(([1.0],)))
```

Reconstruct the declared type in both copy helpers, preventing type narrowing and preserving destination reuse. Add regressions for abstract and union fields.

Fixes #1299.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1302 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1302/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 354.0 ns │      1.3 │        1.51 │    1.63 │        7.12 │   4.03 │
│                  _sum_1000 │ 790.0 ns │     8.22 │        1.11 │  1580.0 │        53.1 │   2.43 │
│               sum_sin_1000 │  6.66 μs │     3.41 │        1.31 │    2.32 │        11.4 │    2.7 │
│              _sum_sin_1000 │  6.42 μs │     3.26 │        1.81 │   196.0 │        13.0 │   2.54 │
│                   kron_sum │ 383.0 μs │     2.77 │        2.78 │    4.56 │       244.0 │   6.18 │
│              kron_view_sum │ 375.0 μs │     2.97 │        5.25 │    10.3 │       303.0 │   6.73 │
│      naive_map_sin_cos_exp │  3.09 μs │     2.31 │        1.32 │ missing │        7.08 │   2.02 │
│            map_sin_cos_exp │  2.89 μs │     2.84 │        1.52 │    2.21 │         6.3 │    2.5 │
│      broadcast_sin_cos_exp │  3.11 μs │     2.55 │        1.37 │    4.67 │        1.92 │   1.89 │
│                 simple_mlp │ 382.0 μs │     4.47 │        2.84 │    1.62 │        8.95 │   3.18 │
│                     gp_lml │ 250.0 μs │     5.43 │        2.43 │    5.96 │     missing │   4.04 │
│ turing_broadcast_benchmark │  1.96 ms │     4.44 │        2.73 │ missing │        31.0 │   1.44 │
│         large_single_block │ 648.0 ns │     5.62 │        1.78 │  4770.0 │        31.4 │    2.1 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->