### PR TITLE
Julia 1.13.0 Test and Support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
       setup:
         version:
           - "1.10"
-          - "1.12"
+          - "1.13"
         label:
           - "cuda"
           - "nnlib"
@@ -51,7 +51,7 @@ steps:
       setup:
         version:
           - "1.10"
-          - "1.12"
+          - "1.13"
         label:
           - "flux"
           - "lux"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,6 @@ jobs:
     name: ${{ matrix.test_group }}-${{ matrix.version }}-${{ matrix.arch }}
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
-    continue-on-error: ${{ matrix.version == '1.13' }}
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +54,6 @@ jobs:
         ]
         version:
           - 'lts'
-          - '1.12'
           - '1.13'
         arch:
           - x64
@@ -72,7 +70,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-          include-all-prereleases: ${{ matrix.version == '1.13' }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
@@ -88,7 +85,6 @@ jobs:
     name: ${{matrix.test_group.test_type}}-${{ matrix.test_group.label }}-${{ matrix.version }}-${{ matrix.arch }}
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
-    continue-on-error: ${{ matrix.version == '1.13' }}
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +113,6 @@ jobs:
         ]
         version:
           - 'lts'
-          - '1.12'
           - '1.13'
         arch:
           - x64
@@ -131,7 +126,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-          include-all-prereleases: ${{ matrix.version == '1.13' }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - run: |
@@ -164,7 +158,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: '1.13'
           arch: x64
           include-all-prereleases: false
       - uses: julia-actions/cache@v3
@@ -183,7 +177,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: '1.13'
           arch: x64
           include-all-prereleases: false
       - uses: julia-actions/cache@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ jobs:
           GKSwstype: nul # turn off GR's interactive plotting for notebooks
         uses: TuringLang/actions/DocsDocumenter@main
         with:
-          julia-version: '1.12'
+          julia-version: '1.13'
           post-preview-comment: 'false'
       - name: Sync PR summary
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/Project.toml
+++ b/Project.toml
@@ -91,7 +91,7 @@ SpecialFunctions = "2"
 StableRNGs = "1"
 Static = "1.1.1"
 Test = "1"
-julia = "~1.10.8, 1.11.6, 1.12.1"
+julia = "~1.10.8, ~1.11.6, ~1.12.1, ~1.13.0"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"

--- a/SUPPORT_POLICY.md
+++ b/SUPPORT_POLICY.md
@@ -5,31 +5,29 @@ Consequently, the versions of Julia which are officially supported by `Mooncake.
 
 We may also run CI against a prerelease of the next Julia minor version to find compatibility problems before release. These lanes are preparatory: a Julia version becomes officially supported only when its stable release is available.
 
-For example, the LTS is 1.10 and the latest release is 1.12, at the time of writing. When 1.13 is released, we will
-1. bump the Julia compat bounds in `Mooncake.jl` to require either 1.10 or 1.13,
-1. cease to run CI on 1.12,
-1. cease to provide bug fixes for 1.12,
-1. cease to accept 1.12-specific bug fixes, as we will not be running CI for 1.12 and therefore will not be able to test that they have worked.
+The LTS is 1.10 and the latest stable release is 1.13, at the time of writing. With the release of 1.13, we
+1. run required CI on 1.10 and stable 1.13, including extension and integration tests,
+1. cease to run CI or guarantee bug fixes for 1.12,
+1. cease to accept 1.12-specific bug fixes, as we no longer run CI for 1.12 and therefore cannot test that they have worked.
 
-In short: as far as `Mooncake.jl`'s future releases are concerned, 1.12 ceases to exist the moment 1.13 is released.
+Official support is distinct from installability. Julia 1.11 and 1.12 remain allowed by the Julia compat bounds on a best-effort basis, with minimum versions 1.11.6 and 1.12.1 respectively. They are not covered by CI, and correctness or continued compatibility is not guaranteed. Dropping official support does not by itself require excluding a version from compat. Untested future minor versions are not admitted automatically.
 
 Note that these changes are not applied retrospectively to existing releases of `Mooncake.jl`.
-Suppose that `Mooncake.jl` is at `v0.4.50` when 1.12 is released.
-Then the above changes would be relevant to `Mooncake.jl` versions `v0.4.51` and higher.
+Users staying on Julia 1.11 or 1.12 can install new Mooncake releases while their compat bounds permit it, or retain an older compatible release if they encounter problems.
 
 # Patch Versions
 
 The above only discussed minor versions of Julia (1.10, 1.11, 1.12, etc).
 However, it also applies to patch versions of Julia.
-For example, at the time of writing, Julia version 1.10.12 is _actually_ the LTS, and 1.12.7 the current release of Julia.
+For example, at the time of writing, Julia version 1.10.12 is _actually_ the LTS, and 1.13.0 the current release of Julia.
 The moment that 1.10.13 is released, we will cease to run any CI on 1.10.12, and will not accept fixes for it.
-The same is true of 1.12.8.
+The same is true of 1.13.1 replacing 1.13.0.
 
 Since patch releases of Julia are less invasive than minor releases, this should generally not cause users problems.
 
 # Context
 
-In order to support a particular version of Julia, we must
+In order to officially support a particular version of Julia, we must
 1. always run CI for that version,
 1. accept and proactively produce fixes for that version,
 1. maintain version-specific code in the `Mooncake.jl` codebase.
@@ -38,7 +36,8 @@ All of this adds a surprising amount of overhead to the development of `Mooncake
 All of this makes it harder to improve `Mooncake.jl`.
 Consequently, this policy represents a decision to tradeoff support for a range of minor Julia versions in exchange for easing the development burden associated to `Mooncake.jl`.
 
-## Why not gently drop support?
+## Why not gently drop official support?
 
 In the JuliaGaussianProcesses ecosystem, we had a loosely-defined policy of keeping support for an older version until we ran into a large problem which could not be fixed easily, at which point we would drop support.
 While this sounds appealing, in practice it makes it hard to know exactly when to drop support for a particular version of Julia, increases the burden for maintainers, and makes it hard for users to know exactly what to expect.
+Allowing installation on a best-effort basis does not extend this official support commitment.

--- a/docs/src/developer_documentation/ir_representation.md
+++ b/docs/src/developer_documentation/ir_representation.md
@@ -523,6 +523,7 @@ julia> blocks_copy[3] = CFGBlock(
 julia> blocks_copy[3].insts[end] = new_inst(IDGotoIfNot(cond_id, block_2_id));
 
 julia> for inst in blocks_copy[2].insts[1:2]
+           # Block #4 only prints before jumping back, so reuse block #3's updated values.
            phi = inst.stmt
            value = phi.values[findfirst(==(blk.id), phi.edges)]
            push!(phi.edges, new_bb_id)
@@ -547,7 +548,6 @@ julia> new_ir = lower_cfg_blocks_to_ir(blocks_copy, ir)
 Observe that in order to tie the conditional to the goto-if-not, we simply ensure that the `ID` associated to the instruction which computes the conditional appears in the `IDGotoIfNot` instruction.
 The loop header now has an additional predecessor, so both phi nodes must also accept values from the new block.
 Since that block only prints, it forwards the same updated values as block `#3`.
-Omitting these inputs leaves the loop-carried values undefined on the printing path; `verify_ir` permits incomplete phi nodes and does not catch this mistake.
 
 ### Run the new code
 

--- a/docs/src/developer_documentation/ir_representation.md
+++ b/docs/src/developer_documentation/ir_representation.md
@@ -522,10 +522,17 @@ julia> blocks_copy[3] = CFGBlock(
 
 julia> blocks_copy[3].insts[end] = new_inst(IDGotoIfNot(cond_id, block_2_id));
 
+julia> for inst in blocks_copy[2].insts[1:2]
+           phi = inst.stmt
+           value = phi.values[findfirst(==(blk.id), phi.edges)]
+           push!(phi.edges, new_bb_id)
+           push!(phi.values, value)
+       end;
+
 julia> new_ir = lower_cfg_blocks_to_ir(blocks_copy, ir)
   1 ─      nothing::Nothing
-4 2 ┄ %2 = φ (#1 => 1, #3 => %8)::Int64
-  │   %3 = φ (#1 => 0, #3 => %7)::Int64
+4 2 ┄ %2 = φ (#1 => 1, #3 => %8, #4 => %8)::Int64
+  │   %3 = φ (#1 => 0, #3 => %7, #4 => %7)::Int64
   │   %4 = intrinsic Base.slt_int(%3, _2)::Bool
   └──      goto #5 if not %4
 2 3 ─ %6 = intrinsic (Core.Intrinsics.mul_int)(%3, 2)::Int64
@@ -538,6 +545,9 @@ julia> new_ir = lower_cfg_blocks_to_ir(blocks_copy, ir)
 8 5 ─      return %2
 ```
 Observe that in order to tie the conditional to the goto-if-not, we simply ensure that the `ID` associated to the instruction which computes the conditional appears in the `IDGotoIfNot` instruction.
+The loop header now has an additional predecessor, so both phi nodes must also accept values from the new block.
+Since that block only prints, it forwards the same updated values as block `#3`.
+Omitting these inputs leaves the loop-carried values undefined on the printing path; `verify_ir` permits incomplete phi nodes and does not catch this mistake.
 
 ### Run the new code
 

--- a/docs/src/known_limitations.md
+++ b/docs/src/known_limitations.md
@@ -173,14 +173,14 @@ julia> struct B end
 julia> direct_primitive(::A) = A()
 direct_primitive (generic function with 1 method)
 
-julia> Mooncake.@mooncake_overlay direct_primitive(::A) = B()
+julia> Mooncake.@mooncake_overlay direct_primitive(::A) = B();
 
 julia> Mooncake.@is_primitive Mooncake.DefaultCtx Mooncake.ReverseMode Tuple{typeof(direct_primitive), A}
 
 julia> helper(::A) = A()
 helper (generic function with 1 method)
 
-julia> Mooncake.@mooncake_overlay helper(::A) = B()
+julia> Mooncake.@mooncake_overlay helper(::A) = B();
 
 julia> indirect_primitive(x::A) = helper(x)
 indirect_primitive (generic function with 1 method)

--- a/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt/MooncakeCUDAExt.jl
@@ -3037,19 +3037,23 @@ function rrule!!(
     return C, generic_matmatmul!_pb!!
 end
 
-# 7-arg version of `generic_matmatmul!`: used by CUDA.jl's override of the LinearAlgebra
-# function, which always passes explicit alpha and beta scalars.  The 5-arg rule above
-# covers the pure LinearAlgebra fallback path; this rule covers the CUDA.jl path
-# (cublas/linalg.jl line 349) that is reached from `A * B` → `mul!` → matmul dispatch.
+# The 7-arg `generic_matmatmul!` is the CUDA.jl boundary through Julia 1.12; Julia 1.13
+# uses the equivalent public storage-type boundary `mul!(C, tA, tB, A, B, alpha, beta)`.
 #
 # alpha / beta are differentiated.  They are usually `true`/`false` (from `MulAddMul`), which
 # carry no derivative and cost nothing here, but a caller may pass floats — `mul!(C, A, B, α,
 # β)` — and their derivatives are simple: ⟨op_A(A)·op_B(B), dC⟩ and ⟨C_old, dC⟩.
 
+const _MatMatMul = if VERSION >= v"1.13-"
+    Union{typeof(LinearAlgebra.generic_matmatmul!),typeof(mul!)}
+else
+    typeof(LinearAlgebra.generic_matmatmul!)
+end
+
 @is_primitive(
     MinimalCtx,
     Tuple{
-        typeof(LinearAlgebra.generic_matmatmul!),
+        _MatMatMul,
         <:CuMaybeComplexArray,
         Char,
         Char,
@@ -3060,7 +3064,7 @@ end
     },
 )
 function frule!!(
-    ::Dual{typeof(LinearAlgebra.generic_matmatmul!)},
+    ::Dual{<:_MatMatMul},
     C::Dual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
     tA::Dual{Char,NoTangent},
     tB::Dual{Char,NoTangent},
@@ -3091,7 +3095,7 @@ function frule!!(
     return C
 end
 function rrule!!(
-    ::CoDual{typeof(LinearAlgebra.generic_matmatmul!)},
+    ::CoDual{<:_MatMatMul},
     C::CoDual{<:CuMaybeComplexArray,<:CuMaybeComplexArray},
     tA::CoDual{Char,NoFData},
     tB::CoDual{Char,NoFData},
@@ -3280,10 +3284,16 @@ end
 #
 # Limitation: 'T' flag for complex arrays is rejected (same as generic_matmatmul!).
 
+const _MatVecMul = if VERSION >= v"1.13-"
+    Union{typeof(LinearAlgebra.generic_matvecmul!),typeof(mul!)}
+else
+    typeof(LinearAlgebra.generic_matvecmul!)
+end
+
 @is_primitive(
     MinimalCtx,
     Tuple{
-        typeof(LinearAlgebra.generic_matvecmul!),
+        _MatVecMul,
         <:CuMaybeComplexVec,
         <:AbstractChar,
         <:CuMaybeComplexMat,
@@ -3293,7 +3303,7 @@ end
     },
 )
 function frule!!(
-    ::Dual{typeof(LinearAlgebra.generic_matvecmul!)},
+    ::Dual{<:_MatVecMul},
     Y::Dual{<:CuMaybeComplexVec,<:CuMaybeComplexVec},
     tA::Dual{<:AbstractChar,NoTangent},
     A::Dual{<:CuMaybeComplexMat,<:CuMaybeComplexMat},
@@ -3323,7 +3333,7 @@ function frule!!(
     return Y
 end
 function rrule!!(
-    ::CoDual{typeof(LinearAlgebra.generic_matvecmul!)},
+    ::CoDual{<:_MatVecMul},
     Y::CoDual{<:CuMaybeComplexVec,<:CuMaybeComplexVec},
     tA::CoDual{<:AbstractChar,NoFData},
     A::CoDual{<:CuMaybeComplexMat,<:CuMaybeComplexMat},

--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -53,7 +53,7 @@ where Mooncake.jl fails to differentiate `bar` for some reason.
 If you have access to another function `baz`, which does the same thing as `bar`, but does
     so in a way which Mooncake.jl can differentiate, you can simply write:
 ```jldoctest overlay
-julia> Mooncake.@mooncake_overlay foo(x::Float64) = baz(x)
+julia> Mooncake.@mooncake_overlay foo(x::Float64) = baz(x);
 
 ```
 When looking up the code for `foo(::Float64)`, Mooncake.jl will see this method, rather than
@@ -79,7 +79,7 @@ julia> Mooncake.value_and_gradient!!(rule, scale, 5.0)
 
 We can use `@mooncake_overlay` to change the definition which Mooncake.jl sees:
 ```jldoctest overlay-doctest; setup = :(using Mooncake)
-julia> Mooncake.@mooncake_overlay scale(x) = 3x
+julia> Mooncake.@mooncake_overlay scale(x) = 3x;
 
 julia> rule = Mooncake.build_rrule(Tuple{typeof(scale), Float64});
 
@@ -93,7 +93,7 @@ Additionally, it is possible to use the usual multi-line syntax to declare an ov
 ```jldoctest overlay-doctest; setup = :(using Mooncake)
 julia> Mooncake.@mooncake_overlay function scale(x)
            return 4x
-       end
+       end;
 
 julia> rule = Mooncake.build_rrule(Tuple{typeof(scale), Float64});
 


### PR DESCRIPTION
## Summary
- Promote Julia 1.13 from an allowed-to-fail prerelease lane to required stable CI, retaining 1.10 LTS and removing 1.12 test lanes.
- Move GPU CI, benchmarks, and documentation builds to 1.13.
- Keep Julia 1.11.6+ and 1.12.1+ installable on a best-effort basis, distinct from official support. Bound each admitted minor series explicitly so future minor versions are not admitted automatically.
- Update the support policy to document this distinction.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1306 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1306/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬─────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │  Enzyme │
│                     String │   String │   String │      String │  String │      String │  String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼─────────┤
│                   sum_1000 │ 181.0 ns │     1.55 │        1.61 │    1.33 │         5.7 │ missing │
│                  _sum_1000 │   1.1 μs │     5.99 │        1.02 │  1130.0 │        33.3 │ missing │
│               sum_sin_1000 │  7.43 μs │     2.52 │        2.08 │    2.55 │        10.8 │ missing │
│              _sum_sin_1000 │  7.42 μs │     2.41 │        2.07 │   176.0 │        9.89 │ missing │
│                   kron_sum │ 196.0 μs │     3.49 │        3.37 │    20.1 │       447.0 │ missing │
│              kron_view_sum │ 242.0 μs │     4.14 │        4.35 │    14.5 │       452.0 │ missing │
│      naive_map_sin_cos_exp │  2.27 μs │     2.82 │         1.5 │ missing │        9.33 │ missing │
│            map_sin_cos_exp │  2.31 μs │     3.18 │        1.52 │    1.56 │        6.65 │ missing │
│      broadcast_sin_cos_exp │  2.34 μs │     2.94 │        1.44 │    3.24 │        1.66 │ missing │
│                 simple_mlp │ 348.0 μs │     5.16 │        2.88 │    1.83 │        10.5 │ missing │
│                     gp_lml │ 370.0 μs │     4.18 │        1.71 │    4.07 │     missing │ missing │
│ turing_broadcast_benchmark │  1.71 ms │     7.41 │        3.92 │ missing │        40.9 │ missing │
│         large_single_block │ 480.0 ns │     4.95 │        1.92 │  6060.0 │        32.4 │ missing │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴─────────┘
```

<!-- managed-pr-summary:end -->