### PR TITLE
Fix IR substitution of literal `missing`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.5.55"
+version = "0.5.56"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/ir_utils.jl
+++ b/src/interpreter/ir_utils.jl
@@ -464,10 +464,10 @@ function in `ir_normalisation.jl`. You probably do not want to use it.
 """
 function replace_uses_with!(stmt, def::Union{Argument,SSAValue}, val)
     if stmt isa Expr
-        stmt.args = Any[arg == def ? val : arg for arg in stmt.args]
+        stmt.args = Any[arg === def ? val : arg for arg in stmt.args]
         return stmt
     elseif stmt isa GotoIfNot
-        if stmt.cond == def
+        if stmt.cond === def
             @assert val isa Bool
             return GotoIfNot(val, stmt.dest)
         else

--- a/test/interpreter/ir_utils.jl
+++ b/test/interpreter/ir_utils.jl
@@ -55,10 +55,15 @@ end
             Mooncake.UnhandledLanguageFeatureException, Mooncake.unhandled_feature("foo")
         )
     end
-    @testset "replace_uses_with!" begin
-        stmt = Expr(:call, sin, SSAValue(1))
-        Mooncake.replace_uses_with!(stmt, SSAValue(1), 5.0)
-        @test stmt.args[end] == 5.0
+    @testset "replace_uses_with! $T" for T in (Argument, SSAValue)
+        # Literal missing must survive IR reference substitution (issue #1308).
+        stmt = Expr(:call, ifelse, T(1), missing, T(2))
+        Mooncake.replace_uses_with!(stmt, T(1), true)
+        @test isequal(stmt, Expr(:call, ifelse, true, missing, T(2)))
+        stmt = GotoIfNot(T(1), 3)
+        @test Mooncake.replace_uses_with!(stmt, T(1), true).cond === true
+        stmt = GotoIfNot(T(2), 3)
+        @test Mooncake.replace_uses_with!(stmt, T(1), true) === stmt
     end
     @testset "characeterise_used_ssas" begin
         stmts = Any[


### PR DESCRIPTION
Use `===` to match IR references, avoiding Boolean errors on Julia 1.13:

```julia
using Mooncake
@noinline helper(x, day) = x
f(x) = helper(x[1], Missing())
Mooncake.prepare_gradient_cache(f, [2.0])
```

Verified on Julia 1.10–1.13. Bumps version to 0.5.56.

Fixes #1308.

<!-- managed-pr-summary:start -->

## CI Summary — GitHub Actions



### Documentation Preview

Mooncake.jl documentation for PR #1309 is available at:
https://chalk-lab.github.io/Mooncake.jl/previews/PR1309/

### Performance

Performance Ratio:
Ratio of time to compute gradient and time to compute function.
Warning: results are very approximate! See [here](https://github.com/chalk-lab/Mooncake.jl/tree/main/bench#inter-framework-benchmarking) for more context.
```
┌────────────────────────────┬──────────┬──────────┬─────────────┬─────────┬─────────────┬─────────┐
│                      Label │   Primal │ Mooncake │ MooncakeFwd │  Zygote │ ReverseDiff │  Enzyme │
│                     String │   String │   String │      String │  String │      String │  String │
├────────────────────────────┼──────────┼──────────┼─────────────┼─────────┼─────────────┼─────────┤
│                   sum_1000 │ 170.0 ns │     1.65 │        1.59 │    1.71 │        6.78 │ missing │
│                  _sum_1000 │ 972.0 ns │     6.72 │        1.03 │  1250.0 │        34.5 │ missing │
│               sum_sin_1000 │  6.67 μs │     3.05 │        2.08 │    1.83 │        11.3 │ missing │
│              _sum_sin_1000 │  6.67 μs │     2.66 │        2.06 │   192.0 │        11.4 │ missing │
│                   kron_sum │ 211.0 μs │     3.65 │        3.45 │     7.0 │       346.0 │ missing │
│              kron_view_sum │ 267.0 μs │     4.22 │        3.87 │    12.4 │       314.0 │ missing │
│      naive_map_sin_cos_exp │  2.28 μs │      2.9 │        1.47 │ missing │        7.87 │ missing │
│            map_sin_cos_exp │  2.17 μs │     3.38 │        1.66 │    1.79 │        7.05 │ missing │
│      broadcast_sin_cos_exp │  2.31 μs │     3.08 │        1.48 │    4.04 │        1.74 │ missing │
│                 simple_mlp │ 387.0 μs │     4.67 │        2.58 │    1.76 │        9.25 │ missing │
│                     gp_lml │ 390.0 μs │     4.12 │        1.66 │    4.32 │     missing │ missing │
│ turing_broadcast_benchmark │  2.03 ms │     5.81 │        2.97 │ missing │        30.4 │ missing │
│         large_single_block │ 430.0 ns │     5.43 │        1.87 │  7300.0 │        31.1 │ missing │
└────────────────────────────┴──────────┴──────────┴─────────────┴─────────┴─────────────┴─────────┘
```

<!-- managed-pr-summary:end -->