### PR TITLE
Run existing DiffTests under GC pressure to expose Julia 1.13 failure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,6 +137,8 @@ jobs:
       - run: |
           if [ ${{ matrix.test_group.test_type }} == 'ext' ]; then
             julia --code-coverage=user --eval 'include("test/run_extra.jl")'
+          elif [ "$LABEL" == 'diff_tests' ]; then
+            julia --heap-size-hint=32M --eval 'include("test/run_extra.jl")'
           else
             julia --eval 'include("test/run_extra.jl")'
           fi

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -22,35 +22,7 @@ stale_fwd_lazy(x) = stale_fwd_mid(x)
 const STALE_FWD_FNS = Function[stale_fwd_mid]
 stale_fwd_dyn(x) = (STALE_FWD_FNS[1])(x)
 
-gc_preserve_collect() = GC.gc(true)
-Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_collect)}
-function gc_preserve_poison(x)
-    finalizer(x) do mem
-        return fill!(mem, -100.0)
-    end
-    return nothing
-end
-Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_poison),Any}
-function gc_preserve_slice_dot(x, y)
-    a = x[1:5]
-    gc_preserve_poison(@static VERSION >= v"1.11-" ? a.ref.mem : a)
-    gc_preserve_collect()
-    return dot(a, y)
-end
-
 @testset "s2s_forward_mode_ad" begin
-    @testset "temporary BLAS operand survives collection (issue #1303)" begin
-        # Poison on finalization instead of depending on allocator reuse. Julia 1.13
-        # eliminates the temporary Array wrappers, exposing the missing forward GC roots.
-        x, y = collect(1.0:6.0), collect(6.0:10.0)
-        dx, dy = collect(2.0:7.0), collect(3.0:7.0)
-        @test gc_preserve_slice_dot(x, y) == 130.0
-        rule = build_frule(gc_preserve_slice_dot, x, y)
-        result = rule(zero_dual(gc_preserve_slice_dot), Dual(x, dx), Dual(y, dy))
-        @test primal(result) == 130.0
-        @test tangent(result) == 255.0
-    end
-
     test_cases = collect(enumerate(TestResources.generate_test_functions()))
     @testset "$n - $(_typeof((fx)))" for (n, (int_only, pf, _, fx...)) in test_cases
         @info "$n: $(_typeof(fx))"

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -22,7 +22,35 @@ stale_fwd_lazy(x) = stale_fwd_mid(x)
 const STALE_FWD_FNS = Function[stale_fwd_mid]
 stale_fwd_dyn(x) = (STALE_FWD_FNS[1])(x)
 
+gc_preserve_collect() = GC.gc(true)
+Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_collect)}
+function gc_preserve_poison(x)
+    finalizer(x) do mem
+        return fill!(mem, -100.0)
+    end
+    return nothing
+end
+Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_poison),Any}
+function gc_preserve_slice_dot(x, y)
+    a = x[1:5]
+    gc_preserve_poison(@static VERSION >= v"1.11-" ? a.ref.mem : a)
+    gc_preserve_collect()
+    return dot(a, y)
+end
+
 @testset "s2s_forward_mode_ad" begin
+    @testset "temporary BLAS operand survives collection (issue #1303)" begin
+        # Poison on finalization instead of depending on allocator reuse. Julia 1.13
+        # eliminates the temporary Array wrappers, exposing the missing forward GC roots.
+        x, y = collect(1.0:6.0), collect(6.0:10.0)
+        dx, dy = collect(2.0:7.0), collect(3.0:7.0)
+        @test gc_preserve_slice_dot(x, y) == 130.0
+        rule = build_frule(gc_preserve_slice_dot, x, y)
+        result = rule(zero_dual(gc_preserve_slice_dot), Dual(x, dx), Dual(y, dy))
+        @test primal(result) == 130.0
+        @test tangent(result) == 255.0
+    end
+
     test_cases = collect(enumerate(TestResources.generate_test_functions()))
     @testset "$n - $(_typeof((fx)))" for (n, (int_only, pf, _, fx...)) in test_cases
         @info "$n: $(_typeof(fx))"


### PR DESCRIPTION
## Purpose
Capture the failing “before” state for #1303 using the existing DiffTests integration suite, not a synthetic regression.

The original DiffTests.neural_step test already ran on PR #856 and passed. After merging, the same Julia 1.13 lane failed its two forward-rule reuse assertions. The synthetic reproducer initially added here also passed in CI, so it has been removed.

The net change is two lines of CI configuration: run the existing diff_tests lane with --heap-size-hint=32M on all three Julia versions. This asks Julia to collect more aggressively; it is not a hard memory limit. No production code, test inputs, or assertions are changed. Other CI lanes are unchanged.

## Local verification
Using the existing full lane:
```sh
LABEL=diff_tests TEST_TYPE=integration_testing julia --heap-size-hint=32M --eval 'include("test/run_extra.jl")'
```

- Julia 1.10.12: 2,846/2,846 pass
- Julia 1.12.7: 2,846/2,846 pass
- Julia 1.13.0-rc4: 2,844 pass, 2 fail, both in DiffTests.neural_step forward-rule Reuse

On Julia 1.13 the first/second calls disagreed: primal 0.5 versus 0.9990183901683176, tangent 3.0e-323 versus 0.0014630377487576307. The isolated existing neural_step case also failed both reuse assertions under the same heap hint. An unmodified full-lane run without the hint failed one of those assertions locally, confirming the timing-sensitive nature of the original failure.

YAML parsing, shell-routing checks for affected and unaffected lanes, and git diff --check pass.

## CI interpretation
This is an intentionally failing before-state investigation, not a production fix. Local results do not guarantee the same failure under CI; the new CI run must establish that.

The existing Julia 1.13 continue-on-error setting is unchanged. Inspect individual DiffTests job logs rather than relying only on overall workflow status.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1304 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1304/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 150.0 ns │      1.8 │        1.73 │    1.87 │        6.68 │   9.41 │
│                  _sum_1000 │  1.03 μs │     6.46 │        1.03 │  1090.0 │        39.0 │   1.17 │
│               sum_sin_1000 │  7.06 μs │     2.53 │        1.18 │    2.73 │        11.0 │   2.09 │
│              _sum_sin_1000 │  4.49 μs │     3.86 │        2.59 │   259.0 │        18.2 │   3.21 │
│                   kron_sum │ 188.0 μs │     3.19 │        3.43 │    6.35 │       708.0 │   13.3 │
│              kron_view_sum │ 217.0 μs │     3.54 │        5.91 │    17.0 │       733.0 │   8.14 │
│      naive_map_sin_cos_exp │  2.09 μs │      2.8 │         1.5 │ missing │        9.02 │    2.4 │
│            map_sin_cos_exp │   2.0 μs │     3.55 │        1.65 │     2.0 │        8.29 │   3.18 │
│      broadcast_sin_cos_exp │  2.16 μs │     3.01 │        1.57 │     5.1 │        1.83 │   2.34 │
│                 simple_mlp │ 292.0 μs │      5.1 │        2.88 │    1.59 │        10.9 │   3.34 │
│                     gp_lml │ 216.0 μs │     6.17 │        2.51 │    5.73 │     missing │   4.67 │
│ turing_broadcast_benchmark │  1.59 ms │     7.28 │        3.75 │ missing │        47.5 │   2.28 │
│         large_single_block │ 441.0 ns │     5.79 │        1.93 │  6770.0 │        40.6 │    2.5 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->