### PR TITLE
Fix forward-mode GC preservation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,6 +137,8 @@ jobs:
       - run: |
           if [ ${{ matrix.test_group.test_type }} == 'ext' ]; then
             julia --code-coverage=user --eval 'include("test/run_extra.jl")'
+          elif [ "$LABEL" == 'diff_tests' ]; then
+            julia --heap-size-hint=32M --eval 'include("test/run_extra.jl")'
           else
             julia --eval 'include("test/run_extra.jl")'
           fi

--- a/docs/src/developer_documentation/forwards_mode_design.md
+++ b/docs/src/developer_documentation/forwards_mode_design.md
@@ -215,6 +215,10 @@ The purpose of converting `Expr(:foreigncall...)`, `Expr(:new, ...)` and `Expr(:
 
 The purpose of translating `Expr(:call, ::IntrinsicFunction, ...)` is to do with type stability -- see the docstring for the [Mooncake.IntrinsicsWrappers](@ref) module for more info.
 
+Native `gc_preserve_begin` / `gc_preserve_end` scopes are retained in forward mode.
+Their operands are mapped to `Dual` values, keeping both primal and tangent storage
+alive throughout the differentiated pointer-use interval. Preserving raw pointers alone
+does not keep their owning Julia objects alive.
 
 #### Statement Transformation
 

--- a/docs/src/developer_documentation/forwards_mode_design.md
+++ b/docs/src/developer_documentation/forwards_mode_design.md
@@ -215,10 +215,10 @@ The purpose of converting `Expr(:foreigncall...)`, `Expr(:new, ...)` and `Expr(:
 
 The purpose of translating `Expr(:call, ::IntrinsicFunction, ...)` is to do with type stability -- see the docstring for the [Mooncake.IntrinsicsWrappers](@ref) module for more info.
 
-Native `gc_preserve_begin` / `gc_preserve_end` scopes are retained in forward mode.
-Their operands are mapped to `Dual` values, keeping both primal and tangent storage
-alive throughout the differentiated pointer-use interval. Preserving raw pointers alone
-does not keep their owning Julia objects alive.
+Native `gc_preserve_begin` / `gc_preserve_end` scopes are retained in forwards-mode AD.
+The preserved owners are mapped to `Dual` values, keeping both primal and tangent storage alive throughout the scope.
+The end expression still consumes the native begin token, not a `Dual`.
+Preserving raw pointers alone does not keep their owning Julia objects alive.
 
 #### Statement Transformation
 

--- a/src/developer_tools.jl
+++ b/src/developer_tools.jl
@@ -35,7 +35,9 @@ function primal_ir(interp::MooncakeInterpreter, sig::Type{<:Tuple}; normalize=tr
     end
     normalize || return ir
     _, spnames = is_vararg_and_sparam_names(sig)
-    return normalise!(ir, spnames)
+    return normalise!(
+        ir, spnames; preserve_gc=interp isa MooncakeInterpreter{<:Any,ForwardMode}
+    )
 end
 
 """

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -407,8 +407,11 @@ function modify_fwd_ad_stmts!(
     stmt::Expr, dual_ir::IRCode, ssa::SSAValue, captures::Vector{Any}, info::DualInfo
 )
     if isexpr(stmt, :gc_preserve_begin) || isexpr(stmt, :gc_preserve_end)
-        # The begin operands refer to Duals, keeping primal and tangent owners alive.
-        # The end operand remains the native begin token, not a Dual.
+        # Forward AD inserts a captures argument before the original arguments.
+        # Without shifting its argument references, gc_preserve_begin would preserve
+        # the wrong values. inc_args shifts them by one to refer to the intended Duals.
+        # gc_preserve_end refers to the result of its matching begin, not an argument
+        # position, so inc_args leaves that reference unchanged. See PR #1305.
         replace_call!(dual_ir, ssa, inc_args(stmt))
     elseif isexpr(stmt, :invoke) || isexpr(stmt, :call)
         raw_args = isexpr(stmt, :invoke) ? stmt.args[2:end] : stmt.args

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -407,7 +407,8 @@ function modify_fwd_ad_stmts!(
     stmt::Expr, dual_ir::IRCode, ssa::SSAValue, captures::Vector{Any}, info::DualInfo
 )
     if isexpr(stmt, :gc_preserve_begin) || isexpr(stmt, :gc_preserve_end)
-        # Preserve the Dual operands, keeping both primal and tangent owners alive.
+        # The begin operands refer to Duals, keeping primal and tangent owners alive.
+        # The end operand remains the native begin token, not a Dual.
         replace_call!(dual_ir, ssa, inc_args(stmt))
     elseif isexpr(stmt, :invoke) || isexpr(stmt, :call)
         raw_args = isexpr(stmt, :invoke) ? stmt.args[2:end] : stmt.args

--- a/src/interpreter/forward_mode.jl
+++ b/src/interpreter/forward_mode.jl
@@ -212,7 +212,7 @@ function generate_dual_ir(
 
     # Normalise the IR.
     isva, spnames = is_vararg_and_sparam_names(sig_or_mi)
-    primal_ir = normalise!(primal_ir, spnames)
+    primal_ir = normalise!(primal_ir, spnames; preserve_gc=true)
 
     # Keep a copy of the primal IR with the insertions
     dual_ir = CC.copy(primal_ir)
@@ -406,7 +406,10 @@ __get_primal(x::Dual) = primal(x)
 function modify_fwd_ad_stmts!(
     stmt::Expr, dual_ir::IRCode, ssa::SSAValue, captures::Vector{Any}, info::DualInfo
 )
-    if isexpr(stmt, :invoke) || isexpr(stmt, :call)
+    if isexpr(stmt, :gc_preserve_begin) || isexpr(stmt, :gc_preserve_end)
+        # Preserve the Dual operands, keeping both primal and tangent owners alive.
+        replace_call!(dual_ir, ssa, inc_args(stmt))
+    elseif isexpr(stmt, :invoke) || isexpr(stmt, :call)
         raw_args = isexpr(stmt, :invoke) ? stmt.args[2:end] : stmt.args
         sig_types = map(raw_args) do x
             t = CC.widenconst(get_forward_primal_type(info.primal_ir, x))

--- a/src/interpreter/ir_normalisation.jl
+++ b/src/interpreter/ir_normalisation.jl
@@ -12,7 +12,7 @@ unchanged, but makes AD more straightforward. In particular, replace
 7. `gc_preserve_begin` / `gc_preserve_end` exprs so that memory release is delayed.
 
 With `preserve_gc=true`, leave native GC preservation scopes intact for forward AD,
-which maps their operands to `Dual`s to retain both primal and tangent storage.
+which maps the preserved owners to `Dual`s to retain both primal and tangent storage.
 
 `spnames` are the names associated to the static parameters of `ir`. These are needed when
 handling `:foreigncall` expressions, in which it is not necessarily the case that all

--- a/src/interpreter/ir_normalisation.jl
+++ b/src/interpreter/ir_normalisation.jl
@@ -1,5 +1,5 @@
 """
-    normalise!(ir::IRCode, spnames::Vector{Symbol})
+    normalise!(ir::IRCode, spnames::Vector{Symbol}; preserve_gc=false)
 
 Apply a sequence of standardising transformations to `ir` which leaves its semantics
 unchanged, but makes AD more straightforward. In particular, replace
@@ -11,6 +11,9 @@ unchanged, but makes AD more straightforward. In particular, replace
 6. `memoryrefget` calls to `lmemoryrefget` calls, and related transformations,
 7. `gc_preserve_begin` / `gc_preserve_end` exprs so that memory release is delayed.
 
+With `preserve_gc=true`, leave native GC preservation scopes intact for forward AD,
+which maps their operands to `Dual`s to retain both primal and tangent storage.
+
 `spnames` are the names associated to the static parameters of `ir`. These are needed when
 handling `:foreigncall` expressions, in which it is not necessarily the case that all
 static parameter names have been translated into either types, or `:static_parameter`
@@ -20,7 +23,7 @@ Unfortunately, the static parameter names are not retained in `IRCode`, and the 
 from which the `IRCode` is derived must be consulted. `Mooncake.is_vararg_and_sparam_names`
 provides a convenient way to do this.
 """
-function normalise!(ir::IRCode, spnames::Vector{Symbol})
+function normalise!(ir::IRCode, spnames::Vector{Symbol}; preserve_gc=false)
     sp_map = Dict{Symbol,CC.VarState}(zip(spnames, ir.sptypes))
     ir = interpolate_boundschecks!(ir)
     ir = fix_up_invoke_inference!(ir)
@@ -31,7 +34,7 @@ function normalise!(ir::IRCode, spnames::Vector{Symbol})
         inst = intrinsic_to_function(inst)
         inst = lift_getfield_and_others(inst)
         inst = lift_memoryrefget_and_memoryrefset_builtins(inst)
-        inst = lift_gc_preservation(inst)
+        preserve_gc || (inst = lift_gc_preservation(inst))
         stmt(ir.stmts)[n] = inst
     end
     ir = const_prop_gotoifnots!(ir)

--- a/src/skill_utils.jl
+++ b/src/skill_utils.jl
@@ -184,7 +184,11 @@ function primal_stages(interp, sig)
 
     _, spnames = is_vararg_and_sparam_names(sig)
     normalized_ir = CC.copy(raw_ir)
-    normalise!(normalized_ir, spnames)
+    normalise!(
+        normalized_ir,
+        spnames;
+        preserve_gc=interp isa MooncakeInterpreter{<:Any,ForwardMode},
+    )
 
     cfg_blocks = _remove_unreachable_cfg_blocks!(_ircode_to_cfg_blocks(normalized_ir))
     return raw_ir, normalized_ir, cfg_blocks

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -22,7 +22,46 @@ stale_fwd_lazy(x) = stale_fwd_mid(x)
 const STALE_FWD_FNS = Function[stale_fwd_mid]
 stale_fwd_dyn(x) = (STALE_FWD_FNS[1])(x)
 
+const GC_PRESERVE_OWNERS = Ref((WeakRef(nothing), WeakRef(nothing)))
+gc_preserve_storage(x) = @static VERSION >= v"1.11-" ? x.ref.mem : x
+function gc_preserve_observe(x)
+    GC_PRESERVE_OWNERS[] = (
+        WeakRef(gc_preserve_storage(x)), WeakRef(gc_preserve_storage(x))
+    )
+    return x
+end
+Mooncake.@is_primitive DefaultCtx ForwardMode Tuple{
+    typeof(gc_preserve_observe),Vector{Float64}
+}
+function Mooncake.frule!!(::Dual{typeof(gc_preserve_observe)}, x::Dual)
+    GC_PRESERVE_OWNERS[] = (
+        WeakRef(gc_preserve_storage(primal(x))), WeakRef(gc_preserve_storage(tangent(x)))
+    )
+    return x
+end
+@noinline function gc_preserve_alive(::Ptr{Float64})
+    GC.gc(true)
+    return map(w -> w.value !== nothing, GC_PRESERVE_OWNERS[])
+end
+Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_alive),Ptr{Float64}}
+function gc_preserve_probe(x)
+    a = gc_preserve_observe(copy(x))
+    return GC.@preserve a gc_preserve_alive(pointer(a))
+end
+
 @testset "s2s_forward_mode_ad" begin
+    @testset "GC preservation of primal and tangent storage (issue #1303)" begin
+        # Observe collection without dereferencing a potentially stale pointer.
+        @test gc_preserve_probe([1.0, 2.0]) == (true, true)
+        rule = build_frule(gc_preserve_probe, [1.0, 2.0])
+        for _ in 1:2
+            result = rule(zero_dual(gc_preserve_probe), Dual([1.0, 2.0], [3.0, 4.0]))
+            @test primal(result) == (true, true)
+            GC.gc(true)
+            @test all(w -> w.value === nothing, GC_PRESERVE_OWNERS[])
+        end
+    end
+
     test_cases = collect(enumerate(TestResources.generate_test_functions()))
     @testset "$n - $(_typeof((fx)))" for (n, (int_only, pf, _, fx...)) in test_cases
         @info "$n: $(_typeof(fx))"

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -22,35 +22,7 @@ stale_fwd_lazy(x) = stale_fwd_mid(x)
 const STALE_FWD_FNS = Function[stale_fwd_mid]
 stale_fwd_dyn(x) = (STALE_FWD_FNS[1])(x)
 
-gc_preserve_collect() = GC.gc(true)
-Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_collect)}
-function gc_preserve_poison(x)
-    finalizer(x) do mem
-        return fill!(mem, -100.0)
-    end
-    return nothing
-end
-Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_poison),Any}
-function gc_preserve_slice_dot(x, y)
-    a = x[1:5]
-    gc_preserve_poison(@static VERSION >= v"1.11-" ? a.ref.mem : a)
-    gc_preserve_collect()
-    return dot(a, y)
-end
-
 @testset "s2s_forward_mode_ad" begin
-    @testset "temporary BLAS operand survives collection (issue #1303)" begin
-        # Poison on finalization instead of depending on allocator reuse. Julia 1.13
-        # eliminates the temporary Array wrappers, exposing the missing forward GC roots.
-        x, y = collect(1.0:6.0), collect(6.0:10.0)
-        dx, dy = collect(2.0:7.0), collect(3.0:7.0)
-        @test gc_preserve_slice_dot(x, y) == 130.0
-        rule = build_frule(gc_preserve_slice_dot, x, y)
-        result = rule(zero_dual(gc_preserve_slice_dot), Dual(x, dx), Dual(y, dy))
-        @test primal(result) == 130.0
-        @test tangent(result) == 255.0
-    end
-
     test_cases = collect(enumerate(TestResources.generate_test_functions()))
     @testset "$n - $(_typeof((fx)))" for (n, (int_only, pf, _, fx...)) in test_cases
         @info "$n: $(_typeof(fx))"

--- a/test/interpreter/forward_mode.jl
+++ b/test/interpreter/forward_mode.jl
@@ -22,7 +22,35 @@ stale_fwd_lazy(x) = stale_fwd_mid(x)
 const STALE_FWD_FNS = Function[stale_fwd_mid]
 stale_fwd_dyn(x) = (STALE_FWD_FNS[1])(x)
 
+gc_preserve_collect() = GC.gc(true)
+Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_collect)}
+function gc_preserve_poison(x)
+    finalizer(x) do mem
+        return fill!(mem, -100.0)
+    end
+    return nothing
+end
+Mooncake.@zero_derivative DefaultCtx Tuple{typeof(gc_preserve_poison),Any}
+function gc_preserve_slice_dot(x, y)
+    a = x[1:5]
+    gc_preserve_poison(@static VERSION >= v"1.11-" ? a.ref.mem : a)
+    gc_preserve_collect()
+    return dot(a, y)
+end
+
 @testset "s2s_forward_mode_ad" begin
+    @testset "temporary BLAS operand survives collection (issue #1303)" begin
+        # Poison on finalization instead of depending on allocator reuse. Julia 1.13
+        # eliminates the temporary Array wrappers, exposing the missing forward GC roots.
+        x, y = collect(1.0:6.0), collect(6.0:10.0)
+        dx, dy = collect(2.0:7.0), collect(3.0:7.0)
+        @test gc_preserve_slice_dot(x, y) == 130.0
+        rule = build_frule(gc_preserve_slice_dot, x, y)
+        result = rule(zero_dual(gc_preserve_slice_dot), Dual(x, dx), Dual(y, dy))
+        @test primal(result) == 130.0
+        @test tangent(result) == 255.0
+    end
+
     test_cases = collect(enumerate(TestResources.generate_test_functions()))
     @testset "$n - $(_typeof((fx)))" for (n, (int_only, pf, _, fx...)) in test_cases
         @info "$n: $(_typeof(fx))"

--- a/test/skill_utils.jl
+++ b/test/skill_utils.jl
@@ -25,6 +25,7 @@ using Mooncake.SkillUtils:
 
 test_fn(x) = sin(x) * cos(x)
 multi_arg_fn(x, y) = x * y + sin(x)
+gc_preserve_test_fn(x) = GC.@preserve x unsafe_load(pointer(x))
 function bar_llvmcall(x)
     Base.llvmcall((
         """
@@ -42,12 +43,12 @@ Mooncake.@zero_derivative Mooncake.MinimalCtx Tuple{typeof(zero_derivative_llvmc
 
 @testset "ir_inspect" begin
     @testset "mode-specific GC preservation" begin
-        x, y = [1.0, 2.0], [3.0, 4.0]
-        sig = Tuple{typeof(BLAS.dot),typeof(x),typeof(y)}
+        x = [1.0, 2.0]
+        sig = Tuple{typeof(gc_preserve_test_fn),typeof(x)}
         for (mode, M) in ((:forward, ForwardMode), (:reverse, ReverseMode))
             for ir in (
                 Mooncake.primal_ir(get_interpreter(M), sig),
-                inspect_ir(BLAS.dot, x, y; mode).stages[:normalized].ir,
+                inspect_ir(gc_preserve_test_fn, x; mode).stages[:normalized].ir,
             )
                 @test any(
                     s -> Meta.isexpr(s, :gc_preserve_begin), Mooncake.stmt(ir.stmts)

--- a/test/skill_utils.jl
+++ b/test/skill_utils.jl
@@ -41,6 +41,21 @@ zero_derivative_llvmcall(x) = bar_llvmcall(x)
 Mooncake.@zero_derivative Mooncake.MinimalCtx Tuple{typeof(zero_derivative_llvmcall),Int}
 
 @testset "ir_inspect" begin
+    @testset "mode-specific GC preservation" begin
+        x, y = [1.0, 2.0], [3.0, 4.0]
+        sig = Tuple{typeof(BLAS.dot),typeof(x),typeof(y)}
+        for (mode, M) in ((:forward, ForwardMode), (:reverse, ReverseMode))
+            for ir in (
+                Mooncake.primal_ir(get_interpreter(M), sig),
+                inspect_ir(BLAS.dot, x, y; mode).stages[:normalized].ir,
+            )
+                @test any(
+                    s -> Meta.isexpr(s, :gc_preserve_begin), Mooncake.stmt(ir.stmts)
+                ) == (mode == :forward)
+            end
+        end
+    end
+
     @testset "inspect_ir reverse mode" begin
         ins = inspect_ir(test_fn, 1.0)
         @test ins.mode == :reverse


### PR DESCRIPTION
Fixes #1303. Replaces the closed before-state demo #1304.

Forward AD was lowering native GC-preserve scopes to a no-op, allowing temporary primal and tangent storage to be collected while BLAS still held their raw pointers. Retain the native scope and preserve the corresponding `Dual` operands. Reverse-mode behavior is unchanged.

The regression forces GC at a pointer-use boundary and checks both owners through weak references, without dereferencing stale pointers. It also checks prepared-rule reuse and collection after return. Before the fix, both in-scope checks fail on Julia 1.13; with the fix, all five assertions pass on 1.10.12, 1.11.6, 1.12.7, and 1.13.0-rc4. Mode-specific IR checks and a type-stability/zero-allocation dot probe also pass on all four versions.

The PR runs the existing DiffTests group with `--heap-size-hint=32M` on all CI versions. The unchanged before-state job failed on 1.13 and passed on 1.12/LTS: [CI run](https://github.com/chalk-lab/Mooncake.jl/actions/runs/34285907374). The causal experiments and reproduction directions are in [the issue](https://github.com/chalk-lab/Mooncake.jl/issues/1303#issuecomment-5593566237).

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1305 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1305/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │ Enzyme │
│                     String │   String │   String │      String │  String │      String │ String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼────────┤
│                   sum_1000 │ 347.0 ns │     1.44 │        1.37 │    1.45 │         5.2 │   7.29 │
│                  _sum_1000 │  1.21 μs │     10.9 │         1.2 │   957.0 │        60.8 │   2.43 │
│               sum_sin_1000 │  5.72 μs │     4.07 │        3.21 │    4.95 │        20.2 │   3.22 │
│              _sum_sin_1000 │  5.93 μs │     5.21 │        1.79 │   197.0 │        20.2 │   4.59 │
│                   kron_sum │ 372.0 μs │     4.71 │        5.98 │    11.2 │       254.0 │   11.1 │
│              kron_view_sum │ 392.0 μs │     3.18 │        4.18 │    12.5 │       277.0 │   11.0 │
│      naive_map_sin_cos_exp │  2.96 μs │     2.55 │        1.42 │ missing │        16.7 │   2.07 │
│            map_sin_cos_exp │  2.71 μs │      5.4 │        2.33 │    2.35 │        15.7 │   3.86 │
│      broadcast_sin_cos_exp │  3.01 μs │     4.12 │        2.91 │    6.32 │        1.95 │   2.53 │
│                 simple_mlp │ 447.0 μs │     4.25 │        2.69 │    1.69 │        8.88 │   2.99 │
│                     gp_lml │ 259.0 μs │     5.75 │        2.49 │    6.22 │     missing │   4.06 │
│ turing_broadcast_benchmark │  2.21 ms │     5.13 │        2.54 │ missing │        29.5 │   1.61 │
│         large_single_block │ 490.0 ns │     7.37 │         2.1 │  6150.0 │        83.0 │   2.37 │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴────────┘
```

<!-- managed-pr-summary:end -->
